### PR TITLE
Extend WebUI test coverage

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -207,3 +207,42 @@ pub(crate) async fn icon_folder_svg() -> Response {
 pub(crate) async fn icon_file_svg() -> Response {
     static_svg(ICON_FILE)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::header;
+
+    fn content_type(response: &Response) -> &str {
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("")
+    }
+
+    #[tokio::test]
+    async fn serves_remaining_static_text_assets_with_content_types() {
+        let javascript = "application/javascript; charset=utf-8";
+        let css = "text/css; charset=utf-8";
+
+        assert_eq!(content_type(&desktop_git_ui_js().await), javascript);
+        assert_eq!(content_type(&login_js().await), javascript);
+        assert_eq!(content_type(&desktop_git_ui_css().await), css);
+        assert_eq!(content_type(&login_css().await), css);
+    }
+
+    #[tokio::test]
+    async fn serves_icon_assets_as_svg() {
+        let svg = "image/svg+xml; charset=utf-8";
+
+        assert_eq!(content_type(&icon_help_svg().await), svg);
+        assert_eq!(content_type(&icon_settings_svg().await), svg);
+        assert_eq!(content_type(&icon_theme_auto_svg().await), svg);
+        assert_eq!(content_type(&icon_git_svg().await), svg);
+        assert_eq!(content_type(&icon_chevron_right_svg().await), svg);
+        assert_eq!(content_type(&icon_chevron_down_svg().await), svg);
+        assert_eq!(content_type(&icon_folder_svg().await), svg);
+        assert_eq!(content_type(&icon_file_svg().await), svg);
+    }
+}

--- a/src/git_ui.rs
+++ b/src/git_ui.rs
@@ -1263,12 +1263,59 @@ async fn git_ui_conflict_action(
 mod tests {
     use super::*;
 
+    fn query() -> GitUiQuery {
+        GitUiQuery {
+            cwd: None,
+            scope: None,
+            file: None,
+            base: None,
+            target: None,
+            merge_base: None,
+            max: None,
+            ref_name: None,
+            all: None,
+            context: None,
+        }
+    }
+
     #[test]
     fn rejects_unsafe_repo_paths() {
         assert!(safe_repo_path("src/main.rs").is_ok());
+        assert_eq!(safe_repo_path(" src/main.rs ").unwrap(), "src/main.rs");
         assert!(safe_repo_path("../secret").is_err());
+        assert!(safe_repo_path("src/../secret").is_err());
         assert!(safe_repo_path("/tmp/secret").is_err());
         assert!(safe_repo_path("").is_err());
+        assert!(safe_repo_path("src\0secret").is_err());
+    }
+
+    #[test]
+    fn rejects_unsafe_git_tokens() {
+        assert_eq!(safe_git_token(" main ", "branch").unwrap(), "main");
+        assert!(safe_git_token("", "branch").is_err());
+        assert!(safe_git_token("--upload-pack=/tmp/x", "branch").is_err());
+        assert!(safe_git_token("main\0next", "branch").is_err());
+    }
+
+    #[test]
+    fn parses_diff_paths() {
+        assert_eq!(
+            parse_diff_path("a/src/main.rs").as_deref(),
+            Some("src/main.rs")
+        );
+        assert_eq!(
+            parse_diff_path("b/src/main.rs").as_deref(),
+            Some("src/main.rs")
+        );
+        assert_eq!(parse_diff_path("/dev/null"), None);
+        assert_eq!(
+            parse_diff_path("\"a/src/file\\tname.rs\"").as_deref(),
+            Some("src/file\tname.rs")
+        );
+        assert_eq!(
+            parse_diff_path("\"b/src/file\\\"name.rs\"").as_deref(),
+            Some("src/file\"name.rs")
+        );
     }
 
     #[test]
@@ -1283,5 +1330,102 @@ mod tests {
         assert_eq!(files[0].chunks[0].lines.len(), 3);
         assert_eq!(files[0].chunks[0].lines[0].line_type, "delete");
         assert_eq!(files[0].chunks[0].lines[1].line_type, "add");
+    }
+
+    #[test]
+    fn parses_added_deleted_and_renamed_diffs() {
+        let diff = "diff --git a/new.txt b/new.txt\nnew file mode 100644\n--- /dev/null\n+++ b/new.txt\n@@ -0,0 +1 @@\n+new\n\ndiff --git a/old.txt b/old.txt\ndeleted file mode 100644\n--- a/old.txt\n+++ /dev/null\n@@ -1 +0,0 @@\n-old\n\ndiff --git a/old-name.txt b/new-name.txt\nsimilarity index 100%\nrename from old-name.txt\nrename to new-name.txt\n--- a/old-name.txt\n+++ b/new-name.txt\n";
+        let files = parse_unified_diff(diff);
+
+        assert_eq!(files.len(), 3);
+        assert_eq!(files[0].status, "added");
+        assert_eq!(files[0].path, "new.txt");
+        assert_eq!(files[0].additions, 1);
+        assert_eq!(files[1].status, "deleted");
+        assert_eq!(files[1].path, "old.txt");
+        assert_eq!(files[1].deletions, 1);
+        assert_eq!(files[2].status, "renamed");
+        assert_eq!(files[2].path, "new-name.txt");
+        assert_eq!(files[2].old_path.as_deref(), Some("old-name.txt"));
+    }
+
+    #[test]
+    fn builds_git_diff_args_for_scopes_and_compare() {
+        let mut staged = query();
+        staged.scope = Some("staged".to_string());
+        staged.file = Some("src/main.rs".to_string());
+        staged.context = Some(500);
+        assert_eq!(
+            git_ui_diff_args(&staged, false).unwrap(),
+            vec![
+                "diff",
+                "--no-ext-diff",
+                "--color=never",
+                "-U200",
+                "--cached",
+                "--",
+                "src/main.rs"
+            ]
+        );
+
+        let mut working = query();
+        working.scope = Some("working".to_string());
+        working.context = Some(0);
+        assert_eq!(
+            git_ui_diff_args(&working, false).unwrap(),
+            vec!["diff", "--no-ext-diff", "--color=never", "-U0"]
+        );
+
+        let mut compare = query();
+        compare.base = Some("main".to_string());
+        compare.target = Some("feature".to_string());
+        compare.merge_base = Some(true);
+        assert_eq!(
+            git_ui_diff_args(&compare, true).unwrap(),
+            vec![
+                "diff",
+                "--no-ext-diff",
+                "--color=never",
+                "-U3",
+                "--merge-base",
+                "main",
+                "feature"
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_unsafe_diff_args() {
+        let mut bad_file = query();
+        bad_file.file = Some("../secret".to_string());
+        assert!(git_ui_diff_args(&bad_file, false).is_err());
+
+        let mut bad_ref = query();
+        bad_ref.base = Some("--help".to_string());
+        assert!(git_ui_diff_args(&bad_ref, true).is_err());
+    }
+
+    #[test]
+    fn validates_git_ui_paths_request() {
+        let body = GitUiPathsRequest {
+            cwd: "/repo".to_string(),
+            paths: vec!["a.txt".to_string(), "dir/b.txt".to_string()],
+            confirmed: None,
+        };
+        assert_eq!(git_ui_paths(&body).unwrap(), vec!["a.txt", "dir/b.txt"]);
+
+        let empty = GitUiPathsRequest {
+            cwd: "/repo".to_string(),
+            paths: vec![],
+            confirmed: None,
+        };
+        assert!(git_ui_paths(&empty).is_err());
+
+        let unsafe_path = GitUiPathsRequest {
+            cwd: "/repo".to_string(),
+            paths: vec!["../secret".to_string()],
+            confirmed: None,
+        };
+        assert!(git_ui_paths(&unsafe_path).is_err());
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -476,6 +476,20 @@ mod tests {
     }
 
     #[test]
+    fn linux_service_unit_quotes_shell_sensitive_args() {
+        let config = WebConfig {
+            bind: "127.0.0.1:8787".parse().unwrap(),
+            session: Some("work session's path".to_string()),
+            api_socket: None,
+            client_socket: None,
+        };
+
+        let unit = linux_service_unit(&config, Path::new("/tmp/herdr webui"));
+
+        assert!(unit.contains("ExecStart='/tmp/herdr webui' --bind 127.0.0.1:8787 --session 'work session'\\''s path'"));
+    }
+
+    #[test]
     fn mac_plist_contains_binary_and_flags() {
         let config = WebConfig {
             bind: "127.0.0.1:8787".parse().unwrap(),
@@ -491,5 +505,18 @@ mod tests {
         assert!(plist.contains("<string>127.0.0.1:8787</string>"));
         assert!(plist.contains("<string>--session</string>"));
         assert!(plist.contains("<string>work</string>"));
+    }
+
+    #[test]
+    fn escapes_service_file_values() {
+        assert_eq!(systemd_escape_arg("plain/path:1"), "plain/path:1");
+        assert_eq!(systemd_escape_arg("has space"), "'has space'");
+        assert_eq!(systemd_escape_arg("has'quote"), "'has'\\''quote'");
+        assert_eq!(systemd_escape_arg("has\\slash"), "'has\\\\slash'");
+
+        assert_eq!(
+            xml_escape("<&>\"'"),
+            "&lt;&amp;&gt;&quot;&apos;".to_string()
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add asset handler content-type coverage for Git UI, login, and SVG icons
- add Git UI helper tests for safe paths/tokens, diff parsing, diff args, and path request validation
- add service helper tests for quoting and XML escaping

## Coverage
- before: 50.09% line coverage
- after: 53.71% line coverage

## Tests
- cargo fmt --check
- cargo test
- make coverage
- node --test src/assets/app_core.test.mjs src/assets/app_load.test.mjs src/assets/app_boot.test.mjs src/assets/mobile_load.test.mjs
- node --check desktop/mobile JS chunks
- git diff --check -- . ':!references'