### PR TITLE
fix: render Nerd Font icons in xterm terminal

### DIFF
--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -65,6 +65,7 @@ const {
   branchPathSlug,
   normalizeAbsolutePath,
   normalizeThemeColors,
+  resolveTerminalFontFamily,
   terminalPasteInput,
   tabActivityLabel,
   terminalWheelScrollBatch,
@@ -529,6 +530,7 @@ const defaultOptions = {
   workingDismissMinutes: 30,
   workspaceSort: "default",
   scrollLines: 3,
+  terminalFontFamily: "",
   showTabActivity: false,
   worktreeAutoDiscoverSeconds: 3,
   generateWorktreeNames: false,
@@ -570,6 +572,7 @@ function normalizeOptions(value) {
   if (!["default", "drag", "state"].includes(next.workspaceSort))
     next.workspaceSort = defaultOptions.workspaceSort;
   next.scrollLines = Math.max(1, Math.min(20, Number(next.scrollLines) || 3));
+  next.terminalFontFamily = String(next.terminalFontFamily || "").trim();
   next.showTabActivity = next.showTabActivity === true;
   next.worktreeAutoDiscoverSeconds = Math.max(
     0,
@@ -775,7 +778,7 @@ if (soundSetting && !el("optAgentSortMode"))
     .closest("label")
     .insertAdjacentHTML(
       "afterend",
-      '<label class="option"><span>Close panel shortcut<small>Stored in browser storage and available after reopening the tab.</small></span><select class="settings-select" id="optCloseShortcut"><option value="off">Disabled</option><option value="altw">Option+W</option><option value="shiftspacew">Shift+Space then W</option></select></label><label class="option"><span>Agent sorting<small>Sort agents by attention priority, or show them in default order.</small></span><select class="settings-select" id="optAgentSortMode"><option value="off">Default order</option><option value="attention">Attention (blocked first)</option><option value="attention_inverted">Attention (working first)</option></select></label><label class="option"><span>Parent workspace close<small>Close panels only (keeps linked worktrees running) or full close with re-open (stops processes, re-opens worktrees with fresh shells).</small></span><select class="settings-select" id="optParentCloseMode"><option value="panels">Close panels only</option><option value="close">Full close + re-open worktrees</option></select></label><label class="option"><input type="checkbox" id="optStuckWorkingEnabled"><span>Ignore stuck working agents<small>Dismiss working agents that appear stuck. Clears automatically on status changes and terminal output.</small></span></label><label class="option"><span>Ignore stuck working for<small>Minutes to keep a local dismissed-working override before showing working again.</small></span><input id="optWorkingDismissMinutes" type="number" min="1" max="1440" step="1"></label><label class="option"><input type="checkbox" id="optShowTabActivity"><span>Show panel last update<small>Display local last-change age on top panel tabs. Updates on refreshes, events, and selected terminal output; no timer polling.</small></span></label><label class="option"><span>Workspace sorting<small>Default tree order, shared drag-and-drop order, or attention state priority.</small></span><select class="settings-select" id="optWorkspaceSort"><option value="default">Default</option><option value="drag">Drag&drop</option><option value="state">State</option></select></label><label class="option"><span>Notification scope<small>Choose whether sounds ring in every open tab or only the tab viewing the agent panel.</small></span><select class="settings-select" id="optSoundScope"><option value="current">Current agent tab</option><option value="all">All tabs</option></select></label><label class="option"><input type="checkbox" id="optGenerateWorktreeNames"><span>Generate worktree branch names<small>Allow blank Branch name in Worktrees modal. Herdr generates worktree/&lt;name&gt;.</small></span></label><label class="option"><span>Default worktree directory<small>Relative paths resolve from repo root. Example: ../worktrees.</small></span><input id="optWorktreeDefaultDirectory" placeholder="../worktrees"></label><label class="option"><span>Scroll speed<small><span id="scrollLinesValue">3</span> terminal lines per wheel step.</small></span><input type="range" id="optScrollLines" min="1" max="20" step="1"></label><label class="option"><span>Worktree autodiscover<small>Seconds to wait after path input stops. Set 0 for immediate.</small></span><input type="number" id="optWorktreeAutoDiscover" min="0" max="30" step="0.5"></label>',
+      '<label class="option"><span>Close panel shortcut<small>Stored in browser storage and available after reopening the tab.</small></span><select class="settings-select" id="optCloseShortcut"><option value="off">Disabled</option><option value="altw">Option+W</option><option value="shiftspacew">Shift+Space then W</option></select></label><label class="option"><span>Agent sorting<small>Sort agents by attention priority, or show them in default order.</small></span><select class="settings-select" id="optAgentSortMode"><option value="off">Default order</option><option value="attention">Attention (blocked first)</option><option value="attention_inverted">Attention (working first)</option></select></label><label class="option"><span>Parent workspace close<small>Close panels only (keeps linked worktrees running) or full close with re-open (stops processes, re-opens worktrees with fresh shells).</small></span><select class="settings-select" id="optParentCloseMode"><option value="panels">Close panels only</option><option value="close">Full close + re-open worktrees</option></select></label><label class="option"><input type="checkbox" id="optStuckWorkingEnabled"><span>Ignore stuck working agents<small>Dismiss working agents that appear stuck. Clears automatically on status changes and terminal output.</small></span></label><label class="option"><span>Ignore stuck working for<small>Minutes to keep a local dismissed-working override before showing working again.</small></span><input id="optWorkingDismissMinutes" type="number" min="1" max="1440" step="1"></label><label class="option"><input type="checkbox" id="optShowTabActivity"><span>Show panel last update<small>Display local last-change age on top panel tabs. Updates on refreshes, events, and selected terminal output; no timer polling.</small></span></label><label class="option"><span>Workspace sorting<small>Default tree order, shared drag-and-drop order, or attention state priority.</small></span><select class="settings-select" id="optWorkspaceSort"><option value="default">Default</option><option value="drag">Drag&drop</option><option value="state">State</option></select></label><label class="option"><span>Notification scope<small>Choose whether sounds ring in every open tab or only the tab viewing the agent panel.</small></span><select class="settings-select" id="optSoundScope"><option value="current">Current agent tab</option><option value="all">All tabs</option></select></label><label class="option"><input type="checkbox" id="optGenerateWorktreeNames"><span>Generate worktree branch names<small>Allow blank Branch name in Worktrees modal. Herdr generates worktree/&lt;name&gt;.</small></span></label><label class="option"><span>Default worktree directory<small>Relative paths resolve from repo root. Example: ../worktrees.</small></span><input id="optWorktreeDefaultDirectory" placeholder="../worktrees"></label><label class="option"><span>Scroll speed<small><span id="scrollLinesValue">3</span> terminal lines per wheel step.</small></span><input type="range" id="optScrollLines" min="1" max="20" step="1"></label><label class="option"><span>Terminal font<small>CSS font-family for the terminal. Add a Nerd Font family name (for example, JetBrainsMono Nerd Font) so icon glyphs render. Leave blank for the default stack.</small></span><input id="optTerminalFont" placeholder="JetBrainsMono Nerd Font, monospace"></label><label class="option"><span>Worktree autodiscover<small>Seconds to wait after path input stops. Set 0 for immediate.</small></span><input type="number" id="optWorktreeAutoDiscover" min="0" max="30" step="0.5"></label>',
     );
 groupSettingsSections();
 function groupSettingsSections() {
@@ -790,7 +793,7 @@ function groupSettingsSections() {
     {
       title: "Terminal input",
       desc: "Viewport sizing, scrolling, and keyboard behavior.",
-      ids: ["optOverflow", "optFit", "optShiftEnterNewline", "optScrollLines"],
+      ids: ["optOverflow", "optFit", "optShiftEnterNewline", "optScrollLines", "optTerminalFont"],
     },
     {
       title: "Agents and alerts",
@@ -863,6 +866,7 @@ function applyOptions() {
     soundScope = el("optSoundScope"),
     scrollLines = el("optScrollLines"),
     scrollLinesValue = el("scrollLinesValue"),
+    terminalFont = el("optTerminalFont"),
     showTabActivity = el("optShowTabActivity"),
     worktreeAutoDiscover = el("optWorktreeAutoDiscover"),
     generateWorktreeNames = el("optGenerateWorktreeNames"),
@@ -889,6 +893,7 @@ function applyOptions() {
   if (scrollLines) scrollLines.value = String(options.scrollLines || 3);
   if (scrollLinesValue)
     scrollLinesValue.textContent = String(options.scrollLines || 3);
+  if (terminalFont) terminalFont.value = options.terminalFontFamily || "";
   if (showTabActivity) showTabActivity.checked = !!options.showTabActivity;
   if (worktreeAutoDiscover)
     worktreeAutoDiscover.value = String(
@@ -1017,6 +1022,21 @@ function applyTheme() {
     }
   }
   fitTerminalShell();
+}
+function applyTerminalFont() {
+  if (!term) return;
+  const family = resolveTerminalFontFamily(options.terminalFontFamily);
+  try {
+    term.options.fontFamily = family;
+  } catch (e) {
+    try {
+      term.setOption("fontFamily", family);
+    } catch (_) {}
+  }
+  try {
+    term.refresh(0, Math.max(0, (term.rows || 1) - 1));
+  } catch (_) {}
+  fitTerminalSurface();
 }
 function applyThemeColorVars(mode) {
   const colors = options.themeColors[mode] || themeColorDefaults[mode];
@@ -2209,7 +2229,7 @@ function connectTerminal() {
   if (!term) {
     term = new Terminal({
       convertEol: false,
-      fontFamily: "ui-monospace,SFMono-Regular,Menlo,monospace",
+      fontFamily: resolveTerminalFontFamily(options.terminalFontFamily),
       theme: terminalTheme(),
       scrollback: 10000,
     });
@@ -3733,6 +3753,12 @@ el("optScrollLines").oninput = () => {
   );
   saveOptions();
   applyOptions();
+};
+el("optTerminalFont").oninput = () => {
+  options.terminalFontFamily = el("optTerminalFont").value.trim();
+  saveOptions();
+  applyOptions();
+  applyTerminalFont();
 };
 el("optWorktreeAutoDiscover").oninput = () => {
   options.worktreeAutoDiscoverSeconds = Math.max(

--- a/src/assets/app_core.js
+++ b/src/assets/app_core.js
@@ -89,10 +89,19 @@
     return next;
   }
 
+  const DEFAULT_TERMINAL_FONT_FAMILY =
+    "ui-monospace, SFMono-Regular, Menlo, 'JetBrainsMono Nerd Font', 'FiraCode Nerd Font', 'Hack Nerd Font', 'Cascadia Code NF', 'MesloLGS NF', 'Symbols Nerd Font Mono', monospace";
+
+  function resolveTerminalFontFamily(value) {
+    const trimmed = String(value == null ? "" : value).trim();
+    return trimmed || DEFAULT_TERMINAL_FONT_FAMILY;
+  }
+
   const helpers = {
     branchPathSlug,
     normalizeAbsolutePath,
     normalizeThemeColors,
+    resolveTerminalFontFamily,
     terminalWheelScrollBatch,
     terminalPasteInput,
     tabActivityLabel,

--- a/src/assets/app_core.test.mjs
+++ b/src/assets/app_core.test.mjs
@@ -7,6 +7,7 @@ const {
   branchPathSlug,
   normalizeAbsolutePath,
   normalizeThemeColors,
+  resolveTerminalFontFamily,
   tabActivityLabel,
   terminalPasteInput,
   terminalWheelScrollBatch,
@@ -129,6 +130,29 @@ describe("normalizeThemeColors", () => {
     assert.deepEqual(
       normalizeThemeColors({ dark: { background: "red" } }, defaults),
       defaults,
+    );
+  });
+});
+
+describe("resolveTerminalFontFamily", () => {
+  it("returns the default stack for blank values", () => {
+    assert.equal(resolveTerminalFontFamily(""), resolveTerminalFontFamily());
+    assert.equal(resolveTerminalFontFamily("   "), resolveTerminalFontFamily());
+    assert.equal(resolveTerminalFontFamily(null), resolveTerminalFontFamily());
+    assert.equal(resolveTerminalFontFamily(undefined), resolveTerminalFontFamily());
+  });
+
+  it("includes Nerd Font fallbacks in the default stack", () => {
+    const fallback = resolveTerminalFontFamily("");
+    assert.match(fallback, /Symbols Nerd Font Mono/);
+    assert.match(fallback, /JetBrainsMono Nerd Font/);
+    assert.match(fallback, /monospace/);
+  });
+
+  it("trims and preserves a user-provided font-family list", () => {
+    assert.equal(
+      resolveTerminalFontFamily("  'Iosevka Nerd Font', monospace  "),
+      "'Iosevka Nerd Font', monospace",
     );
   });
 });

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -155,6 +155,30 @@ describe("app bundle load", () => {
     match(source, /title: "Server"/);
   });
 
+  it("exposes a configurable terminal font-family setting", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    match(source, /id="optTerminalFont"/);
+    match(
+      source,
+      /ids: \["optOverflow", "optFit", "optShiftEnterNewline", "optScrollLines", "optTerminalFont"\]/,
+    );
+    match(source, /function applyTerminalFont\(\)/);
+  });
+
+  it("normalizes the terminal font-family option to a trimmed string", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    equal(
+      ctx.normalizeOptions({ terminalFontFamily: "  Hack Nerd Font  " })
+        .terminalFontFamily,
+      "Hack Nerd Font",
+    );
+    equal(ctx.normalizeOptions({}).terminalFontFamily, "");
+  });
+
   it("defines stuck-working dismissal controls", () => {
     const ctx = context();
     vm.runInContext(source, ctx);

--- a/src/assets/mobile.js
+++ b/src/assets/mobile.js
@@ -564,6 +564,8 @@
     updateWorktreeField: mobileWorktrees.updateField,
     setThemeMode: mobileSettings.setThemeMode,
     setLayoutPreference: mobileSettings.setLayoutPreference,
+    setTerminalFontFamily: mobileSettings.setTerminalFontFamily,
+    applyTerminalFontFamily: mobileTerminal.applyFontFamily,
     currentScreen,
     currentSelection,
     refresh,

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -184,6 +184,13 @@ describe("mobile bundle load", () => {
     ok(settingsHtml.includes("mobile-settings-group"));
     ok(settingsHtml.includes("Appearance"));
     ok(settingsHtml.includes("Layout"));
+    ok(settingsHtml.includes("Terminal font"));
+    ok(settingsHtml.includes("HerdrMobile.setTerminalFontFamily"));
+    equal(typeof ctx.HerdrMobile.setTerminalFontFamily, "function");
+    equal(typeof ctx.HerdrMobile.applyTerminalFontFamily, "function");
+    doesNotThrow(() =>
+      ctx.HerdrMobile.setTerminalFontFamily("Hack Nerd Font, monospace"),
+    );
     doesNotThrow(() => ctx.HerdrMobile.showScreen("worktrees"));
     doesNotThrow(() =>
       ctx.HerdrMobile.updateWorktreeField("worktreeBranch", "feature/mobile"),

--- a/src/assets/mobile_settings.js
+++ b/src/assets/mobile_settings.js
@@ -8,7 +8,8 @@
     function render() {
       const layout = localStorage.getItem("herdr-web-layout") || "auto";
       const theme = localStorage.getItem("herdr-web-theme") || "auto";
-      return `<section class="mobile-section mobile-form"><h2>Settings</h2><div class="mobile-settings-group"><h3>Appearance</h3><label><span>Theme</span><select onchange="HerdrMobile.setThemeMode(this.value)"><option value="auto" ${theme === "auto" ? "selected" : ""}>Auto</option><option value="dark" ${theme === "dark" ? "selected" : ""}>Dark</option><option value="light" ${theme === "light" ? "selected" : ""}>Light</option></select></label></div><div class="mobile-settings-group"><h3>Layout</h3><label><span>Layout mode</span><select onchange="HerdrMobile.setLayoutPreference(this.value)"><option value="auto" ${layout === "auto" ? "selected" : ""}>Auto</option><option value="mobile" ${layout === "mobile" ? "selected" : ""}>Mobile</option><option value="desktop" ${layout === "desktop" ? "selected" : ""}>Desktop</option></select><small>Auto uses viewport width, not user agent.</small></label></div><div class="mobile-settings-group"><h3>Data</h3><button class="mobile-btn primary mobile-wide" onclick="HerdrMobile.refresh()">Refresh data</button><button class="mobile-btn mobile-wide" onclick="location.reload()">Reload selected layout</button></div>${state.error ? `<div class="mobile-error">${escapeHtml(state.error)}</div>` : ""}</section>`;
+      const font = terminalFontValue();
+      return `<section class="mobile-section mobile-form"><h2>Settings</h2><div class="mobile-settings-group"><h3>Appearance</h3><label><span>Theme</span><select onchange="HerdrMobile.setThemeMode(this.value)"><option value="auto" ${theme === "auto" ? "selected" : ""}>Auto</option><option value="dark" ${theme === "dark" ? "selected" : ""}>Dark</option><option value="light" ${theme === "light" ? "selected" : ""}>Light</option></select></label></div><div class="mobile-settings-group"><h3>Layout</h3><label><span>Layout mode</span><select onchange="HerdrMobile.setLayoutPreference(this.value)"><option value="auto" ${layout === "auto" ? "selected" : ""}>Auto</option><option value="mobile" ${layout === "mobile" ? "selected" : ""}>Mobile</option><option value="desktop" ${layout === "desktop" ? "selected" : ""}>Desktop</option></select><small>Auto uses viewport width, not user agent.</small></label></div><div class="mobile-settings-group"><h3>Terminal</h3><label><span>Terminal font</span><input placeholder="JetBrainsMono Nerd Font, monospace" value="${escapeHtml(font)}" onchange="HerdrMobile.setTerminalFontFamily(this.value)"></label><small>Add a Nerd Font family name so icon glyphs render. Leave blank for the default stack.</small></div><div class="mobile-settings-group"><h3>Data</h3><button class="mobile-btn primary mobile-wide" onclick="HerdrMobile.refresh()">Refresh data</button><button class="mobile-btn mobile-wide" onclick="location.reload()">Reload selected layout</button></div>${state.error ? `<div class="mobile-error">${escapeHtml(state.error)}</div>` : ""}</section>`;
     }
 
     function setThemeMode(value) {
@@ -20,7 +21,33 @@
       localStorage.setItem("herdr-web-layout", value);
     }
 
-    return { render, setLayoutPreference, setThemeMode };
+    function terminalFontValue() {
+      try {
+        const parsed = JSON.parse(
+          localStorage.getItem("herdr-web-options") || "{}",
+        );
+        return (parsed && parsed.terminalFontFamily) || "";
+      } catch (_) {
+        return "";
+      }
+    }
+
+    function setTerminalFontFamily(value) {
+      try {
+        const parsed = JSON.parse(
+          localStorage.getItem("herdr-web-options") || "{}",
+        );
+        parsed.terminalFontFamily = String(value || "").trim();
+        localStorage.setItem("herdr-web-options", JSON.stringify(parsed));
+      } catch (_) {}
+      if (
+        globalThis.HerdrMobile &&
+        globalThis.HerdrMobile.applyTerminalFontFamily
+      )
+        globalThis.HerdrMobile.applyTerminalFontFamily();
+    }
+
+    return { render, setLayoutPreference, setThemeMode, setTerminalFontFamily };
   }
 
   globalThis.HerdrMobileSettings = { create: createMobileSettings };

--- a/src/assets/mobile_terminal.js
+++ b/src/assets/mobile_terminal.js
@@ -6,6 +6,35 @@
       connectedTerminalKey = "",
       connectedTerminalSize = "";
 
+    function terminalFontFamily() {
+      try {
+        const parsed = JSON.parse(
+          (globalThis.localStorage &&
+            globalThis.localStorage.getItem("herdr-web-options")) ||
+            "{}",
+        );
+        return globalThis.HerdrAppHelpers.resolveTerminalFontFamily(
+          parsed && parsed.terminalFontFamily,
+        );
+      } catch (_) {
+        return globalThis.HerdrAppHelpers.resolveTerminalFontFamily("");
+      }
+    }
+    function applyFontFamily() {
+      if (!term) return;
+      const family = terminalFontFamily();
+      try {
+        term.options.fontFamily = family;
+      } catch (e) {
+        try {
+          term.setOption("fontFamily", family);
+        } catch (_) {}
+      }
+      try {
+        term.refresh(0, Math.max(0, (term.rows || 1) - 1));
+      } catch (_) {}
+    }
+
     function size() {
       const shell = el("terminalShell");
       if (!shell) return { cols: 80, rows: 24 };
@@ -36,7 +65,7 @@
       if (!term) {
         term = new Terminal({
           convertEol: false,
-          fontFamily: "ui-monospace,SFMono-Regular,Menlo,monospace",
+          fontFamily: terminalFontFamily(),
           scrollback: 10000,
         });
         term.onData((data) => {
@@ -113,7 +142,7 @@
       openedTerminalElement = null;
     }
 
-    return { connect, destroy, disconnect };
+    return { connect, destroy, disconnect, applyFontFamily };
   }
 
   globalThis.HerdrMobileTerminal = { create: createMobileTerminal };


### PR DESCRIPTION
## Summary

The desktop and mobile `xterm.js` `Terminal` inits hardcoded a font stack with no Nerd Font fallbacks, so PUA icon glyphs (devicons, branch, folder, etc.) from an installed Nerd Font never rendered. `customGlyphs` already defaults on, so box-drawing / powerline separators were fine; only the actual icon glyphs were missing.

This adds a shared default font stack with common Nerd Font families plus `Symbols Nerd Font Mono`, and a user-facing **Terminal font** setting applied live without reconnect.

## Root cause

`app.js` and `mobile_terminal.js` both constructed the terminal with:

```js
fontFamily: "ui-monospace,SFMono-Regular,Menlo,monospace"
```

No Nerd Font in the stack → the browser canvas renderer never fell back to an installed Nerd Font → icon glyphs blank.

## Changes

- **`app_core.js`**: shared `DEFAULT_TERMINAL_FONT_FAMILY` (system fonts first, then `JetBrainsMono` / `FiraCode` / `Hack` / `Cascadia Code NF` / `MesloLGS` Nerd Font, then `Symbols Nerd Font Mono`, then `monospace`) + `resolveTerminalFontFamily(value)` (trims; blank → default).
- **Both `Terminal` inits** use the resolved font, so icons render out of the box when any listed Nerd Font is installed.
- **Desktop**: new **Settings → Terminal input → Terminal font** field; persisted in `herdr-web-options.terminalFontFamily`; applied live via `term.options.fontFamily` + `term.refresh` (no reconnect).
- **Mobile**: new **Settings → Terminal** field with the same persistence and live apply.
- Leave the field blank for the default stack, or paste a family list (e.g. `VictorMono Nerd Font, monospace`) to override.

## Checks

```sh
just check
```

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 47 passed
- `node --test src/assets/*.test.mjs` — 58 passed

## Review notes

- Single source of truth for the default font stack (`app_core.js`).
- Live-update mirrors the existing `applyTheme` pattern (`term.options` with `setOption` fallback).
- [nit] Desktop live-apply fn is `applyTerminalFont`, mobile is `applyFontFamily`; names differ, non-blocking.
- No version bump; frontend-asset-only change.