### PR TITLE
Add configurable agent sorting and sidebar split

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Newer Herdr builds may work when protocol stays compatible, but WebUI reports th
 
 - Marks Herdr 0.7.2 as the maximum tested backend so current protocol 15 installs report as compatible.
 
+### Sidebar and agents
+
+- Agents sidebar sorting is configurable in Settings → Agents and alerts. Status groups can be reordered with up/down controls and are saved in browser-local settings.
+- Agent status groups use explicit colors in settings: idle green, working yellow, blocked red, done blue, and others gray.
+- The Workspaces/Agents sidebar split is resizable by dragging the separator, snaps to whole percent values, and can also be set directly in Settings → Agents and alerts.
+
 ## 0.2.4 Release Notes
 
 ### Compatibility

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { beforeEach, describe, it } from "node:test";
-import { doesNotThrow, equal, match, ok } from "node:assert/strict";
+import { deepEqual, doesNotThrow, equal, match, ok } from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import vm from "node:vm";
 
@@ -855,6 +855,46 @@ describe("app bundle load", () => {
       ),
       -1,
     );
+  });
+
+  it("preserves custom agent status order when saving settings", () => {
+    const ctx = context();
+    ctx.localStorage.setItem(
+      "herdr-web-options",
+      JSON.stringify({
+        agentSortMode: "attention_inverted",
+        agentStatusOrder: ["working", "blocked", "idle", "done", "other"],
+      }),
+    );
+    vm.runInContext(source, ctx);
+
+    equal(
+      Math.sign(
+        ctx.agentAttentionCompare(
+          { agent_status: "working" },
+          { agent_status: "blocked" },
+        ),
+      ),
+      -1,
+    );
+    vm.runInContext("saveOptions()", ctx);
+    const saved = JSON.parse(ctx.localStorage.getItem("herdr-web-options"));
+    deepEqual(saved.agentStatusOrder, [
+      "working",
+      "blocked",
+      "idle",
+      "done",
+      "other",
+    ]);
+  });
+
+  it("normalizes sidebar split percent to whole bounded values", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    equal(ctx.normalizeSidebarWorkspacePercent(33.6), 34);
+    equal(ctx.normalizeSidebarWorkspacePercent(10), 20);
+    equal(ctx.normalizeSidebarWorkspacePercent(90), 80);
   });
 
   it("defines tab activity setting and badge", () => {

--- a/src/assets/desktop/app_css/chrome.css
+++ b/src/assets/desktop/app_css/chrome.css
@@ -157,9 +157,12 @@
   margin-top: auto;
 }
 .sidebar-split-handle {
-  flex: 0 0 9px;
+  align-items: center;
+  display: flex;
+  flex: 0 0 18px;
+  justify-content: center;
   cursor: row-resize;
-  margin: -2px 10px 4px;
+  margin: -3px 10px 2px;
   position: relative;
 }
 .sidebar-split-handle::before {
@@ -167,16 +170,32 @@
   border-radius: 999px;
   content: "";
   display: block;
-  height: 3px;
-  left: 0;
+  height: 2px;
+  left: 22px;
   position: absolute;
-  right: 0;
-  top: 3px;
+  right: 22px;
+  top: 8px;
+}
+.sidebar-split-handle::after {
+  color: var(--muted);
+  content: "↕";
+  font-size: 13px;
+  line-height: 1;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 120ms ease, transform 120ms ease;
 }
 .sidebar-split-handle:hover::before,
 .sidebar-split-handle.dragging::before,
 .sidebar-split-handle:focus-visible::before {
   background: var(--accent);
+}
+.sidebar-split-handle:hover::after,
+.sidebar-split-handle.dragging::after,
+.sidebar-split-handle:focus-visible::after {
+  color: var(--accent);
+  opacity: 1;
+  transform: scale(1);
 }
 .sidebar-scroll {
   min-height: 0;

--- a/src/assets/desktop/app_css/chrome.css
+++ b/src/assets/desktop/app_css/chrome.css
@@ -148,13 +148,35 @@
   padding: 0 10px 8px;
 }
 .sidebar-pane.workspaces-pane {
-  flex: 1 1 auto;
-  min-height: 45%;
+  flex: 0 0 var(--sidebar-workspace-percent, 68%);
+  min-height: 20%;
 }
 .sidebar-pane.agents-pane {
-  flex: 0 1 32%;
+  flex: 1 1 auto;
   min-height: 110px;
   margin-top: auto;
+}
+.sidebar-split-handle {
+  flex: 0 0 9px;
+  cursor: row-resize;
+  margin: -2px 10px 4px;
+  position: relative;
+}
+.sidebar-split-handle::before {
+  background: var(--border);
+  border-radius: 999px;
+  content: "";
+  display: block;
+  height: 3px;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 3px;
+}
+.sidebar-split-handle:hover::before,
+.sidebar-split-handle.dragging::before,
+.sidebar-split-handle:focus-visible::before {
+  background: var(--accent);
 }
 .sidebar-scroll {
   min-height: 0;

--- a/src/assets/desktop/app_css/workspaces.css
+++ b/src/assets/desktop/app_css/workspaces.css
@@ -223,6 +223,60 @@ body.light .chip.label {
 .option select {
   margin-left: auto;
 }
+.agent-sort-order {
+  display: grid;
+  gap: 10px;
+}
+.agent-sort-order.disabled {
+  opacity: 0.65;
+}
+.agent-sort-order small {
+  color: var(--muted);
+  display: block;
+  font-size: 12px;
+  margin-top: 3px;
+}
+.agent-sort-list {
+  display: grid;
+  gap: 6px;
+}
+.agent-sort-row {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+.agent-sort-chip {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 5px 9px;
+}
+.agent-sort-chip.green {
+  background: #22c55e26;
+  color: #22c55e;
+}
+.agent-sort-chip.yellow {
+  background: #f59e0b26;
+  color: #f59e0b;
+}
+.agent-sort-chip.red {
+  background: #ef444426;
+  color: #ef4444;
+}
+.agent-sort-chip.blue {
+  background: #3b82f626;
+  color: #3b82f6;
+}
+.agent-sort-chip.gray {
+  background: color-mix(in srgb, var(--muted), transparent 78%);
+  color: var(--muted);
+}
+.agent-sort-buttons {
+  display: inline-flex;
+  gap: 5px;
+}
 .modal-actions {
   position: sticky;
   bottom: 0;

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -179,6 +179,44 @@ el("optAgentSortMode").onchange = () => {
   applyOptions();
   render();
 };
+const optSidebarWorkspacePercent = el("optSidebarWorkspacePercent");
+if (optSidebarWorkspacePercent)
+  optSidebarWorkspacePercent.oninput = () => {
+    setSidebarWorkspacePercent(optSidebarWorkspacePercent.value);
+  };
+const sidebarSplitHandle = el("sidebarSplitHandle");
+if (sidebarSplitHandle) {
+  const resizeFromClientY = (clientY) => {
+    const split = sidebarSplitHandle.parentElement;
+    if (!split) return;
+    const rect = split.getBoundingClientRect();
+    const percent = ((clientY - rect.top) / rect.height) * 100;
+    setSidebarWorkspacePercent(percent);
+  };
+  sidebarSplitHandle.addEventListener("pointerdown", (e) => {
+    e.preventDefault();
+    sidebarSplitHandle.setPointerCapture(e.pointerId);
+    sidebarSplitHandle.classList.add("dragging");
+  });
+  sidebarSplitHandle.addEventListener("pointermove", (e) => {
+    if (!sidebarSplitHandle.hasPointerCapture(e.pointerId)) return;
+    resizeFromClientY(e.clientY);
+  });
+  const stopResize = (e) => {
+    if (sidebarSplitHandle.hasPointerCapture(e.pointerId))
+      sidebarSplitHandle.releasePointerCapture(e.pointerId);
+    sidebarSplitHandle.classList.remove("dragging");
+  };
+  sidebarSplitHandle.addEventListener("pointerup", stopResize);
+  sidebarSplitHandle.addEventListener("pointercancel", stopResize);
+  sidebarSplitHandle.addEventListener("keydown", (e) => {
+    if (!["ArrowUp", "ArrowDown"].includes(e.key)) return;
+    e.preventDefault();
+    setSidebarWorkspacePercent(
+      (options.sidebarWorkspacePercent || 68) + (e.key === "ArrowDown" ? 2 : -2),
+    );
+  });
+}
 el("optParentCloseMode").onchange = () => {
   options.parentCloseMode = el("optParentCloseMode").value;
   saveOptions();

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -175,6 +175,8 @@ el("optTerminalLinks").onchange = () => {
 };
 el("optAgentSortMode").onchange = () => {
   options.agentSortMode = el("optAgentSortMode").value;
+  if (options.agentSortMode === "attention_inverted")
+    options.agentStatusOrder = normalizeAgentStatusOrder(workingFirstAgentStatusOrder);
   saveOptions();
   applyOptions();
   render();

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -186,17 +186,19 @@ if (optSidebarWorkspacePercent)
   };
 const sidebarSplitHandle = el("sidebarSplitHandle");
 if (sidebarSplitHandle) {
+  let pendingSidebarWorkspacePercent = null;
   const resizeFromClientY = (clientY) => {
     const split = sidebarSplitHandle.parentElement;
     if (!split) return;
     const rect = split.getBoundingClientRect();
     const percent = ((clientY - rect.top) / rect.height) * 100;
-    setSidebarWorkspacePercent(percent);
+    pendingSidebarWorkspacePercent = previewSidebarWorkspacePercent(percent);
   };
   sidebarSplitHandle.addEventListener("pointerdown", (e) => {
     e.preventDefault();
     sidebarSplitHandle.setPointerCapture(e.pointerId);
     sidebarSplitHandle.classList.add("dragging");
+    resizeFromClientY(e.clientY);
   });
   sidebarSplitHandle.addEventListener("pointermove", (e) => {
     if (!sidebarSplitHandle.hasPointerCapture(e.pointerId)) return;
@@ -206,6 +208,10 @@ if (sidebarSplitHandle) {
     if (sidebarSplitHandle.hasPointerCapture(e.pointerId))
       sidebarSplitHandle.releasePointerCapture(e.pointerId);
     sidebarSplitHandle.classList.remove("dragging");
+    if (pendingSidebarWorkspacePercent !== null) {
+      setSidebarWorkspacePercent(pendingSidebarWorkspacePercent);
+      pendingSidebarWorkspacePercent = null;
+    }
   };
   sidebarSplitHandle.addEventListener("pointerup", stopResize);
   sidebarSplitHandle.addEventListener("pointercancel", stopResize);

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -980,10 +980,10 @@ function normalizeAgentStatusOrder(value) {
   return order;
 }
 function normalizeSidebarWorkspacePercent(value) {
-  return Math.max(
+  return Math.round(Math.max(
     20,
     Math.min(80, Number.isFinite(Number(value)) ? Number(value) : 68),
-  );
+  ));
 }
 function loadOptions() {
   try {
@@ -1639,6 +1639,13 @@ function setSidebarWorkspacePercent(value) {
   options.sidebarWorkspacePercent = normalizeSidebarWorkspacePercent(value);
   saveOptions();
   applyOptions();
+}
+function previewSidebarWorkspacePercent(value) {
+  const percent = normalizeSidebarWorkspacePercent(value);
+  document.body.style.setProperty("--sidebar-workspace-percent", `${percent}%`);
+  const input = el("optSidebarWorkspacePercent");
+  if (input) input.value = String(percent);
+  return percent;
 }
 function syncThemeColorInputs() {
   for (const mode of ["dark", "light"]) {

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -489,7 +489,7 @@ function shortcutsModalHtml() {
           <h3>Functionality map</h3>
           <p class="settings-note">Main Herdr areas and what each control does.</p>
           <div class="help-grid">
-            <div class="help-row"><strong>Sidebar</strong><span>Workspaces show open roots/worktrees; agents list status. Click to open; double-click names to rename. Colored badges show blocked, done, working, and idle.</span></div>
+            <div class="help-row"><strong>Sidebar</strong><span>Workspaces show open roots/worktrees; agents list status. Click to open; double-click names to rename. Drag the workspace/agents separator to resize by percent. Colored badges show blocked, done, working, and idle.</span></div>
             <div class="help-row"><strong>Header</strong><span>＋ opens/creates workspace; ? opens this help; gear opens Settings; moon/theme toggles color mode; sidebar chevron hides/shows navigation.</span></div>
             <div class="help-row"><strong>Panels/Tabs</strong><span>Top panel switcher changes terminal panel; + creates panel; ✕ closes current panel; double-click panel label to rename.</span></div>
             <div class="help-row"><strong>Terminal</strong><span>Native xterm wheel scrolls scrollback; PageUp/PageDown scroll; Shift+Enter sends newline; Tail resumes follow; terminal links open in browser when enabled.</span></div>
@@ -497,7 +497,7 @@ function shortcutsModalHtml() {
             <div class="help-row"><strong>Git</strong><span>Git selector opens repo tools for diff, stage/unstage, discard, commit, stash, branches, cleanup, and worktree prune; unified/side-by-side diff is in Settings.</span></div>
             <div class="help-row"><strong>Worktrees</strong><span>Row actions create linked worktree, open existing worktree, close panels/workspace, or remove linked worktree after confirmation.</span></div>
             <div class="help-row"><strong>Search</strong><span>Prefix then / opens palette for workspaces, repos, worktrees, labels, agents, and panels.</span></div>
-            <div class="help-row"><strong>Settings</strong><span>Configure shortcuts, terminal font/links, themes, file browser, Git UI, worktree defaults, and notification/no-sleep behavior.</span></div>
+            <div class="help-row"><strong>Settings</strong><span>Configure shortcuts, terminal font/links, themes, file browser, Git UI, worktree defaults, agent group order, sidebar split percent, and notification/no-sleep behavior.</span></div>
           </div>
         </section>
         <div id="shortcutEditor"></div>
@@ -1379,6 +1379,8 @@ function groupSettingsSections() {
         "optGlobalShortcutPrefix",
         "optSearchShortcut",
         "optAgentSortMode",
+        "optAgentStatusOrder",
+        "optSidebarWorkspacePercent",
         "optParentCloseMode",
         "optStuckWorkingEnabled",
         "optWorkingDismissMinutes",
@@ -1413,7 +1415,7 @@ function groupSettingsSections() {
     const nodes = [];
     for (const id of def.ids || []) {
       const control = el(id);
-      const row = control && control.closest("label.option");
+      const row = control && control.closest(".option");
       if (row && !nodes.includes(row)) nodes.push(row);
     }
     for (const id of def.blocks || []) {

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -280,7 +280,15 @@ if (sectionEl && !el("workspacePane")) {
   agentsScroll.appendChild(agentsEl);
   agentsPane.appendChild(agentsScroll);
   if (oldAgentsHeader) oldAgentsHeader.remove();
+  const resizeHandle = document.createElement("div");
+  resizeHandle.id = "sidebarSplitHandle";
+  resizeHandle.className = "sidebar-split-handle";
+  resizeHandle.title = "Drag to resize workspace and agents panels";
+  resizeHandle.setAttribute("role", "separator");
+  resizeHandle.setAttribute("aria-orientation", "horizontal");
+  resizeHandle.tabIndex = 0;
   split.appendChild(workspacePane);
+  split.appendChild(resizeHandle);
   split.appendChild(agentsPane);
   sectionEl.appendChild(split);
   if (versionsEl) {
@@ -931,6 +939,8 @@ const defaultOptions = {
   terminalFontFamily: "ui-monospace,SFMono-Regular,Menlo,monospace",
   terminalLinks: true,
   agentSortMode: "off",
+  agentStatusOrder: ["blocked", "idle", "done", "other", "working"],
+  sidebarWorkspacePercent: 68,
   parentCloseMode: "panels",
   stuckWorkingEnabled: true,
   workingDismissMinutes: 30,
@@ -947,6 +957,34 @@ const defaultOptions = {
   themeColors: themeColorDefaults,
   ...moduleOptionDefaults,
 };
+const agentStatusGroups = [
+  ["idle", "Idle", "green"],
+  ["working", "Working", "yellow"],
+  ["blocked", "Blocked", "red"],
+  ["done", "Done", "blue"],
+  ["other", "Others", "gray"],
+];
+const agentStatusGroupKeys = agentStatusGroups.map(([key]) => key);
+function normalizeAgentStatusOrder(value) {
+  const seen = new Set();
+  const order = [];
+  for (const key of Array.isArray(value) ? value : []) {
+    if (agentStatusGroupKeys.includes(key) && !seen.has(key)) {
+      seen.add(key);
+      order.push(key);
+    }
+  }
+  for (const key of defaultOptions.agentStatusOrder) {
+    if (!seen.has(key)) order.push(key);
+  }
+  return order;
+}
+function normalizeSidebarWorkspacePercent(value) {
+  return Math.max(
+    20,
+    Math.min(80, Number.isFinite(Number(value)) ? Number(value) : 68),
+  );
+}
 function loadOptions() {
   try {
     const stored = JSON.parse(localStorage.getItem("herdr-web-options") || "{}");
@@ -992,11 +1030,23 @@ function normalizeOptions(value) {
   next.terminalLinks = next.terminalLinks !== false;
   if (!["off", "attention", "attention_inverted"].includes(next.agentSortMode))
     next.agentSortMode = defaultOptions.agentSortMode;
+  next.agentStatusOrder = normalizeAgentStatusOrder(next.agentStatusOrder);
+  if (next.agentSortMode === "attention_inverted")
+    next.agentStatusOrder = normalizeAgentStatusOrder([
+      "blocked",
+      "working",
+      "other",
+      "done",
+      "idle",
+    ]);
   if (!["panels", "close"].includes(next.parentCloseMode))
     next.parentCloseMode = defaultOptions.parentCloseMode;
   next.stuckWorkingEnabled = next.stuckWorkingEnabled !== false;
   if (next.sortAgentsByStatus === true) next.agentSortMode = "attention";
   delete next.sortAgentsByStatus;
+  next.sidebarWorkspacePercent = normalizeSidebarWorkspacePercent(
+    next.sidebarWorkspacePercent,
+  );
   next.workingDismissMinutes = Math.max(
     1,
     Math.min(1440, Number(next.workingDismissMinutes) || 30),
@@ -1275,7 +1325,7 @@ if (soundSetting && !el("optAgentSortMode"))
     .closest("label")
     .insertAdjacentHTML(
       "afterend",
-      '<label class="option"><input type="checkbox" id="optGlobalShortcutsEnabled"><span>Global keyboard shortcuts<small>Enable prefix WebUI navigation shortcuts listed under ?.</small></span></label><label class="option"><span>Shortcut prefix<small>Click Record, press desired key combination, then use it before WebUI shortcuts.</small></span><span class="shortcut-capture"><input id="optGlobalShortcutPrefix" readonly><button type="button" class="tab add" id="optGlobalShortcutPrefixCapture">Record</button></span></label><label class="option"><span>Search shortcut<small>Optional direct shortcut. Leave disabled if it conflicts with terminal apps.</small></span><span class="shortcut-capture"><input id="optSearchShortcut" readonly><button type="button" class="tab add" id="optSearchShortcutCapture">Record</button><button type="button" class="tab add" id="optSearchShortcutClear">Clear</button></span></label><label class="option"><span>Terminal font<small>Use installed monospaced font family, including Nerd Fonts used by Neovim.</small></span><input id="optTerminalFontFamily" list="terminalFontPresets" placeholder="&quot;MesloLGS Nerd Font Mono&quot;, monospace"><datalist id="terminalFontPresets"><option value="&quot;MesloLGS Nerd Font Mono&quot;, &quot;MesloLGS NF&quot;, monospace"><option value="&quot;MesloLGS Nerd Font&quot;, &quot;MesloLGS NF&quot;, monospace"><option value="&quot;JetBrainsMono Nerd Font Mono&quot;, &quot;JetBrainsMono Nerd Font&quot;, monospace"><option value="&quot;Hack Nerd Font Mono&quot;, &quot;Hack Nerd Font&quot;, monospace"><option value="&quot;FiraCode Nerd Font Mono&quot;, &quot;FiraCode Nerd Font&quot;, monospace"><option value="&quot;CaskaydiaCove Nerd Font Mono&quot;, &quot;CaskaydiaCove Nerd Font&quot;, monospace"><option value="ui-monospace,SFMono-Regular,Menlo,monospace"></datalist></label><label class="option"><input type="checkbox" id="optTerminalLinks"><span>Terminal links<small>Detect http/https URLs in terminal output and open them in a new tab when clicked.</small></span></label><label class="option"><span>Close panel shortcut<small>Stored in browser storage and available after reopening the tab.</small></span><select class="settings-select" id="optCloseShortcut"><option value="off">Disabled</option><option value="altw">Option+W</option><option value="shiftspacew">Shift+Space then W</option></select></label><label class="option"><span>Agent sorting<small>Sort agents by attention priority, or show them in default order.</small></span><select class="settings-select" id="optAgentSortMode"><option value="off">Default order</option><option value="attention">Attention (blocked first)</option><option value="attention_inverted">Attention (working first)</option></select></label><label class="option"><span>Parent workspace close<small>Close panels only (keeps linked worktrees running) or full close with re-open (stops processes, re-opens worktrees with fresh shells).</small></span><select class="settings-select" id="optParentCloseMode"><option value="panels">Close panels only</option><option value="close">Full close + re-open worktrees</option></select></label><label class="option"><input type="checkbox" id="optStuckWorkingEnabled"><span>Ignore stuck working agents<small>Dismiss working agents that appear stuck. Clears automatically on status changes and terminal output.</small></span></label><label class="option"><span>Ignore stuck working for<small>Minutes to keep a local dismissed-working override before showing working again.</small></span><input id="optWorkingDismissMinutes" type="number" min="1" max="1440" step="1"></label><label class="option"><input type="checkbox" id="optShowTabActivity"><span>Show panel last update<small>Display local last-change age on top panel tabs. Updates on refreshes, events, and selected terminal output; no timer polling.</small></span></label><label class="option"><span>Workspace sorting<small>Default tree order, shared drag-and-drop order, or attention state priority.</small></span><select class="settings-select" id="optWorkspaceSort"><option value="default">Default</option><option value="drag">Drag&drop</option><option value="state">State</option></select></label><label class="option"><span>Notification scope<small>Choose whether alerts fire in every open tab or only the tab viewing the agent panel.</small></span><select class="settings-select" id="optSoundScope"><option value="current">Current agent tab</option><option value="all">All tabs</option></select></label><label class="option"><span>Notification volume<small><span id="notificationVolumeValue">24</span>% for local attention tone.</small></span><input type="range" id="optNotificationVolume" min="0" max="100" step="1"></label><label class="option"><input type="checkbox" id="optGenerateWorktreeNames"><span>Generate worktree branch names<small>Allow blank Branch name in Worktrees modal. Herdr generates worktree/&lt;name&gt;.</small></span></label><label class="option"><span>Worktree default directory<small>Base directory for generated worktree checkout paths. Relative paths resolve from repo root. Example: ../worktrees.</small></span><input id="optWorktreeDefaultDirectory" placeholder="../worktrees"></label><label class="option"><span>Exploration default directory<small>Prefills new/open workspace, worktree discovery, and Git cleanup scan paths.</small></span><input id="optExplorationDefaultDirectory" placeholder="~/Documents/code"></label><label class="option"><span>Scroll speed<small><span id="scrollLinesValue">3</span> terminal lines per wheel step.</small></span><input type="range" id="optScrollLines" min="1" max="20" step="1"></label><label class="option"><span>Worktree autodiscover<small>Seconds to wait after path input stops. Set 0 for immediate.</small></span><input type="number" id="optWorktreeAutoDiscover" min="0" max="30" step="0.5"></label>',
+      '<label class="option"><input type="checkbox" id="optGlobalShortcutsEnabled"><span>Global keyboard shortcuts<small>Enable prefix WebUI navigation shortcuts listed under ?.</small></span></label><label class="option"><span>Shortcut prefix<small>Click Record, press desired key combination, then use it before WebUI shortcuts.</small></span><span class="shortcut-capture"><input id="optGlobalShortcutPrefix" readonly><button type="button" class="tab add" id="optGlobalShortcutPrefixCapture">Record</button></span></label><label class="option"><span>Search shortcut<small>Optional direct shortcut. Leave disabled if it conflicts with terminal apps.</small></span><span class="shortcut-capture"><input id="optSearchShortcut" readonly><button type="button" class="tab add" id="optSearchShortcutCapture">Record</button><button type="button" class="tab add" id="optSearchShortcutClear">Clear</button></span></label><label class="option"><span>Terminal font<small>Use installed monospaced font family, including Nerd Fonts used by Neovim.</small></span><input id="optTerminalFontFamily" list="terminalFontPresets" placeholder="&quot;MesloLGS Nerd Font Mono&quot;, monospace"><datalist id="terminalFontPresets"><option value="&quot;MesloLGS Nerd Font Mono&quot;, &quot;MesloLGS NF&quot;, monospace"><option value="&quot;MesloLGS Nerd Font&quot;, &quot;MesloLGS NF&quot;, monospace"><option value="&quot;JetBrainsMono Nerd Font Mono&quot;, &quot;JetBrainsMono Nerd Font&quot;, monospace"><option value="&quot;Hack Nerd Font Mono&quot;, &quot;Hack Nerd Font&quot;, monospace"><option value="&quot;FiraCode Nerd Font Mono&quot;, &quot;FiraCode Nerd Font&quot;, monospace"><option value="&quot;CaskaydiaCove Nerd Font Mono&quot;, &quot;CaskaydiaCove Nerd Font&quot;, monospace"><option value="ui-monospace,SFMono-Regular,Menlo,monospace"></datalist></label><label class="option"><input type="checkbox" id="optTerminalLinks"><span>Terminal links<small>Detect http/https URLs in terminal output and open them in a new tab when clicked.</small></span></label><label class="option"><span>Close panel shortcut<small>Stored in browser storage and available after reopening the tab.</small></span><select class="settings-select" id="optCloseShortcut"><option value="off">Disabled</option><option value="altw">Option+W</option><option value="shiftspacew">Shift+Space then W</option></select></label><label class="option"><span>Agent sorting<small>Turn on status group sorting for the agents sidebar.</small></span><select class="settings-select" id="optAgentSortMode"><option value="off">Default order</option><option value="attention">Custom group order</option><option value="attention_inverted">Working-first preset</option></select></label><div class="option agent-sort-order" id="optAgentStatusOrder"><div><strong>Agent group order</strong><small>Move status groups with arrows. Idle green, working yellow, blocked red, done blue, others gray. Saved in this browser.</small></div><div class="agent-sort-list" id="agentStatusOrderList"></div></div><label class="option"><span>Workspace panel size<small>Percent of sidebar height used by Workspaces. Drag separator or type a percent.</small></span><input id="optSidebarWorkspacePercent" type="number" min="20" max="80" step="1"></label><label class="option"><span>Parent workspace close<small>Close panels only (keeps linked worktrees running) or full close with re-open (stops processes, re-opens worktrees with fresh shells).</small></span><select class="settings-select" id="optParentCloseMode"><option value="panels">Close panels only</option><option value="close">Full close + re-open worktrees</option></select></label><label class="option"><input type="checkbox" id="optStuckWorkingEnabled"><span>Ignore stuck working agents<small>Dismiss working agents that appear stuck. Clears automatically on status changes and terminal output.</small></span></label><label class="option"><span>Ignore stuck working for<small>Minutes to keep a local dismissed-working override before showing working again.</small></span><input id="optWorkingDismissMinutes" type="number" min="1" max="1440" step="1"></label><label class="option"><input type="checkbox" id="optShowTabActivity"><span>Show panel last update<small>Display local last-change age on top panel tabs. Updates on refreshes, events, and selected terminal output; no timer polling.</small></span></label><label class="option"><span>Workspace sorting<small>Default tree order, shared drag-and-drop order, or attention state priority.</small></span><select class="settings-select" id="optWorkspaceSort"><option value="default">Default</option><option value="drag">Drag&drop</option><option value="state">State</option></select></label><label class="option"><span>Notification scope<small>Choose whether alerts fire in every open tab or only the tab viewing the agent panel.</small></span><select class="settings-select" id="optSoundScope"><option value="current">Current agent tab</option><option value="all">All tabs</option></select></label><label class="option"><span>Notification volume<small><span id="notificationVolumeValue">24</span>% for local attention tone.</small></span><input type="range" id="optNotificationVolume" min="0" max="100" step="1"></label><label class="option"><input type="checkbox" id="optGenerateWorktreeNames"><span>Generate worktree branch names<small>Allow blank Branch name in Worktrees modal. Herdr generates worktree/&lt;name&gt;.</small></span></label><label class="option"><span>Worktree default directory<small>Base directory for generated worktree checkout paths. Relative paths resolve from repo root. Example: ../worktrees.</small></span><input id="optWorktreeDefaultDirectory" placeholder="../worktrees"></label><label class="option"><span>Exploration default directory<small>Prefills new/open workspace, worktree discovery, and Git cleanup scan paths.</small></span><input id="optExplorationDefaultDirectory" placeholder="~/Documents/code"></label><label class="option"><span>Scroll speed<small><span id="scrollLinesValue">3</span> terminal lines per wheel step.</small></span><input type="range" id="optScrollLines" min="1" max="20" step="1"></label><label class="option"><span>Worktree autodiscover<small>Seconds to wait after path input stops. Set 0 for immediate.</small></span><input type="number" id="optWorktreeAutoDiscover" min="0" max="30" step="0.5"></label>',
     );
 const showTabActivitySetting = el("optShowTabActivity");
 if (showTabActivitySetting && !el("optTreeIndentPx"))
@@ -1446,6 +1496,7 @@ function applyOptions() {
     themeSelect = el("optTheme"),
     closeShortcut = el("optCloseShortcut"),
     sortAgents = el("optAgentSortMode"),
+    sidebarWorkspacePercent = el("optSidebarWorkspacePercent"),
     parentCloseMode = el("optParentCloseMode"),
     stuckWorkingEnabled = el("optStuckWorkingEnabled"),
     workingDismissMinutes = el("optWorkingDismissMinutes"),
@@ -1490,6 +1541,15 @@ function applyOptions() {
   if (closeShortcutCurrent)
     closeShortcutCurrent.textContent = closeShortcutLabel();
   if (sortAgents) sortAgents.value = options.agentSortMode || "off";
+  if (sidebarWorkspacePercent)
+    sidebarWorkspacePercent.value = String(
+      Math.round(options.sidebarWorkspacePercent ?? 68),
+    );
+  document.body.style.setProperty(
+    "--sidebar-workspace-percent",
+    `${options.sidebarWorkspacePercent ?? 68}%`,
+  );
+  renderAgentStatusOrderSettings();
   if (parentCloseMode)
     parentCloseMode.value = options.parentCloseMode || "panels";
   if (stuckWorkingEnabled)
@@ -1548,6 +1608,37 @@ function applyOptions() {
       if (typeof Terminal !== "undefined") connectTerminal();
     }
   }
+}
+function renderAgentStatusOrderSettings() {
+  const list = el("agentStatusOrderList"),
+    container = el("optAgentStatusOrder");
+  if (!list || !container) return;
+  const disabled = options.agentSortMode === "off";
+  container.classList.toggle("disabled", disabled);
+  const byKey = Object.fromEntries(agentStatusGroups.map((group) => [group[0], group]));
+  list.innerHTML = normalizeAgentStatusOrder(options.agentStatusOrder)
+    .map((key, index, order) => {
+      const [, label, color] = byKey[key] || [key, key, "gray"];
+      return `<div class="agent-sort-row" data-status="${escapeAttr(key)}"><span class="agent-sort-chip ${escapeAttr(color)}">${escapeHtml(label)}</span><span class="agent-sort-buttons"><button type="button" class="mini" ${index === 0 ? "disabled" : ""} onclick="moveAgentStatusGroup('${escapeAttr(key)}',-1)">↑</button><button type="button" class="mini" ${index === order.length - 1 ? "disabled" : ""} onclick="moveAgentStatusGroup('${escapeAttr(key)}',1)">↓</button></span></div>`;
+    })
+    .join("");
+}
+function moveAgentStatusGroup(key, delta) {
+  const order = normalizeAgentStatusOrder(options.agentStatusOrder);
+  const index = order.indexOf(key);
+  const nextIndex = index + delta;
+  if (index < 0 || nextIndex < 0 || nextIndex >= order.length) return;
+  [order[index], order[nextIndex]] = [order[nextIndex], order[index]];
+  options.agentStatusOrder = order;
+  if (options.agentSortMode === "off") options.agentSortMode = "attention";
+  saveOptions();
+  applyOptions();
+  render();
+}
+function setSidebarWorkspacePercent(value) {
+  options.sidebarWorkspacePercent = normalizeSidebarWorkspacePercent(value);
+  saveOptions();
+  applyOptions();
 }
 function syncThemeColorInputs() {
   for (const mode of ["dark", "light"]) {

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -965,6 +965,16 @@ const agentStatusGroups = [
   ["other", "Others", "gray"],
 ];
 const agentStatusGroupKeys = agentStatusGroups.map(([key]) => key);
+const agentStatusGroupByKey = Object.fromEntries(
+  agentStatusGroups.map((group) => [group[0], group]),
+);
+const workingFirstAgentStatusOrder = [
+  "blocked",
+  "working",
+  "other",
+  "done",
+  "idle",
+];
 function normalizeAgentStatusOrder(value) {
   const seen = new Set();
   const order = [];
@@ -990,16 +1000,17 @@ function loadOptions() {
     const stored = JSON.parse(localStorage.getItem("herdr-web-options") || "{}");
     if (stored.overflow === true && stored.terminalOverflowOptIn !== true)
       stored.overflow = false;
-    return {
-      ...defaultOptions,
-      ...stored,
-    };
+    return stored;
   } catch (_) {
     return { ...defaultOptions };
   }
 }
 function normalizeOptions(value) {
   const next = { ...defaultOptions, ...(value || {}) };
+  const hasStoredAgentStatusOrder = Object.prototype.hasOwnProperty.call(
+    value || {},
+    "agentStatusOrder",
+  );
   delete next.shiftEnter;
   if (next.captureCmdW === true || next.closeShortcut === true)
     next.closeShortcut = "altw";
@@ -1031,14 +1042,8 @@ function normalizeOptions(value) {
   if (!["off", "attention", "attention_inverted"].includes(next.agentSortMode))
     next.agentSortMode = defaultOptions.agentSortMode;
   next.agentStatusOrder = normalizeAgentStatusOrder(next.agentStatusOrder);
-  if (next.agentSortMode === "attention_inverted")
-    next.agentStatusOrder = normalizeAgentStatusOrder([
-      "blocked",
-      "working",
-      "other",
-      "done",
-      "idle",
-    ]);
+  if (next.agentSortMode === "attention_inverted" && !hasStoredAgentStatusOrder)
+    next.agentStatusOrder = normalizeAgentStatusOrder(workingFirstAgentStatusOrder);
   if (!["panels", "close"].includes(next.parentCloseMode))
     next.parentCloseMode = defaultOptions.parentCloseMode;
   next.stuckWorkingEnabled = next.stuckWorkingEnabled !== false;
@@ -1542,13 +1547,7 @@ function applyOptions() {
     closeShortcutCurrent.textContent = closeShortcutLabel();
   if (sortAgents) sortAgents.value = options.agentSortMode || "off";
   if (sidebarWorkspacePercent)
-    sidebarWorkspacePercent.value = String(
-      Math.round(options.sidebarWorkspacePercent ?? 68),
-    );
-  document.body.style.setProperty(
-    "--sidebar-workspace-percent",
-    `${options.sidebarWorkspacePercent ?? 68}%`,
-  );
+    applySidebarWorkspacePercent(options.sidebarWorkspacePercent ?? 68);
   renderAgentStatusOrderSettings();
   if (parentCloseMode)
     parentCloseMode.value = options.parentCloseMode || "panels";
@@ -1615,10 +1614,9 @@ function renderAgentStatusOrderSettings() {
   if (!list || !container) return;
   const disabled = options.agentSortMode === "off";
   container.classList.toggle("disabled", disabled);
-  const byKey = Object.fromEntries(agentStatusGroups.map((group) => [group[0], group]));
   list.innerHTML = normalizeAgentStatusOrder(options.agentStatusOrder)
     .map((key, index, order) => {
-      const [, label, color] = byKey[key] || [key, key, "gray"];
+      const [, label, color] = agentStatusGroupByKey[key] || [key, key, "gray"];
       return `<div class="agent-sort-row" data-status="${escapeAttr(key)}"><span class="agent-sort-chip ${escapeAttr(color)}">${escapeHtml(label)}</span><span class="agent-sort-buttons"><button type="button" class="mini" ${index === 0 ? "disabled" : ""} onclick="moveAgentStatusGroup('${escapeAttr(key)}',-1)">↑</button><button type="button" class="mini" ${index === order.length - 1 ? "disabled" : ""} onclick="moveAgentStatusGroup('${escapeAttr(key)}',1)">↓</button></span></div>`;
     })
     .join("");
@@ -1638,14 +1636,17 @@ function moveAgentStatusGroup(key, delta) {
 function setSidebarWorkspacePercent(value) {
   options.sidebarWorkspacePercent = normalizeSidebarWorkspacePercent(value);
   saveOptions();
-  applyOptions();
+  applySidebarWorkspacePercent(options.sidebarWorkspacePercent);
 }
-function previewSidebarWorkspacePercent(value) {
+function applySidebarWorkspacePercent(value) {
   const percent = normalizeSidebarWorkspacePercent(value);
   document.body.style.setProperty("--sidebar-workspace-percent", `${percent}%`);
   const input = el("optSidebarWorkspacePercent");
   if (input) input.value = String(percent);
   return percent;
+}
+function previewSidebarWorkspacePercent(value) {
+  return applySidebarWorkspacePercent(value);
 }
 function syncThemeColorInputs() {
   for (const mode of ["dark", "light"]) {

--- a/src/assets/desktop/app_js/render.js
+++ b/src/assets/desktop/app_js/render.js
@@ -568,14 +568,13 @@ function agentAttentionCompare(a, b) {
   return aRank - bRank;
 }
 function agentAttentionRank(a) {
-  const status = statusClass(a.agent_status);
-  if (status === "blocked") return 0;
-  if (options.agentSortMode === "attention_inverted") {
-    if (isWorkingDismissed(a)) return 2;
-    return { working: 1, unknown: 3, done: 4, idle: 5 }[status] ?? 3;
-  }
-  if (isWorkingDismissed(a)) return 4;
-  return { idle: 1, done: 2, unknown: 3, working: 5 }[status] ?? 3;
+  const status = isWorkingDismissed(a) ? "idle" : statusClass(a.agent_status);
+  const group = ["idle", "working", "blocked", "done"].includes(status)
+    ? status
+    : "other";
+  const order = normalizeAgentStatusOrder(options.agentStatusOrder);
+  const rank = order.indexOf(group);
+  return rank >= 0 ? rank : order.length;
 }
 function agentToken(cls, value) {
   const s = String(value || "");


### PR DESCRIPTION
## Summary
- add browser-persisted custom agent status group ordering with colored controls
- add resizable Workspaces/Agents sidebar split stored as an integer percent
- document the feature in README and Help & Shortcuts

## Validation
- node --check src/assets/desktop/app_js/core.js
- node --test src/assets/app_load.test.mjs src/assets/app_core.test.mjs src/assets/app_boot.test.mjs src/assets/mobile_load.test.mjs
- cargo check