### PR TITLE
Fix pane exit refresh and collapsed sidebar counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "herdr-webui"
-version = "0.0.35"
+version = "0.0.36"
 dependencies = [
  "axum",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-webui"
-version = "0.0.35"
+version = "0.0.36"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ Agent sorting:
 
 - Configure in Settings under `Agents and alerts` with the `Agent sorting` dropdown.
 - `Default order` shows agents in Herdr's natural order.
-- `Attention (blocked first)` sorts blocked agents first, then done, unknown, idle, ignored working, working.
-- `Attention (working first)` keeps blocked agents first, then inverts the remaining priority so working agents appear before done, unknown, and idle agents.
+- `Attention (blocked first)` sorts blocked agents first, then idle agents, done agents, unknown agents, ignored working agents, and working agents.
+- `Attention (working first)` keeps blocked agents first, then working agents, ignored working agents, unknown agents, and done/idle agents.
 
 Stuck working agents:
 

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -56,8 +56,13 @@ body.light {
   background: linear-gradient(180deg, var(--panel), var(--panel2));
   color: var(--muted);
   cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   font-size: 18px;
   font-weight: 900;
+  gap: 10px;
+  justify-content: center;
   padding: 0;
   transition:
     background 120ms ease,
@@ -71,6 +76,40 @@ body.light {
 }
 #app.sidebar-collapsed .sidebar-toggle {
   color: var(--accent);
+}
+.sidebar-toggle-arrow {
+  display: block;
+  line-height: 1;
+}
+.sidebar-counts {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.sidebar-count {
+  border-radius: 999px;
+  color: var(--bg);
+  display: none;
+  font-size: 11px;
+  font-weight: 900;
+  line-height: 16px;
+  min-width: 16px;
+  padding: 0 2px;
+}
+#app.sidebar-collapsed .sidebar-count {
+  display: inline-block;
+}
+.sidebar-count.blocked {
+  background: #f38ba8;
+}
+.sidebar-count.working {
+  background: #f9e2af;
+}
+.sidebar-count.idle {
+  background: #a6e3a1;
+}
+.sidebar-count.done {
+  background: #89b4fa;
 }
 .head {
   padding: 14px;

--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -51,6 +51,9 @@ let term,
   wheelScrollRemainder = 0;
 const SIDEBAR_COLLAPSED_KEY = "herdr-web-sidebar-collapsed";
 const FAST_REFRESH_EVENTS = new Set([
+  "pane.closed",
+  "pane.exited",
+  "tab.closed",
   "worktree.created",
   "worktree.opened",
   "worktree.removed",
@@ -1545,8 +1548,26 @@ function scheduleRefresh(delay = 500) {
   clearTimeout(refreshTimer);
   refreshTimer = setTimeout(refresh, delay);
 }
-function worktreeEventNeedsFastRefresh(kind) {
+function eventNeedsFastRefresh(kind) {
   return FAST_REFRESH_EVENTS.has(kind);
+}
+function forgetClosedSelection(kind, data) {
+  if (kind === "pane.closed" || kind === "pane.exited") {
+    if (data && data.pane_id && data.pane_id === state.pane) {
+      resetTerminalConnection(true);
+      state.pane = null;
+      state.terminalId = null;
+      render();
+    }
+  } else if (kind === "tab.closed") {
+    if (data && data.tab_id && data.tab_id === state.tab) {
+      resetTerminalConnection(true);
+      state.tab = null;
+      state.pane = null;
+      state.terminalId = null;
+      render();
+    }
+  }
 }
 function applySnapshot(msg) {
   const wr = msg.workspaces && msg.workspaces.result;
@@ -1990,14 +2011,17 @@ function renderAgents(wsById, tabById, tabCountsByWorkspace) {
 function agentAttentionCompare(a, b) {
   const aRank = agentAttentionRank(a),
     bRank = agentAttentionRank(b);
-  if (aRank === 0 || bRank === 0) return aRank - bRank;
-  const diff = aRank - bRank;
-  return options.agentSortMode === "attention_inverted" ? -diff : diff;
+  return aRank - bRank;
 }
 function agentAttentionRank(a) {
-  if (isWorkingDismissed(a)) return 3.5;
   const status = statusClass(a.agent_status);
-  return { blocked: 0, done: 1, unknown: 2, idle: 3, working: 4 }[status] ?? 2;
+  if (status === "blocked") return 0;
+  if (options.agentSortMode === "attention_inverted") {
+    if (isWorkingDismissed(a)) return 2;
+    return { working: 1, unknown: 3, done: 4, idle: 5 }[status] ?? 3;
+  }
+  if (isWorkingDismissed(a)) return 4;
+  return { idle: 1, done: 2, unknown: 3, working: 5 }[status] ?? 3;
 }
 function agentToken(cls, value) {
   const s = String(value || "");
@@ -2099,9 +2123,10 @@ function connectEvents() {
     if (msg.type === "snapshot") applySnapshot(msg);
     else if (msg.type === "event") {
       const evt = msg.event || {},
-        kind = evt.event || evt.type;
+        kind = evt.event || evt.type,
+        data = evt.data || {};
       if (kind === "pane.agent_status_changed") {
-        const d = evt.data || {};
+        const d = data;
         if (statusClass(d.agent_status) !== "working") {
           for (const agent of state.agents) {
             if (
@@ -2117,7 +2142,8 @@ function connectEvents() {
           }
         }
       }
-      scheduleRefresh(worktreeEventNeedsFastRefresh(kind) ? 50 : 500);
+      forgetClosedSelection(kind, data);
+      scheduleRefresh(eventNeedsFastRefresh(kind) ? 50 : 500);
     }
   };
   ws.onclose = () => {

--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -99,10 +99,36 @@ function applySidebarCollapsed() {
     button = el("sidebarToggle");
   if (app) app.classList.toggle("sidebar-collapsed", sidebarCollapsed);
   if (button) {
-    button.textContent = sidebarCollapsed ? "›" : "‹";
+    button.innerHTML = sidebarToggleHtml();
     button.title = sidebarCollapsed ? "Show sidebar" : "Hide sidebar";
     button.setAttribute("aria-label", button.title);
   }
+}
+function sidebarAgentStatusCounts() {
+  const counts = { blocked: 0, working: 0, idle: 0, done: 0 };
+  for (const agent of state.agents || []) {
+    const status = isWorkingDismissed(agent) ? "idle" : statusClass(agent.agent_status);
+    if (Object.prototype.hasOwnProperty.call(counts, status)) counts[status] += 1;
+  }
+  return counts;
+}
+function sidebarToggleHtml() {
+  const arrow = `<span class="sidebar-toggle-arrow">${sidebarCollapsed ? "›" : "‹"}</span>`;
+  if (!sidebarCollapsed) return arrow;
+  const counts = sidebarAgentStatusCounts();
+  const badges = [
+    ["blocked", counts.blocked],
+    ["working", counts.working],
+    ["idle", counts.idle],
+    ["done", counts.done],
+  ]
+    .filter(([, count]) => count > 0)
+    .map(
+      ([status, count]) =>
+        `<span class="sidebar-count ${status}" title="${count} ${status} agent${count === 1 ? "" : "s"}">${count}</span>`,
+    )
+    .join("");
+  return arrow + (badges ? `<span class="sidebar-counts">${badges}</span>` : "");
 }
 const headTitle = document.querySelector(".head strong");
 if (headTitle) {
@@ -1679,6 +1705,7 @@ function render() {
     agents.innerHTML = agentsHtml;
     lastAgentsHtml = agentsHtml;
   }
+  applySidebarCollapsed();
   const pane = state.panes.find((p) => p.pane_id === state.pane);
   const themeIcon =
     themeMode === "auto" ? "A" : themeMode === "dark" ? "☾" : "☀";

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -176,14 +176,33 @@ describe("app bundle load", () => {
     match(source, /applySidebarCollapsed/);
   });
 
-  it("fast-refreshes worktree lifecycle events", () => {
+  it("fast-refreshes pane, tab, and worktree lifecycle events", () => {
     const ctx = context();
     vm.runInContext(source, ctx);
 
-    equal(ctx.worktreeEventNeedsFastRefresh("worktree.created"), true);
-    equal(ctx.worktreeEventNeedsFastRefresh("worktree.opened"), true);
-    equal(ctx.worktreeEventNeedsFastRefresh("worktree.removed"), true);
-    equal(ctx.worktreeEventNeedsFastRefresh("pane.closed"), false);
+    equal(ctx.eventNeedsFastRefresh("pane.closed"), true);
+    equal(ctx.eventNeedsFastRefresh("pane.exited"), true);
+    equal(ctx.eventNeedsFastRefresh("tab.closed"), true);
+    equal(ctx.eventNeedsFastRefresh("worktree.created"), true);
+    equal(ctx.eventNeedsFastRefresh("worktree.opened"), true);
+    equal(ctx.eventNeedsFastRefresh("worktree.removed"), true);
+    equal(ctx.eventNeedsFastRefresh("pane.focused"), false);
+  });
+
+  it("forgets selected pane when Herdr reports it exited", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    const result = vm.runInContext(
+      `state.pane = "pane_1";
+       state.terminalId = "term_1";
+       forgetClosedSelection("pane.exited", { pane_id: "pane_1" });
+       ({ pane: state.pane, terminalId: state.terminalId });`,
+      ctx,
+    );
+
+    equal(result.pane, null);
+    equal(result.terminalId, null);
   });
 
   it("keeps blocked agents first when attention sorting is inverted", () => {
@@ -217,6 +236,61 @@ describe("app bundle load", () => {
         ctx.agentAttentionCompare(
           { agent_status: "working" },
           { agent_status: "done" },
+        ),
+      ),
+      -1,
+    );
+    equal(
+      Math.sign(
+        ctx.agentAttentionCompare(
+          { agent_status: "unknown" },
+          { agent_status: "done" },
+        ),
+      ),
+      -1,
+    );
+  });
+
+  it("keeps blocked agents first, then idle before done", () => {
+    const ctx = context();
+    ctx.localStorage.setItem(
+      "herdr-web-options",
+      JSON.stringify({ agentSortMode: "attention" }),
+    );
+    vm.runInContext(source, ctx);
+
+    equal(
+      Math.sign(
+        ctx.agentAttentionCompare(
+          { agent_status: "blocked" },
+          { agent_status: "idle" },
+        ),
+      ),
+      -1,
+    );
+    equal(
+      Math.sign(
+        ctx.agentAttentionCompare(
+          { agent_status: "idle" },
+          { agent_status: "done" },
+        ),
+      ),
+      -1,
+    );
+    equal(
+      Math.sign(
+        ctx.agentAttentionCompare(
+          { agent_status: "idle" },
+          { agent_status: "working" },
+        ),
+      ),
+      -1,
+    );
+    equal(
+      Math.sign(
+        ctx.agentAttentionCompare(
+          { agent_status: "done" },
+          { agent_status: "working" },
         ),
       ),
       -1,

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -174,6 +174,31 @@ describe("app bundle load", () => {
     match(html, /id="sidebarToggle"/);
     match(source, /herdr-web-sidebar-collapsed/);
     match(source, /applySidebarCollapsed/);
+    match(source, /sidebarAgentStatusCounts/);
+    match(source, /sidebar-count/);
+  });
+
+  it("renders collapsed sidebar agent counters", () => {
+    const ctx = context();
+    ctx.localStorage.setItem("herdr-web-sidebar-collapsed", "1");
+    vm.runInContext(source, ctx);
+
+    const html = vm.runInContext(
+      `state.agents = [
+        { agent_status: "blocked" },
+        { agent_status: "working" },
+        { agent_status: "idle" },
+        { agent_status: "done" },
+        { agent_status: "done" },
+      ];
+      sidebarToggleHtml();`,
+      ctx,
+    );
+
+    match(html, /sidebar-count blocked[^>]*>1</);
+    match(html, /sidebar-count working[^>]*>1</);
+    match(html, /sidebar-count idle[^>]*>1</);
+    match(html, /sidebar-count done[^>]*>2</);
   });
 
   it("fast-refreshes pane, tab, and worktree lifecycle events", () => {


### PR DESCRIPTION
## Summary
- immediately clear stale selected terminal pane when Herdr emits pane.closed or pane.exited
- fast-refresh pane/tab lifecycle events
- keep blocked agents first, then sort normal mode as idle/done-first and inverted mode as working-first
- show collapsed sidebar agent counters for blocked, working, idle, and done
- bump WebUI to v0.0.36

## Tests
- node --test src/assets/app_core.test.mjs src/assets/app_load.test.mjs src/assets/app_boot.test.mjs src/assets/mobile_load.test.mjs
- cargo fmt --check
- cargo test --target-dir target
- cargo clippy --target-dir target --all-targets -- -D warnings
- git diff --check