### PR TITLE
fix: resolveWorktreeSource sends cwd exclusively, not both

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-webui"
-version = "0.0.40"
+version = "0.0.41"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"

--- a/src/assets/core.js
+++ b/src/assets/core.js
@@ -1,0 +1,185 @@
+(function (root) {
+  function branchPathSlug(branch) {
+    let slug = "",
+      lastDash = false;
+    for (const ch of String(branch || "")) {
+      if (/^[A-Za-z0-9]$/.test(ch)) {
+        slug += ch.toLowerCase();
+        lastDash = false;
+      } else if (!lastDash) {
+        slug += "-";
+        lastDash = true;
+      }
+    }
+    slug = slug.replace(/^-+|-+$/g, "");
+    return slug || "worktree";
+  }
+
+  function normalizeAbsolutePath(path) {
+    path = String(path || "");
+    if (!path.startsWith("/")) return path;
+    const parts = [];
+    for (const part of path.split("/")) {
+      if (!part || part === ".") continue;
+      if (part === "..") parts.pop();
+      else parts.push(part);
+    }
+    return "/" + parts.join("/");
+  }
+
+  function terminalPasteInput(text, bracketedPasteMode) {
+    const normalized = String(text || "").replace(/\r\n|\r|\n/g, " ").replace(/ +$/, "");
+    if (bracketedPasteMode) return "\x1b[200~" + normalized + "\x1b[201~";
+    return normalized;
+  }
+
+  function terminalWheelScrollBatch(remainder, delta, deltaMode, speed, rows) {
+    const mode = Number(deltaMode) || 0,
+      lineSpeed = Math.max(1, Math.min(20, Number(speed) || 3)),
+      rowCount = Math.max(1, Number(rows) || 30);
+    const units =
+      mode === 1
+        ? Number(delta) / 3
+        : mode === 2
+          ? (Number(delta) * Math.max(1, rowCount - 1)) / 3
+          : Number(delta) / 100;
+    const next = (Number(remainder) || 0) + units * lineSpeed;
+    const whole = Math.trunc(Math.abs(next));
+    if (!Number.isFinite(next) || whole < 1)
+      return { direction: null, lines: 0, remainder: Number.isFinite(next) ? next : 0 };
+    const lines = Math.min(whole, 120),
+      sign = Math.sign(next);
+    return {
+      direction: sign < 0 ? "up" : "down",
+      lines,
+      remainder: next - sign * lines,
+    };
+  }
+
+  function tabActivityLabel(updatedAt, now) {
+    const age = Math.max(0, Number(now) - Number(updatedAt));
+    if (!Number.isFinite(age)) return "";
+    const minute = 60 * 1000,
+      hour = 60 * minute,
+      day = 24 * hour;
+    if (age > day) return ">1d";
+    if (age > hour) return ">1h";
+    if (age < minute) return "<1m";
+    return Math.floor(age / minute) + "m ago";
+  }
+
+  function isHexColor(value) {
+    return /^#[0-9a-fA-F]{6}$/.test(String(value || ""));
+  }
+
+  function normalizeThemeColors(value, defaults) {
+    const source = value && typeof value === "object" ? value : {};
+    const next = {};
+    for (const mode of ["dark", "light"]) {
+      next[mode] = {};
+      const colors =
+        source[mode] && typeof source[mode] === "object" ? source[mode] : {};
+      for (const key of Object.keys(defaults[mode] || {})) {
+        const candidate = colors[key];
+        next[mode][key] = isHexColor(candidate)
+          ? candidate.toLowerCase()
+          : defaults[mode][key];
+      }
+    }
+    return next;
+  }
+
+  const DEFAULT_TERMINAL_FONT_FAMILY =
+    "ui-monospace, SFMono-Regular, Menlo, 'JetBrainsMono Nerd Font', 'FiraCode Nerd Font', 'Hack Nerd Font', 'Cascadia Code NF', 'MesloLGS NF', 'Symbols Nerd Font Mono', monospace";
+
+  function resolveTerminalFontFamily(value) {
+    const trimmed = String(value == null ? "" : value).trim();
+    return trimmed || DEFAULT_TERMINAL_FONT_FAMILY;
+  }
+
+  function textValue(v) {
+    if (v === null || v === undefined) return "";
+    if (typeof v === "string") return v;
+    if (typeof v === "number" || typeof v === "boolean") return String(v);
+    if (v.path) return textValue(v.path);
+    if (v.display) return textValue(v.display);
+    if (v.label) return textValue(v.label);
+    if (v.name) return textValue(v.name);
+    return "";
+  }
+
+  function resolveWorktreeSource(input) {
+    const workspaceId = input.workspaceId || null,
+      sourcePath = String(input.sourcePath || "").trim(),
+      originalSource = String(input.originalSource || "").trim(),
+      discovered = input.discoveredSource || {},
+      fallbackWorkspaceId = input.fallbackWorkspaceId || null;
+    if (workspaceId) {
+      const edited = sourcePath && sourcePath !== originalSource;
+      if (edited) return { workspace_id: null, cwd: sourcePath };
+      return { workspace_id: workspaceId, cwd: null };
+    }
+    const wsId = discovered.workspace_id || (!sourcePath ? fallbackWorkspaceId : null);
+    return {
+      workspace_id: wsId || null,
+      cwd: wsId ? null : (discovered.cwd || sourcePath || null),
+    };
+  }
+
+  function checkedOutWorktreeForBranch(branch, worktreeLists) {
+    branch = String(branch || "").trim();
+    if (!branch) return null;
+    const lists = worktreeLists || [];
+    for (const list of lists) {
+      const found = (list || []).find(
+        (w) => textValue(w.branch) === branch && !w.is_prunable,
+      );
+      if (found) return found;
+    }
+    return null;
+  }
+
+  function validateWorktreeCreate(input) {
+    const branch = String(input.branch || "").trim();
+    if (!branch && !input.generateWorktreeNames) {
+      return "Branch name is required. Enable Generate worktree branch names in Settings to leave it blank.";
+    }
+    const checkedOut = checkedOutWorktreeForBranch(
+      branch,
+      input.worktreeLists || [],
+    );
+    if (checkedOut) {
+      return `Branch "${branch}" is already checked out at ${textValue(checkedOut.path)}`;
+    }
+    return "";
+  }
+
+  function buildWorktreeCreateBody(input) {
+    const source = input.source || {};
+    return {
+      workspace_id: source.workspace_id ?? null,
+      cwd: source.cwd ?? null,
+      branch: String(input.branch || "").trim() || null,
+      base: String(input.base || "").trim() || null,
+      label: String(input.label || "").trim() || null,
+      path: String(input.path || "").trim() || null,
+    };
+  }
+
+  const helpers = {
+    branchPathSlug,
+    normalizeAbsolutePath,
+    normalizeThemeColors,
+    resolveTerminalFontFamily,
+    textValue,
+    resolveWorktreeSource,
+    checkedOutWorktreeForBranch,
+    validateWorktreeCreate,
+    buildWorktreeCreateBody,
+    terminalWheelScrollBatch,
+    terminalPasteInput,
+    tabActivityLabel,
+  };
+  root.HerdrAppHelpers = helpers;
+  if (typeof module !== "undefined" && module.exports) module.exports = helpers;
+})(typeof globalThis !== "undefined" ? globalThis : window);


### PR DESCRIPTION
## Summary

Backend rejects requests with both `workspace_id` and `cwd` with "only one of workspace_id or cwd may be supplied". When the user edits the source path in the create-worktree modal, `resolveWorktreeSource` now returns `{ workspace_id: null, cwd: sourcePath }` instead of `{ workspace_id, cwd }`.

Unchanged path still sends `workspace_id` only.

## Checks

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 47 passed
- `node --test src/assets/*.test.mjs` — 79 passed

Version bumped to 0.0.41.