### PR TITLE
fix: stop command fails with KeepAlive respawn and no SIGTERM handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "herdr-webui"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "axum",
  "bincode",
@@ -610,6 +620,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +698,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ interprocess = "2.4.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "signal"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/Makefile
+++ b/Makefile
@@ -84,18 +84,24 @@ update-mac: build
 
 start-mac:
 	@if [ ! -f "$(INSTALL_PLIST)" ]; then echo "LaunchAgent plist not found at $(INSTALL_PLIST)" >&2; exit 1; fi
+	launchctl enable "gui/$$(id -u)/$(INSTALL_LABEL)" >/dev/null 2>&1 || true
 	launchctl kickstart -k "gui/$$(id -u)/$(INSTALL_LABEL)" >/dev/null 2>&1 || \
 		{ launchctl bootstrap "gui/$$(id -u)" "$(INSTALL_PLIST)" && launchctl kickstart -k "gui/$$(id -u)/$(INSTALL_LABEL)"; }
 	@echo "Started $(INSTALL_LABEL)"
 
 stop-mac:
+	launchctl disable "gui/$$(id -u)/$(INSTALL_LABEL)" >/dev/null 2>&1 || true
 	launchctl bootout "gui/$$(id -u)/$(INSTALL_LABEL)" >/dev/null 2>&1 || true
 	@echo "Stopped $(INSTALL_LABEL)"
 
-restart-mac: stop-mac start-mac
+restart-mac:
+	$(MAKE) stop-mac
+	@sleep 1
+	$(MAKE) start-mac
 	@echo "Restarted $(INSTALL_LABEL)"
 
 uninstall-mac:
+	launchctl disable "gui/$$(id -u)/$(INSTALL_LABEL)" >/dev/null 2>&1 || true
 	launchctl bootout "gui/$$(id -u)" "$(INSTALL_PLIST)" >/dev/null 2>&1 || true
 	rm -f "$(INSTALL_PLIST)"
 	@echo "Uninstalled $(INSTALL_LABEL)"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::future::IntoFuture;
 use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::SocketAddr;
@@ -588,27 +589,41 @@ async fn serve_rebindable(
     state: WebState,
     mut rebind_rx: tokio::sync::watch::Receiver<SocketAddr>,
 ) -> io::Result<()> {
+    let mut sigterm =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .map_err(io::Error::other)?;
+    let mut sigint =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+            .map_err(io::Error::other)?;
+
     loop {
         let bind = *rebind_rx.borrow_and_update();
         let listener = match tokio::net::TcpListener::bind(bind).await {
             Ok(listener) => listener,
             Err(err) => {
                 eprintln!("failed to bind http://{bind}: {err}");
-                rebind_rx.changed().await.map_err(io::Error::other)?;
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
                 continue;
             }
         };
         eprintln!("herdr-webui listening on http://{bind}");
         let mut shutdown_rx = rebind_rx.clone();
-        axum::serve(
+        let server = axum::serve(
             listener,
             app_router(state.clone()).into_make_service_with_connect_info::<SocketAddr>(),
         )
         .with_graceful_shutdown(async move {
             let _ = shutdown_rx.changed().await;
         })
-        .await
-        .map_err(io::Error::other)?;
+        .into_future();
+        tokio::pin!(server);
+        tokio::select! {
+            _ = sigterm.recv() => return Ok(()),
+            _ = sigint.recv() => return Ok(()),
+            res = &mut server => {
+                res.map_err(io::Error::other)?;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Three root causes for `make stop-mac` not working:

1. **KeepAlive=true respawn race**: `bootout` kills the process, but `KeepAlive=true` causes launchd to respawn it before bootout fully removes the service. Fix: `stop-mac` calls `launchctl disable` before `bootout`. `start-mac` calls `launchctl enable`.

2. **No SIGTERM handler in server**: `serve_rebindable` graceful shutdown only listened to the rebind watch channel. OS signals killed the process ungracefully. Fix: add `tokio::signal` handlers for SIGTERM/SIGINT via `tokio::select!`, returning `Ok(())` on signal.

3. **Bind failure hangs forever**: On `Address already in use` (port in TIME_WAIT during restart), server hung in `rebind_rx.changed().await` waiting for a rebind signal that never came. Fix: replace with 1-second sleep + retry loop.

Additional changes:
- `restart-mac` uses explicit stop/sleep 1/start instead of make prerequisites
- `uninstall-mac` adds `launchctl disable` before bootout
- tokio `signal` feature enabled in Cargo.toml

Tested: start → stop → port stays free (no respawn). SIGTERM → clean exit.