### PR TITLE
Use Herdr 0.7.1 worktree API and add collapsible sidebar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "herdr-webui"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "axum",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-webui"
-version = "0.0.34"
+version = "0.0.35"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ Standalone browser UI for an official Herdr backend session.
 
 Compatibility:
 
-- Backend protocol: `14`.
-- Minimum tested Herdr: `0.7.0`.
-- Maximum tested Herdr: `0.7.1`.
-- Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested.
+| WebUI | Herdr | Protocol | Status | Notes |
+| --- | --- | --- | --- | --- |
+| `0.0.35` | `0.7.1` | `14` | Tested | Uses native `worktree.create` existing-branch support and async/deferred worktree operations. |
+| `0.0.35` | `0.7.0` | `14` | Minimum supported | Uses WebUI's legacy existing-branch worktree fallback when needed. |
+
+Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested.
 
 ## Build
 
@@ -120,6 +122,18 @@ If `--session NAME` is supplied, launched Herdr processes receive `HERDR_SESSION
 ## WebUI Features
 
 The browser UI provides workspace navigation, top panel tabs, agent status, terminal attach, and local-only convenience settings stored in browser storage.
+
+Sidebar:
+
+- Use the vertical divider between the sidebar and terminal to hide or show the workspace/agents sidebar.
+- The collapsed state is stored in browser `localStorage`.
+
+Worktrees:
+
+- With Herdr `0.7.1` and newer, WebUI uses Herdr's native `worktree.create` support for existing local branches and deferred Git work.
+- With Herdr `0.7.0`, WebUI keeps a legacy fallback for creating a checkout from an existing branch when a checkout path is supplied.
+- WebUI subscribes to `worktree.created`, `worktree.opened`, and `worktree.removed` and refreshes workspace/agent state quickly after these events.
+- `worktree.removed` events from Herdr `0.7.1` may include a workspace snapshot. This is additive; WebUI refreshes from the backend state instead of relying only on the event payload.
 
 Panel tab activity:
 

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -29,9 +29,12 @@ body.light {
 }
 #app {
   display: grid;
-  grid-template-columns: 330px minmax(0, 1fr);
+  grid-template-columns: 330px 18px minmax(0, 1fr);
   height: 100vh;
   overflow: hidden;
+}
+#app.sidebar-collapsed {
+  grid-template-columns: 0 28px minmax(0, 1fr);
 }
 .side {
   border-right: 1px solid var(--border);
@@ -40,6 +43,34 @@ body.light {
   flex-direction: column;
   min-width: 0;
   overflow: hidden;
+}
+#app.sidebar-collapsed .side {
+  border-right: 0;
+  visibility: hidden;
+}
+.sidebar-toggle {
+  appearance: none;
+  border: 0;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  background: linear-gradient(180deg, var(--panel), var(--panel2));
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 18px;
+  font-weight: 900;
+  padding: 0;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+}
+.sidebar-toggle:hover,
+.sidebar-toggle:focus {
+  background: var(--border);
+  color: var(--fg);
+  outline: none;
+}
+#app.sidebar-collapsed .sidebar-toggle {
+  color: var(--accent);
 }
 .head {
   padding: 14px;

--- a/src/assets/app.html
+++ b/src/assets/app.html
@@ -26,6 +26,7 @@
           <div id="agents"></div>
         </div>
       </aside>
+      <button class="sidebar-toggle" id="sidebarToggle" title="Hide sidebar" aria-label="Hide sidebar">‹</button>
       <main class="main">
         <div class="tabs" id="tabs"></div>
         <div class="terminal-shell" id="terminalShell">

--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -49,6 +49,7 @@ let term,
   inputFlushTimer = null,
   pasteFrameUntil = 0,
   wheelScrollRemainder = 0;
+let sidebarCollapsed = localStorage.getItem("herdr-web-sidebar-collapsed") === "1";
 let noSleepState = { mode: "off", until_ms: null, error: null, supported: true };
 const inputEncoder = new TextEncoder();
 const {
@@ -63,6 +64,28 @@ const workspaces = el("workspaces"),
   agents = el("agents"),
   tabs = el("tabs"),
   newWs = el("newWs");
+applySidebarCollapsed();
+const sidebarToggle = el("sidebarToggle");
+if (sidebarToggle)
+  sidebarToggle.onclick = () => {
+    sidebarCollapsed = !sidebarCollapsed;
+    localStorage.setItem(
+      "herdr-web-sidebar-collapsed",
+      sidebarCollapsed ? "1" : "0",
+    );
+    applySidebarCollapsed();
+    scheduleTerminalFit();
+  };
+function applySidebarCollapsed() {
+  const app = el("app"),
+    button = el("sidebarToggle");
+  if (app) app.classList.toggle("sidebar-collapsed", sidebarCollapsed);
+  if (button) {
+    button.textContent = sidebarCollapsed ? "›" : "‹";
+    button.title = sidebarCollapsed ? "Show sidebar" : "Hide sidebar";
+    button.setAttribute("aria-label", button.title);
+  }
+}
 const headTitle = document.querySelector(".head strong");
 if (headTitle) {
   const brand = document.createElement("div");
@@ -1503,9 +1526,12 @@ async function refresh() {
     if (button) button.textContent = (state.session || "default") + " offline";
   }
 }
-function scheduleRefresh() {
+function scheduleRefresh(delay = 500) {
   clearTimeout(refreshTimer);
-  refreshTimer = setTimeout(refresh, 500);
+  refreshTimer = setTimeout(refresh, delay);
+}
+function worktreeEventNeedsFastRefresh(kind) {
+  return kind === "worktree.created" || kind === "worktree.opened" || kind === "worktree.removed";
 }
 function applySnapshot(msg) {
   const wr = msg.workspaces && msg.workspaces.result;
@@ -2076,7 +2102,7 @@ function connectEvents() {
           }
         }
       }
-      scheduleRefresh();
+      scheduleRefresh(worktreeEventNeedsFastRefresh(kind) ? 50 : 500);
     }
   };
   ws.onclose = () => {

--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -49,7 +49,13 @@ let term,
   inputFlushTimer = null,
   pasteFrameUntil = 0,
   wheelScrollRemainder = 0;
-let sidebarCollapsed = localStorage.getItem("herdr-web-sidebar-collapsed") === "1";
+const SIDEBAR_COLLAPSED_KEY = "herdr-web-sidebar-collapsed";
+const FAST_REFRESH_EVENTS = new Set([
+  "worktree.created",
+  "worktree.opened",
+  "worktree.removed",
+]);
+let sidebarCollapsed = storedFlag(SIDEBAR_COLLAPSED_KEY);
 let noSleepState = { mode: "off", until_ms: null, error: null, supported: true };
 const inputEncoder = new TextEncoder();
 const {
@@ -69,13 +75,22 @@ const sidebarToggle = el("sidebarToggle");
 if (sidebarToggle)
   sidebarToggle.onclick = () => {
     sidebarCollapsed = !sidebarCollapsed;
-    localStorage.setItem(
-      "herdr-web-sidebar-collapsed",
-      sidebarCollapsed ? "1" : "0",
-    );
+    storeFlag(SIDEBAR_COLLAPSED_KEY, sidebarCollapsed);
     applySidebarCollapsed();
     scheduleTerminalFit();
   };
+function storedFlag(key) {
+  try {
+    return localStorage.getItem(key) === "1";
+  } catch (_) {
+    return false;
+  }
+}
+function storeFlag(key, value) {
+  try {
+    localStorage.setItem(key, value ? "1" : "0");
+  } catch (_) {}
+}
 function applySidebarCollapsed() {
   const app = el("app"),
     button = el("sidebarToggle");
@@ -1531,7 +1546,7 @@ function scheduleRefresh(delay = 500) {
   refreshTimer = setTimeout(refresh, delay);
 }
 function worktreeEventNeedsFastRefresh(kind) {
-  return kind === "worktree.created" || kind === "worktree.opened" || kind === "worktree.removed";
+  return FAST_REFRESH_EVENTS.has(kind);
 }
 function applySnapshot(msg) {
   const wr = msg.workspaces && msg.workspaces.result;

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -23,6 +23,9 @@ function element(id = "") {
     textContent: "",
     innerHTML: "",
     title: "",
+    setAttribute(name, value) {
+      this[name] = value;
+    },
     closest() {
       return this;
     },
@@ -163,6 +166,24 @@ describe("app bundle load", () => {
     match(source, /Dismiss/);
     match(source, /herdr-web-working-dismissals/);
     match(source, /displayStatus = dismissed \? "ignored"/);
+  });
+
+  it("defines sidebar collapse controls", () => {
+    const html = readFileSync(new URL("./app.html", import.meta.url), "utf8");
+
+    match(html, /id="sidebarToggle"/);
+    match(source, /herdr-web-sidebar-collapsed/);
+    match(source, /applySidebarCollapsed/);
+  });
+
+  it("fast-refreshes worktree lifecycle events", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    equal(ctx.worktreeEventNeedsFastRefresh("worktree.created"), true);
+    equal(ctx.worktreeEventNeedsFastRefresh("worktree.opened"), true);
+    equal(ctx.worktreeEventNeedsFastRefresh("worktree.removed"), true);
+    equal(ctx.worktreeEventNeedsFastRefresh("pane.closed"), false);
   });
 
   it("keeps blocked agents first when attention sorting is inverted", () => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1369,6 +1369,18 @@ fn proxy_request(api: &ApiClient, request: serde_json::Value) -> Response {
     }
 }
 
+async fn proxy_request_async(api: ApiClient, request: serde_json::Value) -> Response {
+    match tokio::task::spawn_blocking(move || api.request_value(request)).await {
+        Ok(Ok(value)) => Json(value).into_response(),
+        Ok(Err(err)) => (StatusCode::BAD_GATEWAY, Json(json!({ "error": err }))).into_response(),
+        Err(err) => (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({ "error": err.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
 async fn workspaces(
     State(state): State<WebState>,
     headers: HeaderMap,
@@ -1498,34 +1510,37 @@ async fn create_worktree(
     }
     let cwd = body.cwd.as_deref().map(expand_user_path_string);
     let path = body.path.as_deref().map(expand_user_path_string);
-    if let (Some(cwd), Some(path), Some(branch)) = (&cwd, &path, body.branch.as_deref()) {
-        let branch = branch.trim();
-        if !branch.is_empty() {
-            let base = body
-                .base
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .unwrap_or("HEAD");
-            match create_worktree_checkout(cwd, path, branch, base) {
-                Ok(()) => {
-                    return proxy_request(
-                        &api_for_headers(&state, &headers),
-                        open_created_worktree_request(cwd, path, body.label),
-                    );
-                }
-                Err(err) => {
-                    return (
-                        StatusCode::BAD_REQUEST,
-                        Json(json!({ "ok": false, "error": err })),
-                    )
-                        .into_response();
+    let api = api_for_headers(&state, &headers);
+    if !backend_supports_native_existing_branch_worktrees(&api) {
+        if let (Some(cwd), Some(path), Some(branch)) = (&cwd, &path, body.branch.as_deref()) {
+            let branch = branch.trim();
+            if !branch.is_empty() && git_branch_exists(cwd, branch).unwrap_or(false) {
+                let base = body
+                    .base
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("HEAD");
+                match create_worktree_checkout(cwd, path, branch, base) {
+                    Ok(()) => {
+                        return proxy_request(
+                            &api,
+                            open_created_worktree_request(cwd, path, body.label),
+                        );
+                    }
+                    Err(err) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(json!({ "ok": false, "error": err })),
+                        )
+                            .into_response();
+                    }
                 }
             }
         }
     }
-    proxy_request(
-        &api_for_headers(&state, &headers),
+    proxy_request_async(
+        api,
         json!({
             "id": "web:worktree:create",
             "method": "worktree.create",
@@ -1540,6 +1555,22 @@ async fn create_worktree(
             },
         }),
     )
+    .await
+}
+
+fn backend_supports_native_existing_branch_worktrees(api: &ApiClient) -> bool {
+    api.backend_info()
+        .version
+        .as_deref()
+        .and_then(crate::compat::SimpleVersion::parse)
+        .is_some_and(|version| {
+            version
+                >= (crate::compat::SimpleVersion {
+                    major: 0,
+                    minor: 7,
+                    patch: 1,
+                })
+        })
 }
 
 fn run_git_capture(args: &[&str]) -> Result<std::process::Output, String> {
@@ -2001,10 +2032,11 @@ async fn remove_worktree(
     if let Err(response) = require_auth(&state, &headers, remote) {
         return response;
     }
-    proxy_request(
-        &api_for_headers(&state, &headers),
+    proxy_request_async(
+        api_for_headers(&state, &headers),
         json!({ "id": "web:worktree:remove", "method": "worktree.remove", "params": { "workspace_id": workspace_id, "force": false } }),
     )
+    .await
 }
 
 #[derive(Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1418,6 +1418,92 @@ fn open_created_worktree_request(
     })
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HerdrWorktreeApiVersion {
+    V0_7_0,
+    V0_7_1,
+}
+
+impl HerdrWorktreeApiVersion {
+    fn from_backend(version: Option<&str>) -> Self {
+        let supports_native_existing_branch = version
+            .and_then(crate::compat::SimpleVersion::parse)
+            .is_some_and(|version| {
+                version
+                    >= (crate::compat::SimpleVersion {
+                        major: 0,
+                        minor: 7,
+                        patch: 1,
+                    })
+            });
+        if supports_native_existing_branch {
+            Self::V0_7_1
+        } else {
+            Self::V0_7_0
+        }
+    }
+
+    fn uses_native_existing_branch_create(self) -> bool {
+        matches!(self, Self::V0_7_1)
+    }
+}
+
+struct HerdrWorktreeApi {
+    client: ApiClient,
+    version: HerdrWorktreeApiVersion,
+}
+
+impl HerdrWorktreeApi {
+    fn new(client: ApiClient) -> Self {
+        let backend = client.backend_info();
+        let version = HerdrWorktreeApiVersion::from_backend(backend.version.as_deref());
+        Self { client, version }
+    }
+
+    fn needs_legacy_existing_branch_create(&self, cwd: &str, branch: &str) -> bool {
+        !self.version.uses_native_existing_branch_create()
+            && !branch.trim().is_empty()
+            && git_branch_exists(cwd, branch).unwrap_or(false)
+    }
+
+    fn legacy_open_created_request(
+        &self,
+        cwd: &str,
+        path: &str,
+        label: Option<String>,
+    ) -> serde_json::Value {
+        let _ = self;
+        open_created_worktree_request(cwd, path, label)
+    }
+
+    fn create_request(
+        &self,
+        body: CreateWorktreeRequest,
+        cwd: Option<String>,
+        path: Option<String>,
+    ) -> serde_json::Value {
+        let _ = self;
+        json!({
+            "id": "web:worktree:create",
+            "method": "worktree.create",
+            "params": {
+                "workspace_id": body.workspace_id,
+                "cwd": cwd,
+                "branch": body.branch,
+                "base": body.base,
+                "path": path,
+                "label": body.label,
+                "focus": true,
+            },
+        })
+    }
+
+    fn remove_request(&self, workspace_id: String) -> serde_json::Value {
+        let _ = self;
+        json!({ "id": "web:worktree:remove", "method": "worktree.remove", "params": { "workspace_id": workspace_id, "force": false } })
+    }
+}
+
 async fn workspace_order(
     State(state): State<WebState>,
     headers: HeaderMap,
@@ -1510,67 +1596,35 @@ async fn create_worktree(
     }
     let cwd = body.cwd.as_deref().map(expand_user_path_string);
     let path = body.path.as_deref().map(expand_user_path_string);
-    let api = api_for_headers(&state, &headers);
-    if !backend_supports_native_existing_branch_worktrees(&api) {
-        if let (Some(cwd), Some(path), Some(branch)) = (&cwd, &path, body.branch.as_deref()) {
-            let branch = branch.trim();
-            if !branch.is_empty() && git_branch_exists(cwd, branch).unwrap_or(false) {
-                let base = body
-                    .base
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .unwrap_or("HEAD");
-                match create_worktree_checkout(cwd, path, branch, base) {
-                    Ok(()) => {
-                        return proxy_request(
-                            &api,
-                            open_created_worktree_request(cwd, path, body.label),
-                        );
-                    }
-                    Err(err) => {
-                        return (
-                            StatusCode::BAD_REQUEST,
-                            Json(json!({ "ok": false, "error": err })),
-                        )
-                            .into_response();
-                    }
+    let worktree_api = HerdrWorktreeApi::new(api_for_headers(&state, &headers));
+    if let (Some(cwd), Some(path), Some(branch)) = (&cwd, &path, body.branch.as_deref()) {
+        let branch = branch.trim();
+        if worktree_api.needs_legacy_existing_branch_create(cwd, branch) {
+            let base = body
+                .base
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("HEAD");
+            match create_worktree_checkout(cwd, path, branch, base) {
+                Ok(()) => {
+                    return proxy_request(
+                        &worktree_api.client,
+                        worktree_api.legacy_open_created_request(cwd, path, body.label),
+                    );
+                }
+                Err(err) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({ "ok": false, "error": err })),
+                    )
+                        .into_response();
                 }
             }
         }
     }
-    proxy_request_async(
-        api,
-        json!({
-            "id": "web:worktree:create",
-            "method": "worktree.create",
-            "params": {
-                "workspace_id": body.workspace_id,
-                "cwd": cwd,
-                "branch": body.branch,
-                "base": body.base,
-                "path": path,
-                "label": body.label,
-                "focus": true,
-            },
-        }),
-    )
-    .await
-}
-
-fn backend_supports_native_existing_branch_worktrees(api: &ApiClient) -> bool {
-    api.backend_info()
-        .version
-        .as_deref()
-        .and_then(crate::compat::SimpleVersion::parse)
-        .is_some_and(|version| {
-            version
-                >= (crate::compat::SimpleVersion {
-                    major: 0,
-                    minor: 7,
-                    patch: 1,
-                })
-        })
+    let request = worktree_api.create_request(body, cwd, path);
+    proxy_request_async(worktree_api.client, request).await
 }
 
 fn run_git_capture(args: &[&str]) -> Result<std::process::Output, String> {
@@ -1690,7 +1744,6 @@ async fn remove_worktree_path(
             .into_response(),
     }
 }
-
 async fn agents(
     State(state): State<WebState>,
     headers: HeaderMap,
@@ -2032,11 +2085,9 @@ async fn remove_worktree(
     if let Err(response) = require_auth(&state, &headers, remote) {
         return response;
     }
-    proxy_request_async(
-        api_for_headers(&state, &headers),
-        json!({ "id": "web:worktree:remove", "method": "worktree.remove", "params": { "workspace_id": workspace_id, "force": false } }),
-    )
-    .await
+    let worktree_api = HerdrWorktreeApi::new(api_for_headers(&state, &headers));
+    let request = worktree_api.remove_request(workspace_id);
+    proxy_request_async(worktree_api.client, request).await
 }
 
 #[derive(Deserialize)]
@@ -3076,6 +3127,56 @@ mod tests {
         assert_eq!(request["params"]["cwd"], "/tmp/source-repo");
         assert_eq!(request["params"]["path"], "/tmp/worktrees/repo/feature");
         assert_eq!(request["params"]["label"], "feature");
+    }
+
+    #[test]
+    fn worktree_api_version_selects_native_existing_branch_support() {
+        assert_eq!(
+            HerdrWorktreeApiVersion::from_backend(Some("0.7.0")),
+            HerdrWorktreeApiVersion::V0_7_0,
+        );
+        assert_eq!(
+            HerdrWorktreeApiVersion::from_backend(Some("0.7.1")),
+            HerdrWorktreeApiVersion::V0_7_1,
+        );
+        assert_eq!(
+            HerdrWorktreeApiVersion::from_backend(Some("0.7.2")),
+            HerdrWorktreeApiVersion::V0_7_1,
+        );
+        assert_eq!(
+            HerdrWorktreeApiVersion::from_backend(None),
+            HerdrWorktreeApiVersion::V0_7_0,
+        );
+    }
+
+    #[test]
+    fn worktree_api_builds_native_create_request() {
+        let worktree_api = HerdrWorktreeApi {
+            client: ApiClient {
+                socket_path: PathBuf::from("/tmp/herdr.sock"),
+            },
+            version: HerdrWorktreeApiVersion::V0_7_1,
+        };
+
+        let request = worktree_api.create_request(
+            CreateWorktreeRequest {
+                workspace_id: Some("w_1".into()),
+                cwd: Some("~/repo".into()),
+                branch: Some("feature/demo".into()),
+                base: Some("main".into()),
+                path: Some("../worktrees/demo".into()),
+                label: Some("demo".into()),
+            },
+            Some("/home/me/repo".into()),
+            Some("/home/me/worktrees/demo".into()),
+        );
+
+        assert_eq!(request["method"], "worktree.create");
+        assert_eq!(request["params"]["workspace_id"], "w_1");
+        assert_eq!(request["params"]["cwd"], "/home/me/repo");
+        assert_eq!(request["params"]["path"], "/home/me/worktrees/demo");
+        assert_eq!(request["params"]["branch"], "feature/demo");
+        assert_eq!(request["params"]["focus"], true);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1454,16 +1454,21 @@ struct HerdrWorktreeApi {
 }
 
 impl HerdrWorktreeApi {
-    fn new(client: ApiClient) -> Self {
+    fn detect(client: ApiClient) -> Self {
         let backend = client.backend_info();
         let version = HerdrWorktreeApiVersion::from_backend(backend.version.as_deref());
         Self { client, version }
     }
 
-    fn needs_legacy_existing_branch_create(&self, cwd: &str, branch: &str) -> bool {
+    fn new(client: ApiClient) -> Self {
+        Self {
+            client,
+            version: HerdrWorktreeApiVersion::V0_7_1,
+        }
+    }
+
+    fn needs_legacy_existing_branch_create(&self) -> bool {
         !self.version.uses_native_existing_branch_create()
-            && !branch.trim().is_empty()
-            && git_branch_exists(cwd, branch).unwrap_or(false)
     }
 
     fn legacy_open_created_request(
@@ -1498,8 +1503,7 @@ impl HerdrWorktreeApi {
         })
     }
 
-    fn remove_request(&self, workspace_id: String) -> serde_json::Value {
-        let _ = self;
+    fn remove_request(workspace_id: String) -> serde_json::Value {
         json!({ "id": "web:worktree:remove", "method": "worktree.remove", "params": { "workspace_id": workspace_id, "force": false } })
     }
 }
@@ -1596,10 +1600,16 @@ async fn create_worktree(
     }
     let cwd = body.cwd.as_deref().map(expand_user_path_string);
     let path = body.path.as_deref().map(expand_user_path_string);
-    let worktree_api = HerdrWorktreeApi::new(api_for_headers(&state, &headers));
+    let api = api_for_headers(&state, &headers);
     if let (Some(cwd), Some(path), Some(branch)) = (&cwd, &path, body.branch.as_deref()) {
         let branch = branch.trim();
-        if worktree_api.needs_legacy_existing_branch_create(cwd, branch) {
+        if !branch.is_empty() && git_branch_exists(cwd, branch).unwrap_or(false) {
+            let worktree_api = HerdrWorktreeApi::detect(api.clone());
+            if !worktree_api.needs_legacy_existing_branch_create() {
+                let request =
+                    worktree_api.create_request(body, Some(cwd.clone()), Some(path.clone()));
+                return proxy_request_async(worktree_api.client, request).await;
+            }
             let base = body
                 .base
                 .as_deref()
@@ -1623,6 +1633,7 @@ async fn create_worktree(
             }
         }
     }
+    let worktree_api = HerdrWorktreeApi::new(api);
     let request = worktree_api.create_request(body, cwd, path);
     proxy_request_async(worktree_api.client, request).await
 }
@@ -2085,9 +2096,8 @@ async fn remove_worktree(
     if let Err(response) = require_auth(&state, &headers, remote) {
         return response;
     }
-    let worktree_api = HerdrWorktreeApi::new(api_for_headers(&state, &headers));
-    let request = worktree_api.remove_request(workspace_id);
-    proxy_request_async(worktree_api.client, request).await
+    let request = HerdrWorktreeApi::remove_request(workspace_id);
+    proxy_request_async(api_for_headers(&state, &headers), request).await
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary
- use Herdr 0.7.1 native worktree create support when available
- keep 0.7.0 legacy existing-branch fallback behind a small versioned API abstraction
- refresh faster on worktree lifecycle events
- add persisted collapsible workspace/agents sidebar
- update README compatibility table and docs

## Tests
- node --test src/assets/app_core.test.mjs src/assets/app_load.test.mjs src/assets/app_boot.test.mjs src/assets/mobile_load.test.mjs
- cargo fmt --check
- cargo test --target-dir target
- cargo clippy --target-dir target --all-targets -- -D warnings
- git diff --check