### PR TITLE
fix: mark Herdr 0.7.2 as tested backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "herdr-webui"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "axum",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Compatibility:
 
 | WebUI | Herdr | Protocol | Status | Notes |
 | --- | --- | --- | --- | --- |
-| `0.2.4` | `0.7.1+` | `15` with `14` fallback | Current | Prefers Herdr direct attach protocol 15 and retries protocol 14 when an older compatible server rejects the initial handshake. |
+| `0.2.5` | `0.7.2` | `15` with `14` fallback | Current | Marks Herdr 0.7.2 protocol 15 as tested while preserving protocol 14 fallback for older compatible servers. |
+| `0.2.4` | `0.7.1+` | `15` with `14` fallback | Tested | Prefers Herdr direct attach protocol 15 and retries protocol 14 when an older compatible server rejects the initial handshake. |
 | `0.2.3` | `0.7.1` | `14` | Tested | Expands Help & Shortcuts with a separated Functionality map section and more detailed area rows. |
 | `0.2.2` | `0.7.1` | `14` | Tested | Renames the `?` modal to Help & Shortcuts, with a functionality map and action flows for creating workspaces/panels, opening Files/Git, worktree actions, terminal scroll/follow, search palette, and settings. |
 | `0.2.1` | `0.7.1` | `14` | Tested | Restores native xterm.js wheel scrolling by removing the custom shell wheel handler, enables xterm viewport scrolling, uses dynamic terminal shell sizing without inline height/width, removes the custom terminal context menu, and deduplicates terminal CSS/JS into modular helpers. |
@@ -33,7 +34,13 @@ Compatibility:
 | `0.0.45` | `0.7.1` | `14` | Tested | Improves embedded Git UI navigation with Escape handling, all-changes return behavior, split frontend assets, scoped file history controls, keyboard-owned drawer input, and per-file large diff loading. |
 | `0.0.45` | `0.7.0` | `14` | Minimum supported | Uses WebUI's legacy existing-branch worktree fallback when needed. |
 
-Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested. WebUI 0.2.4 prefers protocol 15 for current Herdr builds and retries protocol 14 for compatible older Herdr 0.7.x servers.
+Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested. WebUI 0.2.5 treats Herdr 0.7.2 protocol 15 as tested and retries protocol 14 for compatible older Herdr 0.7.x servers.
+
+## 0.2.5 Release Notes
+
+### Compatibility
+
+- Marks Herdr 0.7.2 as the maximum tested backend so current protocol 15 installs report as compatible.
 
 ## 0.2.4 Release Notes
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ const MAX_GRAPHICS_FRAME_SIZE: usize = 32 * 1024 * 1024;
 const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 14;
 const PROTOCOL_VERSION: u32 = 15;
 const MIN_BACKEND_VERSION: &str = "0.7.0";
-const MAX_TESTED_BACKEND_VERSION: &str = "0.7.1";
+const MAX_TESTED_BACKEND_VERSION: &str = "0.7.2";
 
 type LocalStream = interprocess::local_socket::Stream;
 
@@ -3243,7 +3243,7 @@ mod tests {
             BackendCompatibility::Compatible
         );
         assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.2"), Some(PROTOCOL_VERSION)),
+            backend_compatibility_for_supported_range(Some("0.7.3"), Some(PROTOCOL_VERSION)),
             BackendCompatibility::UntestedNewer
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
- Bump WebUI release metadata to 0.2.5
- Mark Herdr 0.7.2 as the maximum tested backend
- Keep protocol 15 with protocol 14 fallback compatibility behavior

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test