### PR TITLE
fix: null cwd when workspace_id present in discovered worktree create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 
 /result
 /result-*
+zigbin/

--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -3262,7 +3262,7 @@ async function createDiscoveredWorktree() {
     }
     const source = state.openWorktreeSource || {};
     const workspaceId = source.workspace_id || (!sourcePath ? state.ws : null),
-      cwd = source.cwd || sourcePath || null;
+      cwd = workspaceId ? null : (source.cwd || sourcePath || null);
     const r = await api("/api/worktrees", {
       method: "POST",
       headers: { "content-type": "application/json" },


### PR DESCRIPTION
## Summary

`createDiscoveredWorktree` (src/assets/app.js:3264) sent both `workspace_id` and `cwd` to backend `worktree.create` whenever the discovered source had a parent workspace, triggering backend rejection `"only one of workspace_id or cwd may be supplied"` (`resolve_worktree_source` in herdr `src/app/api/worktrees.rs:182`).

## Fix

Mirror `openDiscoveredWorktree` (app.js:3192) by nulling `cwd` whenever `workspaceId` is set:

```js
const workspaceId = source.workspace_id || (!sourcePath ? state.ws : null),
  cwd = workspaceId ? null : (source.cwd || sourcePath || null);
```

Also fixes the edge case where the path field is empty but a stale `source.cwd` is present: previously `state.ws` + stale `cwd` produced the same backend error; now `cwd` is nulled.

## Verification

- `node --test src/assets/*.test.mjs` — 53/53 pass
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 47/47 pass