### PR TITLE
Add mobile Git UI and desktop diff refinements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "herdr-webui"
-version = "0.0.46"
+version = "0.0.47"
 dependencies = [
  "axum",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "herdr-webui"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "axum",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-webui"
-version = "0.0.46"
+version = "0.0.47"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-webui"
-version = "0.0.47"
+version = "0.0.48"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-js:
 	node --test src/assets/app_core.test.mjs src/assets/app_load.test.mjs src/assets/app_boot.test.mjs src/assets/mobile_load.test.mjs
 
 coverage:
-	CARGO_TARGET_DIR=$(TARGET_DIR) $(CARGO) llvm-cov --summary-only
+	CARGO_TARGET_DIR=$(TARGET_DIR) $(CARGO) llvm-cov --summary-only --fail-under-lines 80
 
 clean:
 	$(CARGO) clean --target-dir $(TARGET_DIR)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Compatibility:
 
 | WebUI | Herdr | Protocol | Status | Notes |
 | --- | --- | --- | --- | --- |
+| `0.0.47` | `0.7.1` | `14` | Tested | Adds smartphone-friendly Git UI, expands mobile Git test coverage, and enforces Rust line coverage above 80%. |
 | `0.0.46` | `0.7.1` | `14` | Tested | Adds configurable WebUI/Git prefix shortcuts, keeps Git drawer keyboard input isolated, and raises Rust line coverage above 70%. |
 | `0.0.45` | `0.7.1` | `14` | Tested | Improves embedded Git UI navigation with Escape handling, all-changes return behavior, split frontend assets, scoped file history controls, keyboard-owned drawer input, and per-file large diff loading. |
 | `0.0.45` | `0.7.0` | `14` | Minimum supported | Uses WebUI's legacy existing-branch worktree fallback when needed. |

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -48,6 +48,7 @@ const MOBILE_CORE_JS: &str = include_str!("assets/mobile/core.js");
 const MOBILE_SETTINGS_JS: &str = include_str!("assets/mobile/settings.js");
 const MOBILE_TERMINAL_JS: &str = include_str!("assets/mobile/terminal.js");
 const MOBILE_WORKTREES_JS: &str = include_str!("assets/mobile/worktrees.js");
+const MOBILE_GIT_JS: &str = include_str!("assets/mobile/git.js");
 const MOBILE_CSS: &str = include_str!("assets/mobile/app.css");
 const MOBILE_JS: &str = include_str!("assets/mobile/app.js");
 const XTERM_CSS: &str = include_str!("assets/xterm.css");
@@ -136,6 +137,10 @@ pub(crate) async fn mobile_terminal_js() -> Response {
 
 pub(crate) async fn mobile_worktrees_js() -> Response {
     static_text(MOBILE_WORKTREES_JS, "application/javascript; charset=utf-8")
+}
+
+pub(crate) async fn mobile_git_js() -> Response {
+    static_text(MOBILE_GIT_JS, "application/javascript; charset=utf-8")
 }
 
 pub(crate) async fn mobile_css() -> Response {

--- a/src/assets/app_boot.js
+++ b/src/assets/app_boot.js
@@ -52,6 +52,7 @@
       loadScript("/assets/mobile/attention.js");
       loadScript("/assets/mobile/terminal.js");
       loadScript("/assets/mobile/worktrees.js");
+      loadScript("/assets/mobile/git.js");
       loadScript("/assets/mobile/settings.js");
     } else {
       loadScript("/assets/desktop/search.js");

--- a/src/assets/app_boot.test.mjs
+++ b/src/assets/app_boot.test.mjs
@@ -81,8 +81,9 @@ describe("app boot", () => {
     equal(scripts[2].src, "/assets/mobile/attention.js");
     equal(scripts[3].src, "/assets/mobile/terminal.js");
     equal(scripts[4].src, "/assets/mobile/worktrees.js");
-    equal(scripts[5].src, "/assets/mobile/settings.js");
-    equal(scripts[6].src, "/assets/mobile/app.js");
+    equal(scripts[5].src, "/assets/mobile/git.js");
+    equal(scripts[6].src, "/assets/mobile/settings.js");
+    equal(scripts[7].src, "/assets/mobile/app.js");
   });
 
   it("honors explicit desktop override", () => {

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -104,6 +104,7 @@ function context() {
 describe("app bundle load", () => {
   let source;
   let gitUiSource;
+  let gitSettingsSource;
 
   beforeEach(() => {
     const desktopAppSource = [
@@ -124,6 +125,7 @@ describe("app bundle load", () => {
       "\n" +
       desktopAppSource;
     gitUiSource = readFileSync(new URL("./desktop/git_ui.js", import.meta.url), "utf8");
+    gitSettingsSource = readFileSync(new URL("./desktop/git_ui/settings.js", import.meta.url), "utf8");
   });
 
   it("loads without initialization-order ReferenceError", () => {
@@ -140,6 +142,20 @@ describe("app bundle load", () => {
     match(gitUiSource, /Large diffs are not rendered by default\./);
     match(gitUiSource, /loadLargeDiff\(file\)/);
     ok(!gitUiSource.includes("Select a file from left list to render its changes."));
+  });
+
+  it("defines side-by-side and unified Git diff layouts", () => {
+    match(gitSettingsSource, /id=\"optGitUiDiffLayout\"/);
+    match(gitSettingsSource, /Unified \(GitHub-style\)/);
+    match(gitSettingsSource, /gitUiDiffLayout: "side-by-side"/);
+    match(gitUiSource, /function diffLayoutMode\(\)/);
+    match(gitUiSource, /function renderUnifiedLine\(/);
+    match(gitUiSource, /git-ui-unified-row/);
+    match(gitUiSource, /sideBySideRows\(chunk\)/);
+    match(gitUiSource, /renderUnifiedLine\(row, path, index, rows, rowIndex, contextArrows\)/);
+    match(gitUiSource, /restoreHunk\('\$\{arg\(path\)\}',\$\{hunkIndex\}\)/);
+    match(gitUiSource, /function contextArrowsForChunk\(chunks, index\)/);
+    match(gitUiSource, /const after = next \? hiddenGap\(chunk, next\) : false;/);
   });
 
   it("defines Git UI changes-list Escape navigation", () => {
@@ -224,6 +240,9 @@ describe("app bundle load", () => {
     match(source, /title: "Agents and alerts"/);
     match(source, /title: "Worktrees"/);
     match(source, /title: "Server"/);
+    match(source, /id="settingsSearch"/);
+    match(source, /function bindSettingsSearch\(\)/);
+    match(source, /No settings found\./);
   });
 
   it("defines keyboard shortcuts and terminal font settings", () => {

--- a/src/assets/desktop/app_css/chrome.css
+++ b/src/assets/desktop/app_css/chrome.css
@@ -177,19 +177,28 @@
   display: grid;
   place-items: center;
 }
-.head #newWs,
-.head #openWorktrees,
 .head .shell-action.active,
 .head .no-sleep-control.active {
   background: var(--accent-1);
   color: var(--accent-fg);
   border: 1px solid var(--accent-1);
 }
+.head #newWs,
+.head #openWorktrees,
 .head .shell-action,
 .head .no-sleep-control {
   background: var(--accent-2);
   color: var(--accent-1);
   border: 1px solid var(--accent-2-border);
+}
+.head #gitWorkspaceToggle.open,
+.head #newWs:active,
+.head #newWs:focus-visible,
+.head #openWorktrees:active,
+.head #openWorktrees:focus-visible {
+  background: var(--accent-1);
+  border-color: var(--accent-1);
+  color: var(--accent-fg);
 }
 .head .shell-action:hover,
 .head .no-sleep-control:hover,

--- a/src/assets/desktop/app_css/controls.css
+++ b/src/assets/desktop/app_css/controls.css
@@ -137,6 +137,12 @@ input[type="checkbox"] {
   color: #a6e3a1;
   border-color: #74c7a3;
 }
+.selected-space-actions .mini.tree:active,
+.selected-space-actions .mini.tree:focus-visible {
+  background: var(--accent-1);
+  color: var(--accent-fg);
+  border-color: var(--accent-1);
+}
 a.item,
 a.item:visited,
 a.item:hover,

--- a/src/assets/desktop/app_css/workspaces.css
+++ b/src/assets/desktop/app_css/workspaces.css
@@ -149,8 +149,36 @@ body.light .chip.label {
   font-size: 16px;
   padding: 5px 9px;
 }
+.settings-search {
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  gap: 6px;
+  padding: 12px 20px;
+}
+.settings-search span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.settings-search input {
+  background: var(--panel2);
+  border: 1px solid var(--border2);
+  border-radius: 10px;
+  color: var(--fg);
+  padding: 9px 11px;
+}
+.settings-search input:focus {
+  border-color: var(--accent-border);
+  outline: none;
+}
 .settings-body {
   padding: 10px 20px 16px;
+}
+.settings-empty {
+  color: var(--muted);
+  padding: 0 20px 16px;
+}
+.settings-filter-hidden {
+  display: none !important;
 }
 .settings-section {
   border: 1px solid var(--border);

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -257,11 +257,15 @@ if (settingsModal && !settingsModal.dataset.ux) {
     head.innerHTML =
       '<div><h2>Settings</h2><p>Browser-local preferences for terminal, theme, and agent behavior.</p></div><button class="mini settings-close" id="settingsCloseTop" title="Close">✕</button>';
     heading.replaceWith(head);
+    const search = document.createElement("label");
+    search.className = "settings-search";
+    search.innerHTML = '<span>Search settings</span><input id="settingsSearch" placeholder="Theme, Git, shortcuts..." autocomplete="off">';
     const body = document.createElement("div");
     body.className = "settings-body";
     [...modal.querySelectorAll("label.option")].forEach((node) =>
       body.appendChild(node),
     );
+    modal.insertBefore(search, modal.querySelector(".modal-actions"));
     modal.insertBefore(body, modal.querySelector(".modal-actions"));
     el("settingsCloseTop").onclick = () => {
       settingsModal.style.display = "none";
@@ -1152,6 +1156,7 @@ if (soundSetting && !el("optAgentSortMode"))
       '<label class="option"><input type="checkbox" id="optGlobalShortcutsEnabled"><span>Global keyboard shortcuts<small>Enable prefix WebUI navigation shortcuts listed under ?.</small></span></label><label class="option"><span>Shortcut prefix<small>Click Record, press desired key combination, then use it before WebUI shortcuts.</small></span><span class="shortcut-capture"><input id="optGlobalShortcutPrefix" readonly><button type="button" class="tab add" id="optGlobalShortcutPrefixCapture">Record</button></span></label><label class="option"><span>Search shortcut<small>Optional direct shortcut. Leave disabled if it conflicts with terminal apps.</small></span><span class="shortcut-capture"><input id="optSearchShortcut" readonly><button type="button" class="tab add" id="optSearchShortcutCapture">Record</button><button type="button" class="tab add" id="optSearchShortcutClear">Clear</button></span></label><label class="option"><span>Terminal font<small>Use installed monospaced font family, including Nerd Fonts used by Neovim.</small></span><input id="optTerminalFontFamily" list="terminalFontPresets" placeholder="&quot;MesloLGS Nerd Font Mono&quot;, monospace"><datalist id="terminalFontPresets"><option value="&quot;MesloLGS Nerd Font Mono&quot;, &quot;MesloLGS NF&quot;, monospace"><option value="&quot;MesloLGS Nerd Font&quot;, &quot;MesloLGS NF&quot;, monospace"><option value="&quot;JetBrainsMono Nerd Font Mono&quot;, &quot;JetBrainsMono Nerd Font&quot;, monospace"><option value="&quot;Hack Nerd Font Mono&quot;, &quot;Hack Nerd Font&quot;, monospace"><option value="&quot;FiraCode Nerd Font Mono&quot;, &quot;FiraCode Nerd Font&quot;, monospace"><option value="&quot;CaskaydiaCove Nerd Font Mono&quot;, &quot;CaskaydiaCove Nerd Font&quot;, monospace"><option value="ui-monospace,SFMono-Regular,Menlo,monospace"></datalist></label><label class="option"><span>Close panel shortcut<small>Stored in browser storage and available after reopening the tab.</small></span><select class="settings-select" id="optCloseShortcut"><option value="off">Disabled</option><option value="altw">Option+W</option><option value="shiftspacew">Shift+Space then W</option></select></label><label class="option"><span>Agent sorting<small>Sort agents by attention priority, or show them in default order.</small></span><select class="settings-select" id="optAgentSortMode"><option value="off">Default order</option><option value="attention">Attention (blocked first)</option><option value="attention_inverted">Attention (working first)</option></select></label><label class="option"><span>Parent workspace close<small>Close panels only (keeps linked worktrees running) or full close with re-open (stops processes, re-opens worktrees with fresh shells).</small></span><select class="settings-select" id="optParentCloseMode"><option value="panels">Close panels only</option><option value="close">Full close + re-open worktrees</option></select></label><label class="option"><input type="checkbox" id="optStuckWorkingEnabled"><span>Ignore stuck working agents<small>Dismiss working agents that appear stuck. Clears automatically on status changes and terminal output.</small></span></label><label class="option"><span>Ignore stuck working for<small>Minutes to keep a local dismissed-working override before showing working again.</small></span><input id="optWorkingDismissMinutes" type="number" min="1" max="1440" step="1"></label><label class="option"><input type="checkbox" id="optShowTabActivity"><span>Show panel last update<small>Display local last-change age on top panel tabs. Updates on refreshes, events, and selected terminal output; no timer polling.</small></span></label><label class="option"><span>Workspace sorting<small>Default tree order, shared drag-and-drop order, or attention state priority.</small></span><select class="settings-select" id="optWorkspaceSort"><option value="default">Default</option><option value="drag">Drag&drop</option><option value="state">State</option></select></label><label class="option"><span>Notification scope<small>Choose whether sounds ring in every open tab or only the tab viewing the agent panel.</small></span><select class="settings-select" id="optSoundScope"><option value="current">Current agent tab</option><option value="all">All tabs</option></select></label><label class="option"><input type="checkbox" id="optGenerateWorktreeNames"><span>Generate worktree branch names<small>Allow blank Branch name in Worktrees modal. Herdr generates worktree/&lt;name&gt;.</small></span></label><label class="option"><span>Default worktree directory<small>Relative paths resolve from repo root. Example: ../worktrees.</small></span><input id="optWorktreeDefaultDirectory" placeholder="../worktrees"></label><label class="option"><span>Scroll speed<small><span id="scrollLinesValue">3</span> terminal lines per wheel step.</small></span><input type="range" id="optScrollLines" min="1" max="20" step="1"></label><label class="option"><span>Worktree autodiscover<small>Seconds to wait after path input stops. Set 0 for immediate.</small></span><input type="number" id="optWorktreeAutoDiscover" min="0" max="30" step="0.5"></label>',
     );
 groupSettingsSections();
+bindSettingsSearch();
 function groupSettingsSections() {
   if (!settingsBody || settingsBody.dataset.sections === "1") return;
   const sectionDefs = [
@@ -1234,6 +1239,36 @@ function groupSettingsSections() {
     settingsBody.appendChild(section);
   }
   settingsBody.dataset.sections = "1";
+}
+function bindSettingsSearch() {
+  const input = el("settingsSearch");
+  if (!input || input.dataset.bound === "1") return;
+  let empty = el("settingsSearchEmpty");
+  if (settingsBody && !empty) {
+    settingsBody.insertAdjacentHTML("afterend", '<div id="settingsSearchEmpty" class="settings-empty" hidden>No settings found.</div>');
+    empty = el("settingsSearchEmpty");
+  }
+  const filter = () => {
+    const query = input.value.trim().toLowerCase();
+    let visibleSections = 0;
+    document.querySelectorAll(".settings-section").forEach((section) => {
+      const head = section.querySelector(".settings-section-head");
+      const headMatch = !!query && !!head && head.textContent.toLowerCase().includes(query);
+      let visibleRows = 0;
+      section.querySelectorAll(":scope > .option, :scope > .theme-customizer, :scope > .server-settings").forEach((row) => {
+        const match = !query || headMatch || row.textContent.toLowerCase().includes(query);
+        row.classList.toggle("settings-filter-hidden", !match);
+        if (match) visibleRows++;
+      });
+      const hideSection = !!query && !headMatch && !visibleRows;
+      section.classList.toggle("settings-filter-hidden", hideSection);
+      if (!hideSection) visibleSections++;
+    });
+    if (empty) empty.hidden = !query || visibleSections > 0;
+  };
+  input.dataset.bound = "1";
+  input.addEventListener("input", filter);
+  filter();
 }
 function applyOptions() {
   const shell = el("terminalShell");

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -208,6 +208,10 @@
     return gitUiOptions().gitUiFileListMode === "flat" ? "flat" : "tree";
   }
 
+  function diffLayoutMode() {
+    return gitUiOptions().gitUiDiffLayout === "unified" ? "unified" : "side-by-side";
+  }
+
   function diffLineCount(files) {
     return (files || []).reduce((total, file) => total + (file.chunks || []).reduce((sum, chunk) => sum + ((chunk.lines || []).length), 0), 0);
   }
@@ -648,7 +652,7 @@
     const left = mode === "changes" ? "previous" : (view.compareBase || "base");
     const right = mode === "readonly-compare" ? (view.compareTarget || "target") : "current";
     if (view.showBlame && (!large || loadedLarge)) ensureBlame(file.path);
-    const restore = mode === "changes" && (view.diffScope || "all") !== "staged"
+    const restore = mode === "changes"
       ? `<button class="git-ui-btn danger" title="Restore complete file" onclick="HerdrGitUi.discardFile('${arg(file.path)}')">Restore file</button>`
       : "";
     const body = collapsed ? "" : large && !loadedLarge ? renderLargeDiffPlaceholder(file) : (file.chunks || []).map((chunk, index) => renderChunk(file, chunk, index)).join("");
@@ -719,8 +723,37 @@
     const actions = canMutateDiff()
       ? `<span class="git-ui-hunk-actions">${hunkButton}</span>`
       : `<span class="git-ui-muted">read only</span>`;
-    const rows = markChangeGroups(sideBySideRows(chunk));
-    return `<div class="git-ui-hunk"><div class="git-ui-hunk-head"><span>${esc(chunk.header)}</span>${actions}</div>${rows.map((row, rowIndex) => renderLine(row, path, index, rows, rowIndex)).join("")}</div>`;
+    const rows = markChangeGroups(diffLayoutMode() === "unified" ? unifiedRows(chunk) : sideBySideRows(chunk));
+    const contextArrows = contextArrowsForChunk(file.chunks || [], index);
+    const body = diffLayoutMode() === "unified"
+      ? rows.map((row, rowIndex) => renderUnifiedLine(row, path, index, rows, rowIndex, contextArrows)).join("")
+      : rows.map((row, rowIndex) => renderLine(row, path, index, rows, rowIndex, contextArrows)).join("");
+    return `<div class="git-ui-hunk ${diffLayoutMode() === "unified" ? "git-ui-hunk-unified" : ""}"><div class="git-ui-hunk-head"><span>${esc(chunk.header)}</span>${actions}</div>${body}</div>`;
+  }
+
+  function contextArrowsForChunk(chunks, index) {
+    const chunk = chunks[index] || {};
+    const prev = chunks[index - 1] || null;
+    const next = chunks[index + 1] || null;
+    const before = prev
+      ? hiddenGap(prev, chunk)
+      : (chunk.old_start || 0) > 1 || (chunk.new_start || 0) > 1;
+    const after = next ? hiddenGap(chunk, next) : false;
+    return { before, after };
+  }
+
+  function hiddenGap(left, right) {
+    return ((right.old_start || 0) - hunkEnd(left, "old")) > 1 || ((right.new_start || 0) - hunkEnd(left, "new")) > 1;
+  }
+
+  function hunkEnd(chunk, side) {
+    const start = side === "old" ? chunk.old_start : chunk.new_start;
+    const count = side === "old" ? chunk.old_lines : chunk.new_lines;
+    return (start || 0) + Math.max(0, (count || 0) - 1);
+  }
+
+  function unifiedRows(chunk) {
+    return (chunk.lines || []).map((line) => ({ line }));
   }
 
   function sideBySideRows(chunk) {
@@ -745,7 +778,7 @@
     return rows;
   }
 
-  function renderLine(row, path, hunkIndex, rows, rowIndex) {
+  function renderLine(row, path, hunkIndex, rows, rowIndex, contextArrows) {
     const view = active() || {};
     const scope = view.diffScope || "all";
     const oldLine = row.oldLine;
@@ -760,18 +793,44 @@
     const oldAuthor = blameName(path, oldNo);
     const newAuthor = blameName(path, newNo);
     const status = view.status || {};
-    const hasWorkingPath = scope === "working" || (scope === "all" && ([...(status.unstaged || []), ...(status.untracked || [])].includes(path)));
-    const blockButton = currentMode() === "changes" && hasWorkingPath && (add || del) && isFirstChange(rows, rowIndex)
+    const canRestorePath = scope === "staged" || scope === "working" || (scope === "all" && ([...(status.staged || []), ...(status.unstaged || []), ...(status.untracked || [])].includes(path)));
+    const blockButton = currentMode() === "changes" && canRestorePath && (add || del) && isFirstChange(rows, rowIndex)
       ? `<button class="git-ui-line-action" title="Restore this block" onclick="HerdrGitUi.restoreHunk('${arg(path)}',${hunkIndex})">&gt;&gt;</button>`
       : `<span class="git-ui-line-action-spacer"></span>`;
-    const contextControls = rowIndex === 0
+    const contextControls = rowIndex === 0 && contextArrows.before
       ? `<button class="git-ui-context-arrow" title="Expand lines before; hunks merge when context overlaps" onclick="HerdrGitUi.expandContext()">↑</button>`
-      : rowIndex === rows.length - 1
+      : rowIndex === rows.length - 1 && contextArrows.after
         ? `<button class="git-ui-context-arrow" title="Expand lines after; hunks merge when context overlaps" onclick="HerdrGitUi.expandContext()">↓</button>`
         : "";
     const oldCode = oldLine ? renderDiffCode(oldLine, newLine, path, "old") : "";
     const newCode = newLine ? renderDiffCode(oldLine, newLine, path, "new") : "";
     return `<div class="git-ui-diff-row ${cls}"><div class="git-ui-context-cell">${contextControls}</div><div class="git-ui-code git-ui-code-old">${oldCode}</div><div class="git-ui-line-pair"><span class="git-ui-line-old"><em>${esc(oldAuthor)}</em>${oldNo}</span>${blockButton}<span class="git-ui-line-new"><em>${esc(newAuthor)}</em>${newNo}</span></div><div class="git-ui-code git-ui-code-new">${newCode}</div></div>`;
+  }
+
+  function renderUnifiedLine(row, path, hunkIndex, rows, rowIndex, contextArrows) {
+    const view = active() || {};
+    const scope = view.diffScope || "all";
+    const line = row.line || {};
+    const add = line.line_type === "add";
+    const del = line.line_type === "delete";
+    let cls = add ? "git-ui-add" : del ? "git-ui-del" : "git-ui-context";
+    if (row.groupStart) cls += " git-ui-change-start";
+    if (row.groupEnd) cls += " git-ui-change-end";
+    const oldNo = line.old_line_number || "";
+    const newNo = line.new_line_number || "";
+    const author = blameName(path, newNo || oldNo);
+    const status = view.status || {};
+    const canRestorePath = scope === "staged" || scope === "working" || (scope === "all" && ([...(status.staged || []), ...(status.unstaged || []), ...(status.untracked || [])].includes(path)));
+    const blockButton = currentMode() === "changes" && canRestorePath && (add || del) && isFirstChange(rows, rowIndex)
+      ? `<button class="git-ui-line-action" title="Restore this block" onclick="HerdrGitUi.restoreHunk('${arg(path)}',${hunkIndex})">↩</button>`
+      : `<span class="git-ui-line-action-spacer"></span>`;
+    const contextControls = rowIndex === 0 && contextArrows.before
+      ? `<button class="git-ui-context-arrow" title="Expand lines before; hunks merge when context overlaps" onclick="HerdrGitUi.expandContext()">↑</button>`
+      : rowIndex === rows.length - 1 && contextArrows.after
+        ? `<button class="git-ui-context-arrow" title="Expand lines after; hunks merge when context overlaps" onclick="HerdrGitUi.expandContext()">↓</button>`
+        : "";
+    const sign = add ? "+" : del ? "-" : " ";
+    return `<div class="git-ui-unified-row ${cls}"><div class="git-ui-context-cell">${contextControls}</div><div class="git-ui-unified-lines"><span>${oldNo}</span><span>${newNo}</span></div><div class="git-ui-unified-action">${blockButton}</div><div class="git-ui-code git-ui-code-unified"><span class="git-ui-unified-author">${esc(author)}</span><span class="git-ui-unified-sign">${sign}</span><span class="git-ui-unified-text">${highlight(line.content || "", path)}</span></div></div>`;
   }
 
   function renderDiffCode(oldLine, newLine, path, side) {
@@ -810,7 +869,7 @@
   }
 
   function isChangedRow(row) {
-    return !!(row && ((row.oldLine && row.oldLine.line_type === "delete") || (row.newLine && row.newLine.line_type === "add")));
+    return !!(row && ((row.oldLine && row.oldLine.line_type === "delete") || (row.newLine && row.newLine.line_type === "add") || (row.line && (row.line.line_type === "add" || row.line.line_type === "delete"))));
   }
 
   function isFirstChange(rows, rowIndex) {
@@ -1140,8 +1199,13 @@
     stageFile(path) { post("/api/git-ui/stage", { cwd: active().cwd, paths: [decodeURIComponent(path)] }); },
     unstageFile(path) { post("/api/git-ui/unstage", { cwd: active().cwd, paths: [decodeURIComponent(path)] }); },
     restoreFile(path) { if (confirm("Restore this file change?")) post("/api/git-ui/discard", { cwd: active().cwd, paths: [decodeURIComponent(path)], confirmed: true }); },
-    restoreHunk(path, index) { path = decodeURIComponent(path); if (confirm("Restore this hunk?")) applyHunk(path, index, { reverse: true }); },
-    discardFile(path) { path = decodeURIComponent(path); if (confirm(`Restore complete file ${path}?`)) post("/api/git-ui/discard", { cwd: active().cwd, paths: [path], confirmed: true }); },
+    restoreHunk(path, index) {
+      path = decodeURIComponent(path);
+      const view = active() || {};
+      const staged = (view.diffScope || "all") === "staged";
+      if (confirm(staged ? "Restore this staged hunk? This discards it from the index." : "Restore this hunk?")) applyHunk(path, index, staged ? { reverse: true, cached: true } : { reverse: true });
+    },
+    discardFile(path) { path = decodeURIComponent(path); if (confirm(`Restore complete file ${path}? This discards staged and unstaged changes.`)) post("/api/git-ui/discard", { cwd: active().cwd, paths: [path], confirmed: true }); },
     toggleBlame() { const view = active(); if (!view) return; view.showBlame = !view.showBlame; render(); },
     async editSideBySide() {
       const view = active();

--- a/src/assets/desktop/git_ui/diff.css
+++ b/src/assets/desktop/git_ui/diff.css
@@ -272,6 +272,13 @@
   font-size: 12px;
   line-height: 1.45;
 }
+.git-ui-unified-row {
+  display: grid;
+  grid-template-columns: 26px 74px 34px minmax(0, 1fr);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.45;
+}
 .git-ui-context-cell {
   background: var(--panel);
   border-right: 1px solid var(--border);
@@ -306,6 +313,25 @@
   padding: 1px 8px;
   text-align: right;
   user-select: none;
+}
+.git-ui-unified-lines {
+  background: var(--panel);
+  border-left: 1px solid var(--border);
+  color: var(--muted);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 1px 8px;
+  text-align: right;
+  user-select: none;
+}
+.git-ui-unified-action {
+  align-items: center;
+  background: var(--panel);
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  display: flex;
+  justify-content: center;
 }
 .git-ui-line-pair em {
   display: block;
@@ -357,14 +383,44 @@
   padding: 1px 8px;
   white-space: pre;
 }
+.git-ui-code-unified {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  gap: 0;
+}
+.git-ui-unified-author {
+  color: var(--muted);
+  display: inline-block;
+  max-width: 110px;
+  overflow: hidden;
+  padding-right: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.git-ui-unified-sign {
+  display: inline-block;
+  padding-right: 8px;
+  user-select: none;
+}
+.git-ui-unified-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .git-ui-change-start .git-ui-code-old,
 .git-ui-change-start .git-ui-code-new,
-.git-ui-change-start .git-ui-line-pair {
+.git-ui-change-start .git-ui-line-pair,
+.git-ui-change-start .git-ui-code-unified,
+.git-ui-change-start .git-ui-unified-lines,
+.git-ui-change-start .git-ui-unified-action {
   border-top: 1px solid var(--border2);
 }
 .git-ui-change-end .git-ui-code-old,
 .git-ui-change-end .git-ui-code-new,
-.git-ui-change-end .git-ui-line-pair {
+.git-ui-change-end .git-ui-line-pair,
+.git-ui-change-end .git-ui-code-unified,
+.git-ui-change-end .git-ui-unified-lines,
+.git-ui-change-end .git-ui-unified-action {
   border-bottom: 1px solid var(--border2);
 }
 .git-ui-add .git-ui-code-new,
@@ -376,6 +432,20 @@
 .git-ui-change .git-ui-code-old {
   background: rgba(248, 81, 73, 0.18);
   border-left: 4px solid #da3633;
+}
+.git-ui-add .git-ui-code-unified {
+  background: rgba(46, 160, 67, 0.18);
+}
+.git-ui-del .git-ui-code-unified {
+  background: rgba(248, 81, 73, 0.18);
+}
+.git-ui-add .git-ui-unified-lines,
+.git-ui-add .git-ui-unified-action {
+  background: rgba(46, 160, 67, 0.1);
+}
+.git-ui-del .git-ui-unified-lines,
+.git-ui-del .git-ui-unified-action {
+  background: rgba(248, 81, 73, 0.1);
 }
 .git-ui-add .git-ui-word-change,
 .git-ui-change .git-ui-code-new .git-ui-word-change {

--- a/src/assets/desktop/git_ui/settings.js
+++ b/src/assets/desktop/git_ui/settings.js
@@ -4,12 +4,13 @@
     id: "gitUi",
     title: "Git UI",
     desc: "Enable the embedded Git drawer and tune file/diff rendering.",
-    defaults: { gitUiEnabled: true, gitUiLargeDiffLineLimit: 2000, gitUiFileListMode: "tree" },
-    html: '<label class="option"><input type="checkbox" id="optGitUiEnabled"><span>Enable Git UI<small>Show embedded Git controls for workspace/worktree checkouts.</small></span></label><label class="option"><span>Git file list<small>Tree groups files by folders. Filename mode shows only the basename and keeps the full path in the hover tooltip.</small></span><select class="settings-select" id="optGitUiFileListMode"><option value="tree">File tree</option><option value="flat">Filename only</option></select></label><label class="option"><span>Git large diff line limit<small>Hide full diff rendering above this many changed/context lines. Select a file to render it. Set 0 to always render.</small></span><input id="optGitUiLargeDiffLineLimit" type="number" min="0" max="200000" step="100"></label>',
-    ids: ["optGitUiEnabled", "optGitUiFileListMode", "optGitUiLargeDiffLineLimit"],
+    defaults: { gitUiEnabled: true, gitUiLargeDiffLineLimit: 2000, gitUiFileListMode: "tree", gitUiDiffLayout: "side-by-side" },
+    html: '<label class="option"><input type="checkbox" id="optGitUiEnabled"><span>Enable Git UI<small>Show embedded Git controls for workspace/worktree checkouts.</small></span></label><label class="option"><span>Git file list<small>Tree groups files by folders. Filename mode shows only the basename and keeps the full path in the hover tooltip.</small></span><select class="settings-select" id="optGitUiFileListMode"><option value="tree">File tree</option><option value="flat">Filename only</option></select></label><label class="option"><span>Git diff layout<small>Side-by-side is desktop default. Unified matches GitHub-style diffs. Mobile always uses unified.</small></span><select class="settings-select" id="optGitUiDiffLayout"><option value="side-by-side">Side-by-side</option><option value="unified">Unified (GitHub-style)</option></select></label><label class="option"><span>Git large diff line limit<small>Hide full diff rendering above this many changed/context lines. Select a file to render it. Set 0 to always render.</small></span><input id="optGitUiLargeDiffLineLimit" type="number" min="0" max="200000" step="100"></label>',
+    ids: ["optGitUiEnabled", "optGitUiFileListMode", "optGitUiDiffLayout", "optGitUiLargeDiffLineLimit"],
     normalize(options) {
       options.gitUiEnabled = options.gitUiEnabled !== false;
       options.gitUiFileListMode = options.gitUiFileListMode === "flat" ? "flat" : "tree";
+      options.gitUiDiffLayout = options.gitUiDiffLayout === "unified" ? "unified" : "side-by-side";
       const limit = Number(options.gitUiLargeDiffLineLimit);
       options.gitUiLargeDiffLineLimit = Number.isFinite(limit) ? Math.max(0, Math.min(200000, limit)) : 2000;
     },
@@ -20,6 +21,8 @@
       if (input) input.value = String(options.gitUiLargeDiffLineLimit ?? 2000);
       const fileListMode = document.getElementById("optGitUiFileListMode");
       if (fileListMode) fileListMode.value = options.gitUiFileListMode === "flat" ? "flat" : "tree";
+      const diffLayout = document.getElementById("optGitUiDiffLayout");
+      if (diffLayout) diffLayout.value = options.gitUiDiffLayout === "unified" ? "unified" : "side-by-side";
     },
     bind(ctx) {
       const enabled = document.getElementById("optGitUiEnabled");
@@ -36,6 +39,16 @@
         fileListMode.dataset.bound = "1";
         fileListMode.onchange = () => {
           ctx.setOption("gitUiFileListMode", fileListMode.value === "flat" ? "flat" : "tree");
+          ctx.saveOptions();
+          ctx.applyOptions();
+          if (window.HerdrGitUi && window.HerdrGitUi.refreshVisible) window.HerdrGitUi.refreshVisible();
+        };
+      }
+      const diffLayout = document.getElementById("optGitUiDiffLayout");
+      if (diffLayout && diffLayout.dataset.bound !== "1") {
+        diffLayout.dataset.bound = "1";
+        diffLayout.onchange = () => {
+          ctx.setOption("gitUiDiffLayout", diffLayout.value === "unified" ? "unified" : "side-by-side");
           ctx.saveOptions();
           ctx.applyOptions();
           if (window.HerdrGitUi && window.HerdrGitUi.refreshVisible) window.HerdrGitUi.refreshVisible();

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -79,6 +79,11 @@ body.light {
   border-color: var(--accent);
   color: var(--accent-fg);
 }
+.mobile-btn.active {
+  border-color: var(--accent);
+  color: var(--fg);
+  background: color-mix(in srgb, var(--accent), transparent 78%);
+}
 .mobile-screen {
   min-height: 0;
   overflow: auto;
@@ -201,7 +206,7 @@ body.light {
 }
 .mobile-nav {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: 6px;
   padding: 8px max(8px, env(safe-area-inset-right))
     max(8px, env(safe-area-inset-bottom)) max(8px, env(safe-area-inset-left));
@@ -214,6 +219,7 @@ body.light {
   border-radius: 12px;
   background: transparent;
   color: var(--muted);
+  font-size: 11px;
   font-weight: 700;
 }
 .mobile-nav button.active {
@@ -272,7 +278,8 @@ body.light {
   color: var(--muted);
 }
 .mobile-form input,
-.mobile-form select {
+.mobile-form select,
+.mobile-form textarea {
   min-height: 44px;
   width: 100%;
   border: 1px solid var(--border2);
@@ -280,6 +287,10 @@ body.light {
   background: var(--panel2);
   color: var(--fg);
   padding: 9px 11px;
+}
+.mobile-form textarea {
+  min-height: 120px;
+  resize: vertical;
 }
 .mobile-wide {
   width: 100%;
@@ -326,6 +337,196 @@ body.light {
 .mobile-worktree-row small {
   color: var(--muted);
   margin-top: 4px;
+}
+.mobile-git {
+  display: grid;
+  gap: 12px;
+}
+.mobile-git-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--panel);
+}
+.mobile-git-summary h2 {
+  margin: 0 0 4px;
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.mobile-git-summary strong,
+.mobile-git-summary span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mobile-git-summary span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.mobile-git-tabs,
+.mobile-git-actions {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+.mobile-git-actions {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 8px 0;
+  background: var(--bg);
+}
+.mobile-git-actions .mobile-btn {
+  flex: 0 0 auto;
+}
+.mobile-btn.danger,
+.mobile-git button.danger {
+  border-color: #f38ba8;
+  color: #f38ba8;
+}
+.mobile-git-section {
+  display: grid;
+  gap: 8px;
+}
+.mobile-git-section h3,
+.mobile-git-form h3 {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.mobile-git-section h3 span {
+  color: var(--fg);
+}
+.mobile-git-file-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--panel);
+}
+.mobile-git-file-head div {
+  min-width: 0;
+}
+.mobile-git-file-head strong,
+.mobile-git-file-head span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mobile-git-file-head span {
+  color: var(--muted);
+  font-size: 12px;
+}
+.mobile-diff {
+  display: grid;
+  gap: 12px;
+}
+.mobile-hunk {
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--panel);
+  overflow: hidden;
+}
+.mobile-hunk header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 12px;
+}
+.mobile-hunk header span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mobile-hunk header button,
+.mobile-git-conflict button,
+.mobile-git-stash button {
+  min-height: 34px;
+  border: 1px solid var(--border2);
+  border-radius: 10px;
+  background: var(--panel2);
+  color: var(--fg);
+}
+.mobile-hunk pre {
+  margin: 0;
+  padding: 10px;
+  overflow-x: auto;
+  font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.mobile-hunk pre span {
+  display: block;
+  min-width: max-content;
+  white-space: pre;
+}
+.mobile-hunk pre .add {
+  color: #a6e3a1;
+  background: color-mix(in srgb, #a6e3a1, transparent 88%);
+}
+.mobile-hunk pre .delete {
+  color: #f38ba8;
+  background: color-mix(in srgb, #f38ba8, transparent 88%);
+}
+.mobile-git-conflict,
+.mobile-git-stash {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) repeat(3, auto);
+  gap: 8px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--panel);
+}
+.mobile-git-stash span {
+  color: var(--muted);
+  font-size: 12px;
+  grid-column: 1 / -1;
+}
+.mobile-blame {
+  display: grid;
+  gap: 1px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--border);
+}
+.mobile-blame div {
+  display: grid;
+  grid-template-columns: 56px minmax(160px, 1fr);
+  gap: 10px;
+  min-width: max-content;
+  padding: 8px 10px;
+  background: var(--panel);
+  font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.mobile-blame span {
+  color: var(--muted);
+  text-align: right;
+}
+.mobile-git-editor textarea {
+  min-height: 50dvh;
+  white-space: pre;
+  overflow: auto;
+  font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 @media (min-width: 600px) and (max-width: 900px) {
   .mobile-app {

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -38,7 +38,8 @@
     mobileAttention,
     mobileSettings,
     mobileTerminal,
-    mobileWorktrees;
+    mobileWorktrees,
+    mobileGit;
 
   function el(id) {
     return document.getElementById(id);
@@ -266,7 +267,7 @@
     else if (state.screen === "panels") screen.innerHTML = renderPanels();
     else if (state.screen === "worktrees")
       screen.innerHTML = mobileWorktrees.renderScreen();
-    else if (state.screen === "git") renderGitScreen(screen);
+    else if (state.screen === "git") screen.innerHTML = mobileGit.renderScreen();
     else if (state.screen === "settings")
       screen.innerHTML = mobileSettings.render();
     else if (state.screen === "terminal") renderTerminalScreen(screen);
@@ -401,28 +402,7 @@
   }
 
   function renderGitScreen(screen) {
-    const status = state.gitStatus;
-    if (state.gitError) {
-      screen.innerHTML = `<section class="mobile-section"><h2>Git</h2><div class="mobile-error">${escapeHtml(state.gitError)}</div><button class="mobile-btn primary mobile-wide" onclick="HerdrMobile.loadGitStatus()">Retry</button></section>`;
-      return;
-    }
-    if (!status) {
-      screen.innerHTML = `<section class="mobile-section"><h2>Git</h2><div class="mobile-loading">Loading Git status</div></section>`;
-      loadGitStatus();
-      return;
-    }
-    const rows = [
-      ["Conflicts", status.conflicted || []],
-      ["Staged", status.staged || []],
-      ["Unstaged", status.unstaged || []],
-      ["Untracked", status.untracked || []],
-    ]
-      .map(
-        ([title, files]) =>
-          `<h3>${escapeHtml(title)}</h3>${files.length ? files.map((file) => `<div class="mobile-row"><strong>${escapeHtml(file)}</strong></div>`).join("") : '<div class="mobile-loading">None</div>'}`,
-      )
-      .join("");
-    screen.innerHTML = `<section class="mobile-section"><h2>Git</h2><p class="mobile-help">${escapeHtml(status.branch || "detached")} · ${escapeHtml(status.state || "")}</p><button class="mobile-btn primary mobile-wide" onclick="HerdrMobile.loadGitStatus()">Refresh</button>${rows}</section>`;
+    screen.innerHTML = mobileGit.renderScreen();
   }
 
   function renderTerminalTabsWithAdd() {
@@ -511,6 +491,7 @@
     state.screen = "terminal";
     state.gitStatus = null;
     state.gitError = "";
+    if (mobileGit) mobileGit.resetForWorkspace();
     history.pushState(null, "", selectionPath(id));
     mobileTerminal.destroy(true);
     refresh();
@@ -613,13 +594,21 @@
     selectionPath,
     state,
   });
+  mobileGit = globalThis.HerdrMobileGit.create({
+    api,
+    currentWorkspaceCwd,
+    escapeHtml,
+    jsArg,
+    render,
+  });
+  globalThis.HerdrMobileGit = mobileGit;
 
   globalThis.HerdrMobile = {
     selectWorkspace,
     selectAgent,
     selectTab,
     createPanel,
-    loadGitStatus,
+    loadGitStatus: mobileGit.refresh,
     loadWorktrees: mobileWorktrees.load,
     openWorktree: mobileWorktrees.open,
     createWorktree: mobileWorktrees.create,

--- a/src/assets/mobile/git.js
+++ b/src/assets/mobile/git.js
@@ -1,0 +1,400 @@
+(function () {
+  function createMobileGit(deps) {
+    const { api, currentWorkspaceCwd, escapeHtml, jsArg, render } = deps;
+    const state = {
+      status: null,
+      diff: null,
+      branches: null,
+      log: null,
+      stashes: null,
+      file: "",
+      kind: "",
+      scope: "all",
+      tab: "changes",
+      loading: false,
+      error: "",
+      selectedLogCommits: [],
+      compareBase: "",
+      compareTarget: "",
+      commitTitle: "",
+      commitBody: "",
+      showActions: "",
+      cwd: "",
+      fileMode: "diff",
+      history: null,
+      blame: {},
+      editor: null,
+    };
+
+    function cwd() {
+      return currentWorkspaceCwd() || "";
+    }
+
+    function resetForCwd(nextCwd) {
+      if (state.cwd === nextCwd) return;
+      state.cwd = nextCwd;
+      state.status = null;
+      state.diff = null;
+      state.branches = null;
+      state.log = null;
+      state.stashes = null;
+      state.file = "";
+      state.kind = "";
+      state.scope = "all";
+      state.error = "";
+      state.selectedLogCommits = [];
+      state.compareBase = "";
+      state.compareTarget = "";
+      state.fileMode = "diff";
+      state.history = null;
+      state.blame = {};
+      state.editor = null;
+    }
+
+    function query(path, params) {
+      const search = new URLSearchParams(Object.assign({ cwd: cwd() }, params || {}));
+      return path + "?" + search.toString();
+    }
+
+    async function refresh() {
+      const currentCwd = cwd();
+      resetForCwd(currentCwd);
+      if (!currentCwd) {
+        state.error = "No checkout path for selected workspace";
+        state.status = null;
+        state.diff = null;
+        render();
+        return;
+      }
+      state.loading = true;
+      state.error = "";
+      render();
+      try {
+        state.status = await api(query("/api/git-ui/status"));
+        await loadDiff();
+        if (state.tab === "log") await loadLog();
+        if (state.tab === "stash") await loadStashes();
+        if (state.tab === "branch") await loadBranches();
+        state.loading = false;
+      } catch (error) {
+        state.error = error.message || String(error);
+        state.loading = false;
+      }
+      render();
+    }
+
+    async function loadDiff() {
+      const params = { context: "3", scope: state.scope || "all" };
+      if (state.file) params.file = state.file;
+      if (state.compareBase || state.compareTarget) {
+        params.base = state.compareBase || "HEAD";
+        params.target = state.compareTarget || ".";
+        state.diff = await api(query("/api/git-ui/compare", params));
+      } else {
+        state.diff = await api(query("/api/git-ui/diff", params));
+      }
+    }
+
+    async function post(path, body) {
+      await api(path, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(Object.assign({ cwd: cwd() }, body || {})),
+      });
+      await refresh();
+    }
+
+    function renderScreen() {
+      resetForCwd(cwd());
+      if (!cwd()) return `<section class="mobile-section"><h2>Git</h2><div class="mobile-loading">Select workspace with checkout path</div></section>`;
+      if (!state.status && !state.loading && !state.error) refresh();
+      if (state.error) return `<section class="mobile-section"><h2>Git</h2><div class="mobile-error">${escapeHtml(state.error)}</div><button class="mobile-btn primary mobile-wide" onclick="HerdrMobileGit.refresh()">Retry</button></section>`;
+      if (state.loading && !state.status) return `<section class="mobile-section"><h2>Git</h2><div class="mobile-loading">Loading Git</div></section>`;
+      return `<section class="mobile-git"><div class="mobile-git-summary">${renderSummary()}</div>${renderTabs()}${renderActiveTab()}</section>`;
+    }
+
+    function renderSummary() {
+      const s = state.status || {};
+      const dirty = countFiles();
+      return `<div><h2>Git</h2><strong>${escapeHtml(s.branch || "detached")}</strong><span>${escapeHtml(s.state || "clean")} · ${dirty} changed</span></div><button class="mobile-btn" onclick="HerdrMobileGit.refresh()">Refresh</button>`;
+    }
+
+    function renderTabs() {
+      return `<div class="mobile-git-tabs">${[
+        ["changes", "Changes"],
+        ["commit", "Commit"],
+        ["log", "Log"],
+        ["stash", "Stash"],
+        ["branch", "Branch"],
+      ].map(([id, label]) => `<button class="mobile-tab${state.tab === id ? " active" : ""}" onclick="HerdrMobileGit.tab('${id}')">${label}</button>`).join("")}</div>`;
+    }
+
+    function renderActiveTab() {
+      if (state.tab === "commit") return renderCommit();
+      if (state.tab === "log") return renderLog();
+      if (state.tab === "stash") return renderStash();
+      if (state.tab === "branch") return renderBranch();
+      return renderChanges();
+    }
+
+    function countFiles() {
+      const s = state.status || {};
+      return [s.conflicted, s.staged, s.unstaged, s.untracked].reduce((sum, files) => sum + ((files || []).length), 0);
+    }
+
+    function renderChanges() {
+      if (state.file) return renderFileDetail();
+      const s = state.status || {};
+      const stageAll = (s.unstaged || []).length + (s.untracked || []).length;
+      const unstageAll = (s.staged || []).length;
+      return `<div class="mobile-git-actions">${stageAll ? `<button class="mobile-btn primary" onclick="HerdrMobileGit.stageAll()">Stage all</button>` : ""}${unstageAll ? `<button class="mobile-btn" onclick="HerdrMobileGit.unstageAll()">Unstage all</button>` : ""}<button class="mobile-btn" onclick="HerdrMobileGit.stashPush()">Stash</button><button class="mobile-btn" onclick="HerdrMobileGit.rebase()">Rebase</button><button class="mobile-btn danger" onclick="HerdrMobileGit.reset()">Reset</button></div>${renderSection("Conflicted", s.conflicted, "U")}${renderSection("Staged", s.staged, "S")}${renderSection("Unstaged", s.unstaged, "M")}${renderSection("Untracked", s.untracked, "?")}`;
+    }
+
+    function renderSection(title, files, kind) {
+      files = files || [];
+      return `<div class="mobile-git-section"><h3>${escapeHtml(title)} <span>${files.length}</span></h3>${files.length ? files.map((file) => renderFileRow(file, kind)).join("") : `<div class="mobile-loading">None</div>`}</div>`;
+    }
+
+    function renderFileRow(file, kind) {
+      return `<button class="mobile-row mobile-git-file" onclick="HerdrMobileGit.selectFile(${jsArg(file)},'${kind}')"><strong>${escapeHtml(pathBase(file))}</strong><span>${escapeHtml(file)}</span></button>`;
+    }
+
+    function renderFileDetail() {
+      const file = currentDiffFile();
+      const actions = state.kind === "S"
+        ? `<button class="mobile-btn" onclick="HerdrMobileGit.unstageFile()">Unstage</button>`
+        : `<button class="mobile-btn primary" onclick="HerdrMobileGit.stageFile()">Stage</button><button class="mobile-btn danger" onclick="HerdrMobileGit.discardFile()">Discard</button>`;
+      return `<div class="mobile-git-file-head"><button class="mobile-btn" onclick="HerdrMobileGit.backToFiles()">Files</button><div><strong>${escapeHtml(state.file)}</strong><span>${file ? `+${file.additions || 0} -${file.deletions || 0}` : "No diff"}</span></div></div><div class="mobile-git-actions"><button class="mobile-btn${state.fileMode === "diff" ? " active" : ""}" onclick="HerdrMobileGit.fileMode('diff')">Diff</button><button class="mobile-btn${state.fileMode === "history" ? " active" : ""}" onclick="HerdrMobileGit.fileMode('history')">History</button><button class="mobile-btn${state.fileMode === "blame" ? " active" : ""}" onclick="HerdrMobileGit.fileMode('blame')">Blame</button><button class="mobile-btn${state.fileMode === "edit" ? " active" : ""}" onclick="HerdrMobileGit.fileMode('edit')">Edit</button>${actions}<button class="mobile-btn" onclick="HerdrMobileGit.stashFile()">Stash file</button></div>${renderFileMode(file)}`;
+    }
+
+    function renderFileMode(file) {
+      if (state.fileMode === "history") return renderFileHistory();
+      if (state.fileMode === "blame") return renderBlame();
+      if (state.fileMode === "edit") return renderEditor();
+      return file ? renderDiffFile(file) : `<div class="mobile-loading">No diff for file</div>`;
+    }
+
+    function renderEditor() {
+      if (!state.editor || state.editor.path !== state.file) loadEditor().then(render).catch(setError);
+      const editor = state.editor;
+      if (!editor || editor.path !== state.file || editor.loading) return `<div class="mobile-loading">Loading editor</div>`;
+      const error = editor.error ? `<div class="mobile-error">${escapeHtml(editor.error)}</div>` : "";
+      return `<div class="mobile-form mobile-git-editor">${error}<p class="mobile-help">Editing working tree file. Save checks file hash to avoid overwriting newer changes.</p><textarea spellcheck="false" oninput="HerdrMobileGit.updateEditor(this.value)">${escapeHtml(editor.content || "")}</textarea><button class="mobile-btn primary mobile-wide" onclick="HerdrMobileGit.saveEditor()">Save file</button></div>`;
+    }
+
+    function renderFileHistory() {
+      if (!state.history || state.history.file !== state.file) loadHistory().then(render).catch(setError);
+      const commits = (state.history && state.history.file === state.file && state.history.commits) || [];
+      return `<div class="mobile-git-list">${commits.map((commit) => `<button class="mobile-row" onclick="HerdrMobileGit.showHistoryCommit(${jsArg(commit.hash)})"><strong>${escapeHtml(commit.hash)} ${escapeHtml(commit.message || "")}</strong><span>${escapeHtml(commit.author || "")} ${escapeHtml(commit.date || "")}</span></button>`).join("") || `<div class="mobile-loading">Loading history</div>`}</div>`;
+    }
+
+    function renderBlame() {
+      const blame = state.blame[state.file];
+      if (blame === undefined) loadBlame().then(render).catch(setError);
+      if (!blame) return `<div class="mobile-loading">Loading blame</div>`;
+      return `<div class="mobile-blame">${Object.keys(blame).map((line) => `<div><span>${escapeHtml(line)}</span><strong>${escapeHtml(blame[line])}</strong></div>`).join("") || `<div class="mobile-loading">No blame data</div>`}</div>`;
+    }
+
+    function renderDiffFile(file) {
+      return `<div class="mobile-diff">${(file.chunks || []).map((chunk, index) => `<article class="mobile-hunk"><header><span>${escapeHtml(chunk.header)}</span>${state.kind === "S" ? `<button onclick="HerdrMobileGit.unstageHunk(${index})">Unstage hunk</button>` : `<button onclick="HerdrMobileGit.stageHunk(${index})">Stage hunk</button>`}</header><pre>${(chunk.lines || []).map(renderDiffLine).join("\n")}</pre></article>`).join("")}</div>`;
+    }
+
+    function renderDiffLine(line) {
+      const prefix = line.line_type === "add" ? "+" : line.line_type === "delete" ? "-" : " ";
+      return `<span class="${line.line_type || "context"}">${escapeHtml(prefix + (line.content || ""))}</span>`;
+    }
+
+    function renderCommit() {
+      const staged = ((state.status || {}).staged || []).length;
+      return `<div class="mobile-form mobile-git-form"><p class="mobile-help">${staged} staged files</p><label><span>Summary</span><input value="${escapeHtml(state.commitTitle)}" oninput="HerdrMobileGit.updateCommit('commitTitle', this.value)" placeholder="Short imperative summary"></label><label><span>Details</span><textarea oninput="HerdrMobileGit.updateCommit('commitBody', this.value)" placeholder="Optional body">${escapeHtml(state.commitBody)}</textarea></label><button class="mobile-btn primary mobile-wide" onclick="HerdrMobileGit.commit(false)">Commit</button><button class="mobile-btn mobile-wide" onclick="HerdrMobileGit.commit(true)">Amend previous</button>${renderConflicts()}</div>`;
+    }
+
+    function renderConflicts() {
+      const files = ((state.status || {}).conflicted || []);
+      if (!files.length) return "";
+      return `<h3>Conflicts</h3>${files.map((file) => `<div class="mobile-git-conflict"><strong>${escapeHtml(file)}</strong><button onclick="HerdrMobileGit.resolve(${jsArg(file)},'ours')">Ours</button><button onclick="HerdrMobileGit.resolve(${jsArg(file)},'theirs')">Theirs</button><button onclick="HerdrMobileGit.resolve(${jsArg(file)},'mark')">Mark</button></div>`).join("")}<div class="mobile-git-actions"><button class="mobile-btn" onclick="HerdrMobileGit.conflictAction('rebase-continue')">Rebase continue</button><button class="mobile-btn danger" onclick="HerdrMobileGit.conflictAction('rebase-abort')">Rebase abort</button><button class="mobile-btn danger" onclick="HerdrMobileGit.conflictAction('merge-abort')">Merge abort</button></div>`;
+    }
+
+    function renderLog() {
+      if (!state.log) loadLog().then(render).catch(setError);
+      const selected = state.selectedLogCommits;
+      const compare = selected.length ? `<div class="mobile-git-actions"><button class="mobile-btn primary" onclick="HerdrMobileGit.compareSelected()">Compare</button><button class="mobile-btn" onclick="HerdrMobileGit.clearLogSelection()">Clear</button></div>` : "";
+      return `${compare}<div class="mobile-git-list">${((state.log && state.log.lines) || []).map(renderLogLine).join("") || `<div class="mobile-loading">Loading log</div>`}</div>`;
+    }
+
+    function renderLogLine(line) {
+      const hash = (String(line).match(/[a-f0-9]{7,}/i) || [""])[0];
+      const selected = state.selectedLogCommits.includes(hash) ? " active" : "";
+      return `<button class="mobile-row${selected}" onclick="HerdrMobileGit.selectLog(${jsArg(hash)})"><strong>${escapeHtml(hash || "graph")}</strong><span>${escapeHtml(String(line).replace(hash, "").trim())}</span></button>`;
+    }
+
+    function renderStash() {
+      if (!state.stashes) loadStashes().then(render).catch(setError);
+      const stashes = (state.stashes && state.stashes.stashes) || [];
+      return `<div class="mobile-git-actions"><button class="mobile-btn primary" onclick="HerdrMobileGit.stashPush()">Stash push</button></div>${stashes.map((stash) => `<div class="mobile-git-stash"><strong>${escapeHtml(stash.name)}</strong><span>${escapeHtml(stash.message || "")}</span><button onclick="HerdrMobileGit.applyStash(${jsArg(stash.name)},false)">Apply</button><button onclick="HerdrMobileGit.applyStash(${jsArg(stash.name)},true)">Pop</button><button class="danger" onclick="HerdrMobileGit.dropStash(${jsArg(stash.name)})">Drop</button></div>`).join("") || `<div class="mobile-loading">No stashes</div>`}`;
+    }
+
+    function renderBranch() {
+      if (!state.branches) loadBranches().then(render).catch(setError);
+      const local = ((state.branches && state.branches.local) || []).map((b) => renderBranchRow(b.name, false, b.current)).join("");
+      const remote = ((state.branches && state.branches.remote) || []).map((b) => renderBranchRow(b.name, true, b.current)).join("");
+      return `<div class="mobile-git-section"><h3>Local</h3>${local || `<div class="mobile-loading">Loading branches</div>`}</div><div class="mobile-git-section"><h3>Remote</h3>${remote || `<div class="mobile-loading">No remote branches</div>`}</div>`;
+    }
+
+    function renderBranchRow(name, remote, current) {
+      return `<button class="mobile-row${current ? " active" : ""}" onclick="HerdrMobileGit.switchBranch(${jsArg(name)},${remote})"><strong>${escapeHtml(name)}</strong><span>${remote ? "remote" : current ? "current" : "local"}</span></button>`;
+    }
+
+    async function loadLog() { state.log = await api(query("/api/git-ui/log", { all: "true" })); }
+    async function loadStashes() { state.stashes = await api(query("/api/git-ui/stashes")); }
+    async function loadBranches() { state.branches = await api(query("/api/git-ui/branches")); }
+    async function loadHistory() {
+      const data = await api(query("/api/git-ui/file-history", { file: state.file }));
+      state.history = Object.assign({ file: state.file }, data);
+    }
+    async function loadBlame() {
+      const data = await api(query("/api/git-ui/blame", { file: state.file }));
+      state.blame[state.file] = parseBlame(data.text || "");
+    }
+    async function loadEditor() {
+      state.editor = { path: state.file, content: "", hash: "", loading: true, error: "" };
+      const data = await api(query("/api/git-ui/file", { file: state.file, ref_name: "working" }));
+      state.editor = { path: state.file, content: data.content || "", hash: data.hash || "", loading: false, error: "" };
+    }
+
+    function parseBlame(text) {
+      const byLine = {};
+      let author = "";
+      let finalLine = 0;
+      for (const line of String(text || "").split("\n")) {
+        const header = line.match(/^[0-9a-f]{40}\s+\d+\s+(\d+)/);
+        if (header) {
+          finalLine = Number(header[1]) || 0;
+          author = "";
+          continue;
+        }
+        if (line.startsWith("author ")) {
+          author = line.slice(7).trim();
+          if (finalLine) byLine[finalLine] = author;
+        }
+      }
+      return byLine;
+    }
+
+    function currentDiffFile() {
+      return ((state.diff && state.diff.files) || []).find((file) => file.path === state.file) || null;
+    }
+
+    function pathBase(path) {
+      const parts = String(path || "").split("/").filter(Boolean);
+      return parts[parts.length - 1] || path;
+    }
+
+    function hunkPatch(index) {
+      const file = currentDiffFile();
+      const chunk = file && file.chunks && file.chunks[index];
+      if (!file || !chunk) return "";
+      const oldPath = file.old_path || file.path;
+      const lines = [`diff --git a/${oldPath} b/${file.path}`, `--- a/${oldPath}`, `+++ b/${file.path}`, chunk.header];
+      for (const line of chunk.lines || []) lines.push((line.line_type === "add" ? "+" : line.line_type === "delete" ? "-" : " ") + (line.content || ""));
+      return lines.join("\n") + "\n";
+    }
+
+    function localNameForRemote(remote) {
+      const parts = String(remote || "").split("/");
+      return parts.length > 1 ? parts.slice(1).join("/") : remote;
+    }
+
+    function setError(error) {
+      state.error = error.message || String(error);
+      render();
+    }
+
+    const apiObject = {
+      refresh,
+      renderScreen,
+      async tab(tab) {
+        state.tab = tab;
+        state.error = "";
+        if (tab === "log" && !state.log) await loadLog().catch(setError);
+        if (tab === "stash" && !state.stashes) await loadStashes().catch(setError);
+        if (tab === "branch" && !state.branches) await loadBranches().catch(setError);
+        render();
+      },
+      selectFile(file, kind) {
+        state.file = file;
+        state.kind = kind;
+        state.fileMode = "diff";
+        state.history = null;
+        state.editor = null;
+        state.scope = kind === "S" ? "staged" : kind === "M" || kind === "?" ? "working" : "all";
+        loadDiff().then(render).catch(setError);
+      },
+      backToFiles() { state.file = ""; state.scope = "all"; state.compareBase = ""; state.compareTarget = ""; loadDiff().then(render).catch(setError); },
+      stageAll() { const s = state.status || {}; post("/api/git-ui/stage", { paths: [...(s.unstaged || []), ...(s.untracked || [])] }); },
+      unstageAll() { post("/api/git-ui/unstage", { paths: (state.status || {}).staged || [] }); },
+      stageFile() { post("/api/git-ui/stage", { paths: [state.file] }); },
+      unstageFile() { post("/api/git-ui/unstage", { paths: [state.file] }); },
+      discardFile() { if (confirm(`Discard ${state.file}?`)) post("/api/git-ui/discard", { paths: [state.file], confirmed: true }); },
+      stashFile() { const message = prompt("Stash message", `herdr-webui stash ${state.file}`); if (message !== null) post("/api/git-ui/stash", { message, paths: [state.file] }); },
+      stashPush() { const message = prompt("Stash message", "herdr-webui stash"); if (message !== null) post("/api/git-ui/stash", { message }); },
+      stageHunk(index) { post("/api/git-ui/apply-patch", { patch: hunkPatch(index), cached: true }); },
+      unstageHunk(index) { post("/api/git-ui/apply-patch", { patch: hunkPatch(index), cached: true, reverse: true }); },
+      updateCommit(field, value) { state[field] = value; },
+      async commit(amend) {
+        await post("/api/git-ui/commit", { title: state.commitTitle, body: state.commitBody, amend });
+        state.commitTitle = "";
+        state.commitBody = "";
+        render();
+      },
+      resolve(path, mode) { post("/api/git-ui/conflict-resolve", { path, mode }); },
+      conflictAction(action) { post("/api/git-ui/conflict-action", { action }); },
+      selectLog(hash) { if (!hash) return; state.selectedLogCommits = state.selectedLogCommits.includes(hash) ? state.selectedLogCommits.filter((item) => item !== hash) : state.selectedLogCommits.concat(hash).slice(-2); render(); },
+      clearLogSelection() { state.selectedLogCommits = []; render(); },
+      compareSelected() { const s = state.selectedLogCommits; state.compareBase = s[0] || "HEAD"; state.compareTarget = s[1] || "."; state.file = ""; state.scope = "all"; state.tab = "changes"; loadDiff().then(render).catch(setError); },
+      fileMode(mode) { state.fileMode = mode; render(); },
+      updateEditor(value) { if (state.editor) state.editor.content = value; },
+      async saveEditor() {
+        if (!state.editor || state.editor.loading) return;
+        try {
+          await api("/api/git-ui/file", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ cwd: cwd(), path: state.file, content: state.editor.content || "", expected_hash: state.editor.hash || "" }),
+          });
+          state.editor = null;
+          state.fileMode = "diff";
+          await refresh();
+        } catch (error) {
+          state.editor.error = error.message || String(error);
+          render();
+        }
+      },
+      showHistoryCommit(hash) { state.compareBase = `${hash}^`; state.compareTarget = hash; state.fileMode = "diff"; state.tab = "changes"; loadDiff().then(render).catch(setError); },
+      applyStash(stash, pop) { post("/api/git-ui/stash-apply", { stash, pop }); },
+      dropStash(stash) { if (confirm(`Drop ${stash}?`)) post("/api/git-ui/stash-drop", { stash, confirmed: true }); },
+      switchBranch(name, remote) { if (remote) post("/api/git-ui/switch", { branch: localNameForRemote(name), create: true, base: name }); else post("/api/git-ui/switch", { branch: name }); state.branches = null; },
+      reset() {
+        const ref = prompt("Reset to ref", "HEAD");
+        if (!ref) return;
+        const mode = prompt("Mode: soft, mixed, hard", "soft");
+        if (!mode) return;
+        const confirmation = mode === "hard" ? prompt('Type "reset hard" to confirm') : "";
+        post("/api/git-ui/reset", { ref_name: ref, mode, confirmation });
+      },
+      rebase() {
+        const upstream = prompt("Rebase commits after ref", "HEAD~1");
+        if (!upstream) return;
+        const onto = prompt("Onto ref. Leave blank for main/master", "");
+        if (onto === null) return;
+        const confirmation = prompt(`Rebase commits after ${upstream} onto ${onto || "main/master"}. Type "rebase selected" to confirm`);
+        if (confirmation === null) return;
+        post("/api/git-ui/rebase", { upstream, onto, confirmation });
+      },
+      resetForWorkspace() { state.status = null; state.diff = null; state.file = ""; state.error = ""; },
+    };
+    return apiObject;
+  }
+
+  globalThis.HerdrMobileGit = { create: createMobileGit };
+})();

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -26,7 +26,7 @@ function context(pathname = "/") {
   const historyCalls = [];
   const terminalStats = { disposed: 0, opened: 0 };
   const requests = [];
-  const navButtons = ["home", "agents", "panels", "worktrees", "terminal"].map(
+  const navButtons = ["home", "agents", "panels", "worktrees", "git", "terminal"].map(
     (screen) => Object.assign(element(), { dataset: { screen } }),
   );
   const getElement = (id) => {
@@ -90,9 +90,49 @@ function context(pathname = "/") {
           status: 200,
           json: async () => ({ result: { tab: { tab_id: "w1:t3" } } }),
         };
+      if (url.includes("/api/git-ui/status"))
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            branch: "feature/mobile",
+            state: "clean",
+            staged: [],
+            unstaged: ["src/mobile.js"],
+            untracked: [],
+            conflicted: [],
+          }),
+        };
+      if (url.includes("/api/git-ui/diff"))
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            files: [
+              {
+                path: "src/mobile.js",
+                additions: 1,
+                deletions: 0,
+                chunks: [
+                  {
+                    header: "@@ -1 +1 @@",
+                    lines: [{ line_type: "add", content: "mobile" }],
+                  },
+                ],
+              },
+            ],
+          }),
+        };
       const result = url.includes("workspaces")
         ? {
-            workspaces: [{ workspace_id: "w1", label: "alpha", pane_count: 1 }],
+            workspaces: [
+              {
+                workspace_id: "w1",
+                label: "alpha",
+                cwd: "/tmp/alpha",
+                pane_count: 1,
+              },
+            ],
           }
         : url.includes("worktrees")
           ? {
@@ -166,6 +206,8 @@ describe("mobile bundle load", () => {
     "\n" +
     readFileSync(new URL("./mobile/worktrees.js", import.meta.url), "utf8") +
     "\n" +
+    readFileSync(new URL("./mobile/git.js", import.meta.url), "utf8") +
+    "\n" +
     readFileSync(new URL("./mobile/settings.js", import.meta.url), "utf8") +
     "\n" +
     readFileSync(new URL("./mobile/app.js", import.meta.url), "utf8");
@@ -195,6 +237,16 @@ describe("mobile bundle load", () => {
     doesNotThrow(() =>
       ctx.HerdrMobile.updateWorktreeField("worktreeBranch", "feature/mobile"),
     );
+  });
+
+  it("renders mobile Git screen from same Git UI API", async () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+    await ctx.HerdrMobile.refresh();
+    doesNotThrow(() => ctx.HerdrMobile.showScreen("git"));
+    equal(typeof ctx.HerdrMobile.loadGitStatus, "function");
+    const html = ctx.document.getElementById("mobileScreen").innerHTML;
+    ok(html.includes("mobile-git") || html.includes("Git"));
   });
 
   it("does not force terminal screen after user selects another mobile tab", async () => {

--- a/src/git_ui.rs
+++ b/src/git_ui.rs
@@ -914,7 +914,7 @@ async fn git_ui_discard(
         let tracked = git_ui_output(&repo, &["ls-files", "--error-unmatch", "--", path])
             .is_ok_and(|output| output.status.success());
         if tracked {
-            if let Err(err) = git_ui_text(&repo, &["restore", "--", path]) {
+            if let Err(err) = git_ui_text(&repo, &["restore", "--staged", "--worktree", "--", path]) {
                 return git_json_error(StatusCode::BAD_GATEWAY, err);
             }
         } else {
@@ -1844,6 +1844,29 @@ mod tests {
             )
             .await;
             assert_eq!(discard.status(), StatusCode::OK);
+            assert_eq!(
+                fs::read_to_string(repo.path.join("tracked.txt")).unwrap(),
+                "one\n"
+            );
+
+            repo.write("tracked.txt", "staged\n");
+            repo.git(&["add", "tracked.txt"]);
+            assert!(repo
+                .git(&["diff", "--cached", "--name-only"])
+                .contains("tracked.txt"));
+            let discard_staged = git_ui_discard(
+                State(state.clone()),
+                HeaderMap::new(),
+                ConnectInfo(remote()),
+                Json(GitUiPathsRequest {
+                    cwd: cwd.clone(),
+                    paths: vec!["tracked.txt".to_string()],
+                    confirmed: Some(true),
+                }),
+            )
+            .await;
+            assert_eq!(discard_staged.status(), StatusCode::OK);
+            assert_eq!(repo.git(&["diff", "--cached", "--name-only"]), "");
             assert_eq!(
                 fs::read_to_string(repo.path.join("tracked.txt")).unwrap(),
                 "one\n"

--- a/src/git_ui.rs
+++ b/src/git_ui.rs
@@ -914,7 +914,8 @@ async fn git_ui_discard(
         let tracked = git_ui_output(&repo, &["ls-files", "--error-unmatch", "--", path])
             .is_ok_and(|output| output.status.success());
         if tracked {
-            if let Err(err) = git_ui_text(&repo, &["restore", "--staged", "--worktree", "--", path]) {
+            if let Err(err) = git_ui_text(&repo, &["restore", "--staged", "--worktree", "--", path])
+            {
                 return git_json_error(StatusCode::BAD_GATEWAY, err);
             }
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,12 @@ const MAX_TESTED_BACKEND_VERSION: &str = "0.7.1";
 
 type LocalStream = interprocess::local_socket::Stream;
 
+#[cfg(test)]
+pub(crate) fn env_test_lock() -> &'static Mutex<()> {
+    static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 fn backend_compatibility_for_supported_range(
     backend: Option<&str>,
     protocol: Option<u32>,
@@ -703,6 +709,7 @@ fn app_router(state: WebState) -> Router {
         .route("/assets/mobile/settings.js", get(mobile_settings_js))
         .route("/assets/mobile/terminal.js", get(mobile_terminal_js))
         .route("/assets/mobile/worktrees.js", get(mobile_worktrees_js))
+        .route("/assets/mobile/git.js", get(mobile_git_js))
         .route("/assets/mobile/app.css", get(mobile_css))
         .route("/assets/mobile/app.js", get(mobile_js))
         .route("/assets/xterm.js", get(xterm_js))
@@ -2460,7 +2467,7 @@ mod tests {
     use axum::http::{Method, Request};
     use serde_json::Value;
     use std::io::Cursor;
-    use std::sync::{Mutex as StdMutex, OnceLock};
+    use std::sync::{Arc as StdArc, Mutex as StdMutex};
     use std::thread;
     use tower::ServiceExt;
 
@@ -2512,8 +2519,7 @@ mod tests {
     }
 
     fn env_lock() -> &'static StdMutex<()> {
-        static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| StdMutex::new(()))
+        crate::env_test_lock()
     }
 
     #[cfg(unix)]
@@ -2548,6 +2554,55 @@ mod tests {
             stream.flush().unwrap();
         });
         (path, handle)
+    }
+
+    #[cfg(unix)]
+    fn fake_api_socket_many(
+        count: usize,
+    ) -> (
+        PathBuf,
+        StdArc<StdMutex<Vec<serde_json::Value>>>,
+        thread::JoinHandle<()>,
+    ) {
+        use interprocess::local_socket::{prelude::*, GenericFilePath, ListenerOptions};
+
+        let path = std::env::temp_dir().join(format!(
+            "herdr-webui-api-many-test-{}.sock",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = fs::remove_file(&path);
+        let name = path.clone().to_fs_name::<GenericFilePath>().unwrap();
+        let listener = ListenerOptions::new()
+            .name(name)
+            .try_overwrite(true)
+            .create_sync()
+            .unwrap();
+        let requests = StdArc::new(StdMutex::new(Vec::new()));
+        let requests_for_thread = requests.clone();
+        let handle = thread::spawn(move || {
+            for index in 0..count {
+                let mut stream = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                let request: serde_json::Value = serde_json::from_str(&line).unwrap();
+                requests_for_thread.lock().unwrap().push(request.clone());
+                let response = json!({
+                    "ok": true,
+                    "index": index,
+                    "result": { "method": request["method"].clone(), "params": request["params"].clone() }
+                });
+                stream
+                    .write_all(serde_json::to_string(&response).unwrap().as_bytes())
+                    .unwrap();
+                stream.write_all(b"\n").unwrap();
+                stream.flush().unwrap();
+            }
+        });
+        (path, requests, handle)
     }
 
     #[test]
@@ -3526,6 +3581,205 @@ mod tests {
 
         assert_eq!(response_json(work).await["order"], json!(["w2", "w1"]));
         assert_eq!(response_json(default).await["order"], json!([]));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn proxy_routes_forward_expected_herdr_requests() {
+        let tmp = std::env::temp_dir().join(format!(
+            "herdr-webui-route-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp).unwrap();
+        let (socket, captured, handle) = fake_api_socket_many(18);
+        let mut state = test_state();
+        state.api_socket = Some(socket.clone());
+        let app = test_app_with_state(state);
+        let routes = vec![
+            (Method::GET, "/api/workspaces", None, "workspace.list"),
+            (
+                Method::POST,
+                "/api/workspaces",
+                Some(json!({ "cwd": tmp.to_string_lossy(), "label": "tmp" })),
+                "workspace.create",
+            ),
+            (
+                Method::POST,
+                "/api/workspaces/w1/rename",
+                Some(json!({ "label": "renamed" })),
+                "workspace.rename",
+            ),
+            (
+                Method::POST,
+                "/api/workspaces/w1/close",
+                None,
+                "workspace.close",
+            ),
+            (Method::GET, "/api/tabs?workspace_id=w1", None, "tab.list"),
+            (
+                Method::POST,
+                "/api/tabs",
+                Some(json!({ "workspace_id": "w1", "label": "panel" })),
+                "tab.create",
+            ),
+            (
+                Method::POST,
+                "/api/tabs/t1/rename",
+                Some(json!({ "label": "shell" })),
+                "tab.rename",
+            ),
+            (Method::POST, "/api/tabs/t1/close", None, "tab.close"),
+            (Method::GET, "/api/panes?workspace_id=w1", None, "pane.list"),
+            (Method::POST, "/api/panes/p1/close", None, "pane.close"),
+            (
+                Method::GET,
+                "/api/pane-layout?pane_id=p1",
+                None,
+                "pane.layout",
+            ),
+            (Method::GET, "/api/agents", None, "agent.list"),
+            (
+                Method::GET,
+                "/api/worktrees?workspace_id=w1",
+                None,
+                "worktree.list",
+            ),
+            (
+                Method::POST,
+                "/api/worktrees",
+                Some(
+                    json!({ "workspace_id": "w1", "cwd": tmp.to_string_lossy(), "branch": "feature/mobile", "base": "main", "path": tmp.join("wt").to_string_lossy(), "label": "mobile" }),
+                ),
+                "worktree.create",
+            ),
+            (
+                Method::POST,
+                "/api/worktrees/open",
+                Some(
+                    json!({ "workspace_id": "w1", "path": tmp.join("wt").to_string_lossy(), "label": "mobile" }),
+                ),
+                "worktree.open",
+            ),
+            (
+                Method::POST,
+                "/api/workspaces/w1/worktree-remove",
+                None,
+                "worktree.remove",
+            ),
+            (Method::POST, "/api/session/close", None, "server.stop"),
+            (Method::GET, "/api/versions", None, "ping"),
+        ];
+
+        for (method, uri, body, expected_method) in &routes {
+            let mut builder =
+                request(method.clone(), uri).header(header::COOKIE, "herdr_web_session=token-123");
+            if body.is_some() {
+                builder = builder.header(header::CONTENT_TYPE, "application/json");
+            }
+            let body = body
+                .as_ref()
+                .map(|value| Body::from(value.to_string()))
+                .unwrap_or_else(Body::empty);
+            let response = app
+                .clone()
+                .oneshot(builder.body(body).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{uri}");
+            let json = response_json(response).await;
+            if *expected_method == "ping" {
+                assert_eq!(json["compatibility"]["status"], "unknown");
+            } else {
+                assert_eq!(json["result"]["method"], *expected_method, "{uri}");
+            }
+        }
+
+        handle.join().unwrap();
+        let requests = captured.lock().unwrap();
+        let methods = requests
+            .iter()
+            .map(|request| request["method"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            methods,
+            routes
+                .iter()
+                .map(|(_, _, _, method)| *method)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(requests[1]["params"]["focus"], false);
+        assert_eq!(requests[5]["params"]["focus"], false);
+        assert_eq!(requests[14]["params"]["focus"], true);
+        assert_eq!(requests[15]["params"]["force"], false);
+        let _ = fs::remove_file(socket);
+        let _ = fs::remove_dir_all(tmp);
+    }
+
+    #[tokio::test]
+    async fn local_path_and_git_routes_cover_success_and_errors() {
+        let _guard = env_lock().lock().unwrap();
+        let home = std::env::temp_dir().join(format!(
+            "herdr-webui-path-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(home.join("alpha-dir")).unwrap();
+        fs::write(home.join("alpha-file"), "not a dir").unwrap();
+        let old_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", &home);
+        let app = test_app();
+
+        let suggestions = app
+            .clone()
+            .oneshot(
+                request(Method::GET, "/api/path-suggestions?prefix=alp")
+                    .header(header::COOKIE, "herdr_web_session=token-123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(suggestions.status(), StatusCode::OK);
+        let body = response_json(suggestions).await;
+        assert_eq!(body["suggestions"][0]["label"], "alpha-dir");
+
+        let missing = app
+            .clone()
+            .oneshot(
+                request(Method::GET, "/api/git-branches")
+                    .header(header::COOKIE, "herdr_web_session=token-123")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::BAD_REQUEST);
+
+        let not_git = app
+            .oneshot(
+                request(
+                    Method::GET,
+                    &format!("/api/git-branches?cwd={}", home.display()),
+                )
+                .header(header::COOKIE, "herdr_web_session=token-123")
+                .body(Body::empty())
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(not_git.status(), StatusCode::BAD_GATEWAY);
+
+        if let Some(old_home) = old_home {
+            std::env::set_var("HOME", old_home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        let _ = fs::remove_dir_all(home);
     }
 
     #[tokio::test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -458,6 +458,101 @@ unsafe fn libc_geteuid() -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::sync::MutexGuard;
+
+    struct TestEnv {
+        _guard: MutexGuard<'static, ()>,
+        root: PathBuf,
+        old_home: Option<std::ffi::OsString>,
+        old_xdg: Option<std::ffi::OsString>,
+        old_path: Option<std::ffi::OsString>,
+        old_herdr_bin: Option<std::ffi::OsString>,
+    }
+
+    impl TestEnv {
+        fn new() -> Self {
+            let guard = crate::env_test_lock()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let root = std::env::temp_dir().join(format!(
+                "herdr-webui-service-test-{}-{}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            fs::create_dir_all(&root).unwrap();
+            let bin = root.join("bin");
+            fs::create_dir_all(&bin).unwrap();
+            write_fake_command(&bin.join("systemctl"));
+            write_fake_command(&bin.join("launchctl"));
+
+            let old_home = std::env::var_os("HOME");
+            let old_xdg = std::env::var_os("XDG_CONFIG_HOME");
+            let old_path = std::env::var_os("PATH");
+            let old_herdr_bin = std::env::var_os("HERDR_WEB_HERDR_BIN");
+
+            std::env::set_var("HOME", &root);
+            std::env::set_var("XDG_CONFIG_HOME", root.join("xdg"));
+            let path = old_path
+                .as_ref()
+                .map(|value| format!("{}:{}", bin.display(), value.to_string_lossy()))
+                .unwrap_or_else(|| bin.display().to_string());
+            std::env::set_var("PATH", path);
+            std::env::set_var("HERDR_WEB_HERDR_BIN", "/tmp/herdr bin");
+
+            Self {
+                _guard: guard,
+                root,
+                old_home,
+                old_xdg,
+                old_path,
+                old_herdr_bin,
+            }
+        }
+
+        fn config(&self) -> WebConfig {
+            WebConfig {
+                bind: "127.0.0.1:8787".parse().unwrap(),
+                session: Some("mobile git".to_string()),
+                api_socket: None,
+                client_socket: None,
+            }
+        }
+    }
+
+    impl Drop for TestEnv {
+        fn drop(&mut self) {
+            restore_env("HOME", self.old_home.take());
+            restore_env("XDG_CONFIG_HOME", self.old_xdg.take());
+            restore_env("PATH", self.old_path.take());
+            restore_env("HERDR_WEB_HERDR_BIN", self.old_herdr_bin.take());
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
+        if let Some(value) = value {
+            std::env::set_var(key, value);
+        } else {
+            std::env::remove_var(key);
+        }
+    }
+
+    fn write_fake_command(path: &Path) {
+        fs::write(
+            path,
+            "#!/bin/sh\nprintf '%s\\n' \"$0 $*\" >> \"$HOME/commands.log\"\nexit 0\n",
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
 
     #[test]
     fn linux_service_unit_contains_binary_and_flags() {
@@ -518,5 +613,81 @@ mod tests {
             xml_escape("<&>\"'"),
             "&lt;&amp;&gt;&quot;&apos;".to_string()
         );
+    }
+
+    #[test]
+    fn linux_service_lifecycle_uses_user_systemd_files() {
+        let env = TestEnv::new();
+
+        install_linux(env.config()).unwrap();
+        let service_path = linux_service_path().unwrap();
+        let unit = fs::read_to_string(&service_path).unwrap();
+        assert!(unit.contains("Environment=HERDR_WEB_HERDR_BIN='/tmp/herdr bin'"));
+        assert!(unit.contains("--session 'mobile git'"));
+        assert!(install_bin_path().unwrap().exists());
+
+        start_linux_service().unwrap();
+        stop_linux_service().unwrap();
+        restart_linux_service().unwrap();
+        update_linux().unwrap();
+        uninstall_linux().unwrap();
+
+        assert!(!service_path.exists());
+        let commands = fs::read_to_string(env.root.join("commands.log")).unwrap();
+        assert!(commands.contains("systemctl --user daemon-reload"));
+        assert!(commands.contains("systemctl --user enable --now herdr-web.service"));
+        assert!(commands.contains("systemctl --user start herdr-web.service"));
+        assert!(commands.contains("systemctl --user stop herdr-web.service"));
+        assert!(commands.contains("systemctl --user restart herdr-web.service"));
+        assert!(commands.contains("systemctl --user disable --now herdr-web.service"));
+    }
+
+    #[test]
+    fn linux_service_start_and_restart_require_installed_unit() {
+        let _env = TestEnv::new();
+
+        let start = start_linux_service().unwrap_err();
+        assert_eq!(start.kind(), io::ErrorKind::NotFound);
+        assert!(start.to_string().contains("systemd user service not found"));
+
+        let restart = restart_linux_service().unwrap_err();
+        assert_eq!(restart.kind(), io::ErrorKind::NotFound);
+        assert!(restart
+            .to_string()
+            .contains("systemd user service not found"));
+    }
+
+    #[test]
+    fn mac_service_lifecycle_uses_launchagent_files() {
+        let env = TestEnv::new();
+
+        install_macos(env.config()).unwrap();
+        let plist = mac_plist_path().unwrap();
+        let plist_xml = fs::read_to_string(&plist).unwrap();
+        assert!(plist_xml.contains("<key>HERDR_WEB_HERDR_BIN</key>"));
+        assert!(plist_xml.contains("<string>/tmp/herdr bin</string>"));
+        assert!(plist_xml.contains("<string>mobile git</string>"));
+        assert!(mac_log_dir().unwrap().exists());
+
+        start_macos_service().unwrap();
+        stop_macos_service().unwrap();
+        restart_macos_service().unwrap();
+        update_macos().unwrap();
+        uninstall_macos().unwrap();
+
+        assert!(!plist.exists());
+        let commands = fs::read_to_string(env.root.join("commands.log")).unwrap();
+        assert!(commands.contains("launchctl bootout gui/"));
+        assert!(commands.contains("launchctl bootstrap gui/"));
+        assert!(commands.contains("launchctl kickstart -k gui/"));
+    }
+
+    #[test]
+    fn mac_service_start_requires_launchagent() {
+        let _env = TestEnv::new();
+
+        let err = start_macos_service().unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(err.to_string().contains("LaunchAgent plist not found"));
     }
 }


### PR DESCRIPTION
## Summary
- add mobile-friendly Git UI using existing Git endpoints
- add desktop Git diff layout setting with unified/GitHub-style rendering
- add settings search/filter and accent-state polish for workspace/worktree controls
- support staged restore for files and hunks

## Checks
- node --check src/assets/desktop/git_ui.js src/assets/desktop/git_ui/settings.js src/assets/desktop/app_js/core.js src/assets/mobile/git.js
- node --test src/assets/app_load.test.mjs src/assets/mobile_load.test.mjs
- cargo check
- cargo test git_ui_file_history_switch_reset_and_patch_routes_work
- git diff --check