### PR TITLE
fix: editable source path in create-worktree modal + homogenize flows

### DIFF
--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -23,6 +23,8 @@ let state = {
   editingWorkspaceValue: "",
   workspaceCreateSuggestedLabel: "",
   workspaceCreatePathSuggestTimer: null,
+  createWorktreeOriginalSource: "",
+  createWorktreePathSuggestTimer: null,
 };
 let term,
   termWs,
@@ -215,7 +217,11 @@ function worktreeCreateModalHtml() {
           <button class="mini settings-close" id="worktreeCreateClose" title="Close">✕</button>
         </div>
         <form class="worktree-form" id="worktreeCreateForm">
-          <div class="worktree-source" id="worktreeCreateSource">source workspace</div>
+          <label class="worktree-source">
+            <span>Source repo path</span>
+            <input id="worktreeCreateSource" list="worktreeCreatePathOptions" placeholder="parent workspace path" autocomplete="off">
+            <datalist id="worktreeCreatePathOptions"></datalist>
+          </label>
           <div class="worktree-grid">
             <label>Branch<input id="worktreeBranch" placeholder="auto-generated if blank"></label>
             <label>Base<input id="worktreeBase" placeholder="default branch"></label>
@@ -2794,19 +2800,27 @@ function openWorktreeCreateModal(id) {
   const w = state.workspaces.find((x) => x.workspace_id === id);
   if (!w || isLinkedWorktree(w)) return;
   state.createWorktreeWorkspace = id;
-  el("worktreeCreateSource").textContent = w.label || id;
+  const sourcePath = (w.worktree && w.worktree.checkout_path) || "";
+  state.createWorktreeOriginalSource = sourcePath;
+  el("worktreeCreateSource").value = sourcePath;
   el("worktreeBranch").value = "";
   el("worktreeBase").value = "";
   el("worktreeLabel").value = "";
   el("worktreePath").value = "";
   el("worktreeCreateError").textContent = "";
+  renderPathOptions("worktreeCreatePathOptions", []);
   el("worktreeCreateModal").style.display = "grid";
-  setTimeout(() => el("worktreeBranch").focus(), 0);
+  setTimeout(() => {
+    el("worktreeBranch").focus();
+    loadCreateWorktreePathSuggestions();
+  }, 0);
 }
 function closeWorktreeCreateModal() {
   const m = el("worktreeCreateModal");
   if (m) m.style.display = "none";
+  clearTimeout(state.createWorktreePathSuggestTimer);
   state.createWorktreeWorkspace = null;
+  state.createWorktreeOriginalSource = "";
 }
 function setWorktreeLoading(show) {
   const loading = el("worktreeLoading");
@@ -2958,6 +2972,15 @@ async function loadWorktreePathSuggestions() {
   );
   if (suggestions) state.openWorktreePathSuggestions = suggestions;
 }
+async function loadCreateWorktreePathSuggestions() {
+  await loadDirectoryPathSuggestions("worktreeCreateSource", (items) => {
+    const opts = (items || []).map(
+      (s) =>
+        `<option value="${escapeAttr(s.path)}">${escapeAttr(s.label || "directory")}</option>`,
+    );
+    renderPathOptions("worktreeCreatePathOptions", opts);
+  });
+}
 async function loadDirectoryPathSuggestions(inputId, onDone) {
   const input = el(inputId);
   if (!input) return null;
@@ -3052,8 +3075,75 @@ function checkedOutWorktreeForBranch(branch) {
   return (
     (state.openWorktreeAllRows || state.openWorktreeRows || []).find(
       (w) => textValue(w.branch) === branch && !w.is_prunable,
-    ) || null
+    ) ||
+    (state.worktrees || []).find(
+      (w) => textValue(w.branch) === branch && !w.is_prunable,
+    ) ||
+    null
   );
+}
+function resolveWorktreeSource(input) {
+  const workspaceId = input.workspaceId || null,
+    sourcePath = String(input.sourcePath || "").trim(),
+    originalSource = String(input.originalSource || "").trim(),
+    discovered = input.discoveredSource || {},
+    fallbackWorkspaceId = input.fallbackWorkspaceId || null;
+  if (workspaceId) {
+    const edited = sourcePath && sourcePath !== originalSource;
+    return { workspace_id: workspaceId, cwd: edited ? sourcePath : null };
+  }
+  const wsId = discovered.workspace_id || (!sourcePath ? fallbackWorkspaceId : null);
+  return {
+    workspace_id: wsId || null,
+    cwd: wsId ? null : (discovered.cwd || sourcePath || null),
+  };
+}
+async function submitWorktreeCreate(input) {
+  const errEl = input.errEl,
+    submitEl = input.submitEl,
+    closeFn = input.closeFn,
+    source = input.source,
+    branch = String(input.branch || "").trim(),
+    base = String(input.base || "").trim(),
+    label = String(input.label || "").trim(),
+    path = String(input.path || "").trim();
+  errEl.textContent = "";
+  if (!branch && !options.generateWorktreeNames) {
+    errEl.textContent =
+      "Branch name is required. Enable Generate worktree branch names in Settings to leave it blank.";
+    return;
+  }
+  const checkedOut = checkedOutWorktreeForBranch(branch);
+  if (checkedOut) {
+    errEl.textContent = `Branch "${branch}" is already checked out at ${textValue(checkedOut.path)}`;
+    return;
+  }
+  submitEl.disabled = true;
+  try {
+    const r = await api("/api/worktrees", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        workspace_id: source.workspace_id,
+        cwd: source.cwd,
+        branch: branch || null,
+        base: base || null,
+        label: label || null,
+        path: path || null,
+      }),
+    });
+    closeFn();
+    const result = r.result || {};
+    go(
+      result.workspace.workspace_id,
+      result.tab && result.tab.tab_id,
+      result.root_pane && result.root_pane.pane_id,
+    );
+  } catch (ex) {
+    errEl.textContent = ex.message || String(ex);
+  } finally {
+    submitEl.disabled = false;
+  }
 }
 function defaultBaseBranch() {
   const branches = state.openWorktreeBranches || [];
@@ -3260,53 +3350,35 @@ async function removeDiscoveredWorktree(index) {
 }
 async function createDiscoveredWorktree() {
   const err = el("worktreeOpenError"),
-    sourcePath = el("worktreeDiscoverPath").value.trim(),
-    branch = el("worktreeNewBranch").value.trim(),
-    base = el("worktreeNewBase").value.trim(),
-    label = el("worktreeNewLabel").value.trim(),
-    path = el("worktreeNewPath").value.trim(),
-    submit = el("worktreeNewSubmit");
+    submitEl = el("worktreeNewSubmit"),
+    sourcePath = el("worktreeDiscoverPath").value.trim();
   err.textContent = "";
-  if (!branch && !options.generateWorktreeNames) {
-    err.textContent =
-      "Branch name is required. Enable Generate worktree branch names in Settings to leave it blank.";
-    return;
-  }
-  submit.disabled = true;
-  try {
-    if (sourcePath && !state.openWorktreeSource) await discoverWorktrees();
-    const checkedOut = checkedOutWorktreeForBranch(branch);
-    if (checkedOut) {
-      err.textContent = `Branch "${branch}" is already checked out at ${textValue(checkedOut.path)}`;
+  if (sourcePath && !state.openWorktreeSource) {
+    submitEl.disabled = true;
+    try {
+      await discoverWorktrees();
+    } catch (ex) {
+      err.textContent = ex.message || String(ex);
       return;
+    } finally {
+      submitEl.disabled = false;
     }
-    const source = state.openWorktreeSource || {};
-    const workspaceId = source.workspace_id || (!sourcePath ? state.ws : null),
-      cwd = workspaceId ? null : (source.cwd || sourcePath || null);
-    const r = await api("/api/worktrees", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        workspace_id: workspaceId,
-        cwd,
-        branch: branch || null,
-        base: base || null,
-        label: label || null,
-        path: path || null,
-      }),
-    });
-    closeWorktreeOpenModal();
-    const result = r.result || {};
-    go(
-      result.workspace.workspace_id,
-      result.tab && result.tab.tab_id,
-      result.root_pane && result.root_pane.pane_id,
-    );
-  } catch (ex) {
-    err.textContent = ex.message || String(ex);
-  } finally {
-    submit.disabled = false;
   }
+  const source = resolveWorktreeSource({
+    sourcePath,
+    discoveredSource: state.openWorktreeSource || {},
+    fallbackWorkspaceId: state.ws,
+  });
+  await submitWorktreeCreate({
+    errEl: el("worktreeOpenError"),
+    submitEl: el("worktreeNewSubmit"),
+    closeFn: closeWorktreeOpenModal,
+    source,
+    branch: el("worktreeNewBranch").value,
+    base: el("worktreeNewBase").value,
+    label: el("worktreeNewLabel").value,
+    path: el("worktreeNewPath").value,
+  });
 }
 async function closeWorkspace(id) {
   const w = state.workspaces.find((x) => x.workspace_id === id),
@@ -3787,40 +3859,29 @@ el("optSound").onchange = () => {
 };
 el("worktreeCreateClose").onclick = closeWorktreeCreateModal;
 el("worktreeCreateCancel").onclick = closeWorktreeCreateModal;
+el("worktreeCreateSource").oninput = () => {
+  state.createWorktreePathSuggestTimer = schedulePathSuggestions(
+    state.createWorktreePathSuggestTimer,
+    loadCreateWorktreePathSuggestions,
+  );
+};
 el("worktreeCreateForm").onsubmit = async (e) => {
   e.preventDefault();
-  const err = el("worktreeCreateError"),
-    submit = el("worktreeCreateSubmit");
-  err.textContent = "";
-  const branch = el("worktreeBranch").value.trim(),
-    base = el("worktreeBase").value.trim(),
-    label = el("worktreeLabel").value.trim(),
-    path = el("worktreePath").value.trim();
-  submit.disabled = true;
-  try {
-    const r = await api("/api/worktrees", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        workspace_id: state.createWorktreeWorkspace,
-        branch: branch || null,
-        base: base || null,
-        label: label || null,
-        path: path || null,
-      }),
-    });
-    closeWorktreeCreateModal();
-    const result = r.result || {};
-    go(
-      result.workspace.workspace_id,
-      result.tab && result.tab.tab_id,
-      result.root_pane && result.root_pane.pane_id,
-    );
-  } catch (ex) {
-    err.textContent = ex.message || String(ex);
-  } finally {
-    submit.disabled = false;
-  }
+  const source = resolveWorktreeSource({
+    workspaceId: state.createWorktreeWorkspace,
+    sourcePath: el("worktreeCreateSource").value,
+    originalSource: state.createWorktreeOriginalSource,
+  });
+  await submitWorktreeCreate({
+    errEl: el("worktreeCreateError"),
+    submitEl: el("worktreeCreateSubmit"),
+    closeFn: closeWorktreeCreateModal,
+    source,
+    branch: el("worktreeBranch").value,
+    base: el("worktreeBase").value,
+    label: el("worktreeLabel").value,
+    path: el("worktreePath").value,
+  });
 };
 el("worktreeOpenClose").onclick = closeWorktreeOpenModal;
 document.addEventListener(

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -413,11 +413,203 @@ describe("app bundle load", () => {
 
     match(ctx.worktreeCreateModalHtml(), /id="worktreeCreateForm"/);
     match(ctx.worktreeCreateModalHtml(), /id="worktreeCreateSubmit"/);
+    match(ctx.worktreeCreateModalHtml(), /id="worktreeCreateSource"/);
+    match(ctx.worktreeCreateModalHtml(), /list="worktreeCreatePathOptions"/);
     match(ctx.worktreeOpenModalHtml(), /id="worktreeDiscoverPath"/);
     match(ctx.worktreeOpenModalHtml(), /id="worktreePathOptions"/);
     match(ctx.worktreeOpenModalHtml(), /id="worktreeBranchOptions"/);
     match(ctx.shortcutsModalHtml(), /id="shortcutsModal"/);
     match(ctx.shortcutsModalHtml(), /id="closeShortcutCurrent"/);
+  });
+
+  it("prefills create-worktree source from parent workspace checkout path", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+    vm.runInContext(
+      `state.workspaces = [
+        { workspace_id: "ws1", label: "alpha", pane_count: 1, worktree: { checkout_path: "/repo/alpha", is_linked_worktree: false } },
+      ];
+      openWorktreeCreateModal("ws1");`,
+      ctx,
+    );
+
+    equal(ctx.document.getElementById("worktreeCreateSource").value, "/repo/alpha");
+    const result = vm.runInContext(
+      `JSON.stringify({
+        workspace: state.createWorktreeWorkspace,
+        original: state.createWorktreeOriginalSource,
+      })`,
+      ctx,
+    );
+    const parsed = JSON.parse(result);
+    equal(parsed.workspace, "ws1");
+    equal(parsed.original, "/repo/alpha");
+  });
+
+  it("sends workspace_id and omits cwd when create-worktree source is unchanged", async () => {
+    const ctx = context();
+    const calls = [];
+    ctx.fetch = async (url, opt) => {
+      calls.push({ url, body: JSON.parse(opt.body) });
+      return { status: 200, json: async () => ({ result: { workspace: { workspace_id: "new" } } }) };
+    };
+    vm.runInContext(source, ctx);
+    vm.runInContext(
+      `state.workspaces = [
+        { workspace_id: "ws1", label: "alpha", pane_count: 1, worktree: { checkout_path: "/repo/alpha", is_linked_worktree: false } },
+      ];
+      openWorktreeCreateModal("ws1");`,
+      ctx,
+    );
+
+    await vm.runInContext(
+      `el("worktreeBranch").value = "feature/x";
+       (async () => { await el("worktreeCreateForm").onsubmit({ preventDefault() {} }); })();`,
+      ctx,
+    );
+
+    equal(calls.length, 1);
+    equal(calls[0].body.workspace_id, "ws1");
+    equal(calls[0].body.cwd, null);
+    equal(calls[0].body.branch, "feature/x");
+  });
+
+  it("sends cwd and keeps workspace_id when create-worktree source is edited", async () => {
+    const ctx = context();
+    const calls = [];
+    ctx.fetch = async (url, opt) => {
+      calls.push({ url, body: JSON.parse(opt.body) });
+      return { status: 200, json: async () => ({ result: { workspace: { workspace_id: "new" } } }) };
+    };
+    vm.runInContext(source, ctx);
+    vm.runInContext(
+      `state.workspaces = [
+        { workspace_id: "ws1", label: "alpha", pane_count: 1, worktree: { checkout_path: "/repo/alpha", is_linked_worktree: false } },
+      ];
+      openWorktreeCreateModal("ws1");`,
+      ctx,
+    );
+
+    await vm.runInContext(
+      `el("worktreeCreateSource").value = "/repo/other";
+       el("worktreeBranch").value = "feature/y";
+       (async () => { await el("worktreeCreateForm").onsubmit({ preventDefault() {} }); })();`,
+      ctx,
+    );
+
+    equal(calls.length, 1);
+    equal(calls[0].body.workspace_id, "ws1");
+    equal(calls[0].body.cwd, "/repo/other");
+    equal(calls[0].body.branch, "feature/y");
+  });
+
+  it("create-worktree form blocks blank branch when generate names disabled", async () => {
+    const ctx = context();
+    const calls = [];
+    ctx.fetch = async (url, opt) => {
+      calls.push({ url, body: JSON.parse(opt.body) });
+      return { status: 200, json: async () => ({ result: { workspace: { workspace_id: "new" } } }) };
+    };
+    vm.runInContext(source, ctx);
+    vm.runInContext(
+      `state.workspaces = [
+        { workspace_id: "ws1", label: "alpha", pane_count: 1, worktree: { checkout_path: "/repo/alpha", is_linked_worktree: false } },
+      ];
+      options.generateWorktreeNames = false;
+      openWorktreeCreateModal("ws1");`,
+      ctx,
+    );
+
+    await vm.runInContext(
+      `el("worktreeBranch").value = "";
+       (async () => { await el("worktreeCreateForm").onsubmit({ preventDefault() {} }); })();`,
+      ctx,
+    );
+
+    equal(calls.length, 0);
+    match(
+      ctx.document.getElementById("worktreeCreateError").textContent,
+      /Branch name is required/,
+    );
+  });
+
+  it("create-worktree form blocks branch already checked out globally", async () => {
+    const ctx = context();
+    const calls = [];
+    ctx.fetch = async (url, opt) => {
+      calls.push({ url, body: JSON.parse(opt.body) });
+      return { status: 200, json: async () => ({ result: { workspace: { workspace_id: "new" } } }) };
+    };
+    vm.runInContext(source, ctx);
+    vm.runInContext(
+      `state.workspaces = [
+        { workspace_id: "ws1", label: "alpha", pane_count: 1, worktree: { checkout_path: "/repo/alpha", is_linked_worktree: false } },
+      ];
+      state.worktrees = [
+        { branch: "feature/exists", path: "/repo/exists", is_prunable: false },
+      ];
+      openWorktreeCreateModal("ws1");`,
+      ctx,
+    );
+
+    await vm.runInContext(
+      `el("worktreeBranch").value = "feature/exists";
+       (async () => { await el("worktreeCreateForm").onsubmit({ preventDefault() {} }); })();`,
+      ctx,
+    );
+
+    equal(calls.length, 0);
+    match(
+      ctx.document.getElementById("worktreeCreateError").textContent,
+      /already checked out/,
+    );
+  });
+
+  it("resolveWorktreeSource keeps workspace anchor when path unchanged", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+    const result = vm.runInContext(
+      `JSON.stringify(resolveWorktreeSource({
+        workspaceId: "ws1",
+        sourcePath: "/repo/alpha",
+        originalSource: "/repo/alpha",
+      }))`,
+      ctx,
+    );
+    const parsed = JSON.parse(result);
+    equal(parsed.workspace_id, "ws1");
+    equal(parsed.cwd, null);
+  });
+
+  it("resolveWorktreeSource sends cwd when explicit workspace path edited", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+    const result = vm.runInContext(
+      `JSON.stringify(resolveWorktreeSource({
+        workspaceId: "ws1",
+        sourcePath: "/repo/other",
+        originalSource: "/repo/alpha",
+      }))`,
+      ctx,
+    );
+    const parsed = JSON.parse(result);
+    equal(parsed.workspace_id, "ws1");
+    equal(parsed.cwd, "/repo/other");
+  });
+
+  it("resolveWorktreeSource is path-first exclusive without workspace anchor", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+    const result = vm.runInContext(
+      `JSON.stringify(resolveWorktreeSource({
+        sourcePath: "/repo/free",
+        discoveredSource: { cwd: "/repo/free" },
+      }))`,
+      ctx,
+    );
+    const parsed = JSON.parse(result);
+    equal(parsed.workspace_id, null);
+    equal(parsed.cwd, "/repo/free");
   });
 
   it("prefills workspace label from final folder segment", () => {


### PR DESCRIPTION
## Summary

The Create worktree modal (sidebar ♧+) showed the source workspace as static, non-editable text, so users could not redirect the worktree to a different repo path. The two create-worktree flows also diverged in unsafe ways: the sidebar flow lacked the branch validation and already-checked-out guard that the Open-worktrees flow had.

This makes the source an editable, prefilled input with path discovery, and homogenizes both flows behind shared helpers.

## Changes

### Editable source (Flow 1: sidebar ♧+ on a parent workspace)
- Replace the static `worktreeCreateSource` div with an `<input>` + datalist, prefilled from the parent workspace `checkout_path`.
- On open: store `createWorktreeOriginalSource`, prefill the input, seed datalist discovery.
- On submit: always send `workspace_id`; send `cwd` only when the user edited the prefilled path. Preserves the workspace anchor unless the user intentionally overrides the source repo.
- On close: clear the suggestion timer and original-source state.

### Homogenized flows (shared helpers)
- **`resolveWorktreeSource`** centralizes source resolution:
  - Workspace-anchored flow (sidebar): keeps `workspace_id` always, sends `cwd` only on edit.
  - Path-first flow (header ♧ → Worktrees): exclusive `workspace_id` xor `cwd`, unchanged.
- **`submitWorktreeCreate`** centralizes: branch validation (required unless `generateWorktreeNames`), the already-checked-out guard, the API call, success navigation, and error handling. Both submit handlers are now ~10-line thin callers.
- **`checkedOutWorktreeForBranch`** now also checks the global `state.worktrees` list, so the sidebar flow gains the already-checked-out guard it was missing.
- Flow 2 discovery errors still surface to the same error element.

### Remaining divergence (by design)
Flow 2 lists existing linked worktrees via discovery; Flow 1 does not (different UX context — you clicked a specific workspace, not browsing repos).

## Checks

```sh
just check
```

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 47 passed
- `node --test src/assets/*.test.mjs` — 66 passed

## Tests
- Prefill source from parent workspace checkout path
- Unchanged source → workspace_id sent, cwd null
- Edited source → workspace_id + cwd sent
- Blank branch blocked when generate names disabled
- Already-checked-out branch blocked (global state.worktrees)
- `resolveWorktreeSource` three strategies: unchanged, edited, path-first exclusive

## Review notes
- Single source of truth for validation/guard/API/navigation via `submitWorktreeCreate`.
- `checkedOutWorktreeForBranch` extended to global list — both flows now catch duplicates.
- [nit] Source resolution differs by context (send-both vs exclusive) — intentional, documented in the helper.
- No version bump; frontend-only change.