### PR TITLE
Fix large terminal paste handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The Rust binary embeds frontend assets with `include_str!`, so release artifacts
 - CodeMirror, desktop Git UI, and desktop file browser JavaScript are lazy-loaded. Initial desktop/mobile terminal loads should not download editor or Git/File feature code until those features are opened.
 - The shared editor uses lightweight read-only previews by default and loads CodeMirror only for editable file views.
 - Desktop terminal output is frame-batched in the browser so bursts of WebSocket terminal frames are coalesced before xterm rendering. Pending frames are flushed before reconnect or close to avoid dropping final output.
-- Large terminal paste input is chunked with WebSocket backpressure instead of being sent as one very large browser frame.
+- Large terminal paste input is sent as semantic paste events instead of xterm `paste()` calls or key-by-key raw input. Browser frames are bounded so very large clipboards do not block the renderer or exceed backend payload limits.
 - Terminal links are optional in Settings. When enabled, desktop and mobile xterm instances detect `http`/`https` URLs and open them in a new browser tab.
 - Blocking browser confirmation dialogs count as input delay in Chrome traces. Git bulk section actions defer their API/render work until after the confirmation returns so dialog wait time is not mixed with mutation/render cost.
 - File search inputs preserve focus and cursor selection while async results render. Prefer `renderPreservingScroll`/focus-preserving render paths when refreshing filter-driven lists so typing does not get interrupted by DOM replacement.
@@ -266,7 +266,7 @@ The Rust binary embeds frontend assets with `include_str!`, so release artifacts
 
 ## Desktop And Mobile Parity
 
-- Both layouts support workspace selection, agent list/attention status, panel selection/creation/closing, linked worktree listing/creation/opening, terminal attach, terminal paste sanitization, terminal scrollback follow/Tail behavior, terminal links, Files browsing with backend search/filter, Git status viewing with file filtering, read-only Git file diffs, Settings, theme choice, browser notifications, local attention tone volume, file tree indentation, and layout preference.
+- Both layouts support workspace selection, agent list/attention status, panel selection/creation/closing, linked worktree listing/creation/opening, terminal attach, semantic terminal paste, terminal scrollback follow/Tail behavior, terminal links, Files browsing with backend search/filter, Git status viewing with file filtering, read-only Git file diffs, Settings, theme choice, browser notifications, local attention tone volume, file tree indentation, and layout preference.
 - Desktop is the full power-user layout. It includes the embedded Git drawer with mutations, diffs, log, stash, cleanup, blame, file history, hunk actions, conflict actions, shortcuts, and the editable file browser with split panes.
 - Mobile is intentionally narrower. It keeps navigation, agents, worktrees, terminal, Files preview with go-up navigation, Git status, and read-only Git file diffs usable on small screens, but does not yet expose desktop Git mutations/log/stash/cleanup/blame/history or file editing/split panes.
 - When adding a desktop feature, decide explicitly whether mobile needs full parity, read-only parity, or documentation as desktop-only. Keep this section updated so mobile gaps are intentional.
@@ -281,7 +281,7 @@ The Rust binary embeds frontend assets with `include_str!`, so release artifacts
 - Terminal panel tabs also scroll horizontally, and terminal output scrolls inside `.mobile-terminal-shell` instead of pushing the app wider or taller.
 - Mobile terminal tabs include `+` to create a panel and `✕` to close the current panel. The Panels screen also exposes `Close current panel` for discoverability.
 - Mobile terminal scrollback mirrors desktop behavior: scrolling up pauses follow, new output preserves the current viewport, and `Tail` jumps to latest output and resumes follow.
-- Mobile paste/input uses bounded WebSocket chunks with backpressure, matching the desktop large-paste protection.
+- Mobile paste uses the same semantic paste WebSocket message as desktop. Normal typed input still uses bounded raw WebSocket chunks with backpressure.
 - Mobile Git file diffs render hunks inside horizontally scrollable code blocks so long lines do not widen the app shell.
 
 TODO:
@@ -442,10 +442,13 @@ Parent workspace close with linked worktrees:
 
 Terminal paste:
 
-- Pasted text is sanitized before reaching the terminal. Newlines (`\r\n`, `\r`, `\n`) are converted to spaces, and trailing spaces are trimmed.
-- This prevents pasted multiline text from auto-submitting terminal input via implicit Enter.
-- Both desktop and mobile terminals capture paste events in the capture phase before xterm or native handlers process them.
-- Desktop paste sends small input directly and chunks larger paste payloads into bounded frames with WebSocket backpressure, reducing browser main-thread stalls from large clipboard pastes.
+- Both desktop and mobile terminals capture browser `paste` events in the capture phase before xterm or native handlers process them.
+- WebUI intentionally does not call xterm.js `terminal.paste(text)`. xterm parses that string synchronously on the browser main thread, which can freeze the UI for large code snippets.
+- The browser sends `{"type":"paste","text":"..."}` text WebSocket messages to `/ws/terminal`. Payloads are split into 512 KiB chunks to stay under Herdr's 1 MiB input-event limit; chunk boundaries avoid splitting UTF-16 surrogate pairs.
+- `terminal_text_messages()` in `src/main.rs` maps those JSON messages to `ClientMessage::InputEvents { events: [ClientInputEvent::Paste { text }] }` before forwarding them over the Herdr direct terminal attach protocol.
+- Herdr's backend paste path preserves multiline text and applies bracketed paste wrapping based on the real terminal runtime state. WebUI no longer guesses bracketed-paste mode from xterm state and no longer converts pasted newlines to spaces.
+- Raw typed input, Shift+Enter, scroll, and resize messages keep their existing raw-input/JSON paths. Only clipboard paste uses the semantic paste event path.
+- The served bundles containing this logic are `/assets/desktop/app.js` for desktop and `/assets/mobile/terminal.js` for mobile. The shared helper in `/assets/shared/core.js` normalizes CRLF/CR to LF when used by fallback code.
 
 Terminal rendering performance:
 

--- a/src/assets/app_core.test.mjs
+++ b/src/assets/app_core.test.mjs
@@ -76,18 +76,18 @@ describe("normalizeAbsolutePath", () => {
 });
 
 describe("terminalPasteInput", () => {
-  it("converts pasted newlines to non-submitting spaces", () => {
-    assert.equal(terminalPasteInput("a\nb\r\nc\rd", false), "a b c d");
+  it("preserves pasted newlines while normalizing CRLF and CR", () => {
+    assert.equal(terminalPasteInput("a\nb\r\nc\rd", false), "a\nb\nc\nd");
   });
 
-  it("drops trailing pasted newlines", () => {
-    assert.equal(terminalPasteInput("run command\n", false), "run command");
+  it("preserves trailing pasted newlines", () => {
+    assert.equal(terminalPasteInput("run command\n", false), "run command\n");
   });
 
   it("wraps bracketed paste when enabled", () => {
     assert.equal(
       terminalPasteInput("hello\n", true),
-      "\x1b[200~hello\x1b[201~",
+      "\x1b[200~hello\n\x1b[201~",
     );
   });
 });

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -55,6 +55,7 @@ let term,
   tabActivity = {},
   closeChordUntil = 0,
   inputQueue = [],
+  inputQueueMaxBufferedAmount = 65536,
   inputFlushTimer = null,
   terminalWriteQueue = [],
   terminalWriteFlushPending = false,
@@ -2229,6 +2230,7 @@ function resetTerminalConnection(clear = false, destroy = false) {
     inputFlushTimer = null;
   }
   inputQueue = [];
+  inputQueueMaxBufferedAmount = 65536;
   if (terminalWriteQueue.length && typeof flushTerminalFrames === "function") flushTerminalFrames();
   terminalWriteQueue = [];
   terminalWriteFlushPending = false;

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -468,21 +468,23 @@ async function pasteClipboard() {
   if (text) pasteToTerminal(text);
   hideClipboardMenu();
 }
-function sendInputData(data) {
+function sendInputData(data, options = {}) {
   if (!termWs || termWs.readyState !== 1 || !data) return;
   const bytes = inputEncoder.encode(data);
-  const chunkSize = 16 * 1024;
+  const chunkSize = options.chunkSize || 16 * 1024;
+  const maxBufferedAmount = options.maxBufferedAmount || 65536;
   if (
     bytes.length <= chunkSize &&
     inputQueue.length === 0 &&
-    termWs.bufferedAmount < 65536
+    termWs.bufferedAmount < maxBufferedAmount
   ) {
     termWs.send(bytes);
     return;
   }
   for (let i = 0; i < bytes.length; i += chunkSize)
     inputQueue.push(bytes.slice(i, i + chunkSize));
-  scheduleInputFlush();
+  inputQueueMaxBufferedAmount = Math.max(inputQueueMaxBufferedAmount, maxBufferedAmount);
+  flushInputQueue();
 }
 function scheduleInputFlush() {
   if (inputFlushTimer) return;
@@ -492,11 +494,13 @@ function flushInputQueue() {
   inputFlushTimer = null;
   if (!termWs || termWs.readyState !== 1) {
     inputQueue = [];
+    inputQueueMaxBufferedAmount = 65536;
     return;
   }
-  while (inputQueue.length && termWs.bufferedAmount < 65536)
+  while (inputQueue.length && termWs.bufferedAmount < inputQueueMaxBufferedAmount)
     termWs.send(inputQueue.shift());
   if (inputQueue.length) scheduleInputFlush();
+  else inputQueueMaxBufferedAmount = 65536;
 }
 function finishPasteFrameSoon() {
   setTimeout(() => {
@@ -521,7 +525,7 @@ function pasteToTerminal(text) {
     finishPasteFrameSoon();
     return;
   }
-  sendInputData(input);
+  sendInputData(input, { chunkSize: 256 * 1024, maxBufferedAmount: 1024 * 1024 });
   finishPasteFrameSoon();
 }
 function showClipboardMenu(x, y) {

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -95,7 +95,7 @@ function connectTerminal() {
           !e.ctrlKey &&
           !e.metaKey
         ) {
-          pasteToTerminal(shiftEnterSequence());
+          sendInputData(shiftEnterSequence());
           return false;
         }
         if (
@@ -123,7 +123,7 @@ function connectTerminal() {
         if (!text) return;
         e.preventDefault();
         e.stopImmediatePropagation();
-        pasteToTerminal(text);
+        sendPasteToTerminal(text);
       },
       true,
     );
@@ -465,7 +465,7 @@ async function pasteClipboard() {
   } catch (e) {
     text = prompt("Paste text") || "";
   }
-  if (text) pasteToTerminal(text);
+  if (text) sendPasteToTerminal(text);
   hideClipboardMenu();
 }
 function sendInputData(data, options = {}) {
@@ -485,6 +485,22 @@ function sendInputData(data, options = {}) {
     inputQueue.push(bytes.slice(i, i + chunkSize));
   inputQueueMaxBufferedAmount = Math.max(inputQueueMaxBufferedAmount, maxBufferedAmount);
   flushInputQueue();
+}
+function sendPasteToTerminal(text) {
+  if (!termWs || termWs.readyState !== 1 || !text) return;
+  const chunkSize = 512 * 1024;
+  pasteFrameUntil = Date.now() + 250;
+  for (let i = 0; i < text.length;) {
+    let end = Math.min(i + chunkSize, text.length);
+    if (end < text.length && isHighSurrogate(text.charCodeAt(end - 1))) end -= 1;
+    if (end <= i) end = Math.min(i + chunkSize, text.length);
+    termWs.send(JSON.stringify({ type: "paste", text: text.slice(i, end) }));
+    i = end;
+  }
+  finishPasteFrameSoon();
+}
+function isHighSurrogate(code) {
+  return code >= 0xd800 && code <= 0xdbff;
 }
 function scheduleInputFlush() {
   if (inputFlushTimer) return;
@@ -507,26 +523,6 @@ function finishPasteFrameSoon() {
     pasteFrameUntil = 0;
     scheduleTerminalFrameWork();
   }, 250);
-}
-function pasteToTerminal(text) {
-  if (!termWs || termWs.readyState !== 1 || !text) return;
-  const input = terminalPasteInput(
-    text,
-    !!(term && term.modes && term.modes.bracketedPasteMode),
-  );
-  const bytes = inputEncoder.encode(input);
-  pasteFrameUntil = Date.now() + 250;
-  if (
-    bytes.length <= 64 * 1024 &&
-    inputQueue.length === 0 &&
-    termWs.bufferedAmount < 1024 * 1024
-  ) {
-    termWs.send(bytes);
-    finishPasteFrameSoon();
-    return;
-  }
-  sendInputData(input, { chunkSize: 256 * 1024, maxBufferedAmount: 1024 * 1024 });
-  finishPasteFrameSoon();
 }
 function showClipboardMenu(x, y) {
   const menu = el("clipboardMenu");

--- a/src/assets/mobile/terminal.js
+++ b/src/assets/mobile/terminal.js
@@ -149,11 +149,7 @@ function terminalLinksEnabled() {
             if (!text || !termWs || termWs.readyState !== 1) return;
             event.preventDefault();
             event.stopImmediatePropagation();
-            const paste = globalThis.HerdrAppHelpers.terminalPasteInput(
-              text,
-              !!(term && term.modes && term.modes.bracketedPasteMode),
-            );
-            sendInputData(paste);
+            sendPasteToTerminal(text);
           },
           true,
         );
@@ -338,6 +334,22 @@ function terminalLinksEnabled() {
       for (let i = 0; i < bytes.length; i += chunkSize)
         inputQueue.push(bytes.slice(i, i + chunkSize));
       scheduleInputFlush();
+    }
+
+    function sendPasteToTerminal(text) {
+      if (!termWs || termWs.readyState !== 1 || !text) return;
+      const chunkSize = 512 * 1024;
+      for (let i = 0; i < text.length;) {
+        let end = Math.min(i + chunkSize, text.length);
+        if (end < text.length && isHighSurrogate(text.charCodeAt(end - 1))) end -= 1;
+        if (end <= i) end = Math.min(i + chunkSize, text.length);
+        termWs.send(JSON.stringify({ type: "paste", text: text.slice(i, end) }));
+        i = end;
+      }
+    }
+
+    function isHighSurrogate(code) {
+      return code >= 0xd800 && code <= 0xdbff;
     }
 
     function scheduleInputFlush() {

--- a/src/assets/shared/core.js
+++ b/src/assets/shared/core.js
@@ -28,7 +28,7 @@
   }
 
   function terminalPasteInput(text, bracketedPasteMode) {
-    const normalized = String(text || "").replace(/\r\n|\r|\n/g, " ").replace(/ +$/, "");
+    const normalized = String(text || "").replace(/\r\n|\r/g, "\n");
     if (bracketedPasteMode) return "\x1b[200~" + normalized + "\x1b[201~";
     return normalized;
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2429,39 +2429,8 @@ async fn terminal_socket(path: PathBuf, query: TerminalQuery, mut socket: WebSoc
                         if in_tx.send(ClientMessage::Input { data: data.to_vec() }).is_err() { break; }
                     }
                     Some(Ok(Message::Text(text))) => {
-                        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
-                            if value.get("type").and_then(|value| value.as_str()) == Some("resize") {
-                                let cols = value.get("cols").and_then(|value| value.as_u64()).unwrap_or(100).min(u16::MAX as u64) as u16;
-                                let rows = value.get("rows").and_then(|value| value.as_u64()).unwrap_or(30).min(u16::MAX as u64) as u16;
-                                let _ = in_tx.send(ClientMessage::Resize { cols: cols.max(1), rows: rows.max(1), cell_width_px: 0, cell_height_px: 0 });
-                            } else if value.get("type").and_then(|value| value.as_str()) == Some("scroll") {
-                                let direction = match value.get("direction").and_then(|value| value.as_str()) {
-                                    Some("up") => AttachScrollDirection::Up,
-                                    Some("down") => AttachScrollDirection::Down,
-                                    _ => AttachScrollDirection::Down,
-                                };
-                                let lines = value.get("lines").and_then(|value| value.as_u64()).unwrap_or(3).clamp(1, u16::MAX as u64) as u16;
-                                let column = value.get("column").and_then(|value| value.as_u64()).and_then(|value| u16::try_from(value).ok());
-                                let row = value.get("row").and_then(|value| value.as_u64()).and_then(|value| u16::try_from(value).ok());
-                                let modifiers = value.get("modifiers").and_then(|value| value.as_u64()).and_then(|value| u8::try_from(value).ok()).unwrap_or(0);
-                                let _ = in_tx.send(ClientMessage::AttachScroll {
-                                    source: AttachScrollSource::Wheel,
-                                    direction,
-                                    lines,
-                                    column,
-                                    row,
-                                    modifiers,
-                                });
-                            } else if value.get("type").and_then(|value| value.as_str()) == Some("key") {
-                                if value.get("code").and_then(|value| value.as_str()) == Some("Enter") {
-                                    let modifiers = value.get("modifiers").and_then(|value| value.as_u64()).and_then(|value| u8::try_from(value).ok()).unwrap_or(0);
-                                    let _ = in_tx.send(ClientMessage::InputEvents { events: vec![ClientInputEvent::Key { code: ClientKeyCode::Enter, modifiers, kind: ClientKeyKind::Press }] });
-                                }
-                            } else if let Some(input) = value.get("input").and_then(|value| value.as_str()) {
-                                let _ = in_tx.send(ClientMessage::Input { data: input.as_bytes().to_vec() });
-                            }
-                        } else {
-                            let _ = in_tx.send(ClientMessage::Input { data: text.to_string().into_bytes() });
+                        for message in terminal_text_messages(&text) {
+                            if in_tx.send(message).is_err() { break; }
                         }
                     }
                     Some(Ok(Message::Close(_))) | None => break,
@@ -2472,6 +2441,101 @@ async fn terminal_socket(path: PathBuf, query: TerminalQuery, mut socket: WebSoc
         }
     }
     let _ = in_tx.send(ClientMessage::Detach);
+}
+
+fn terminal_text_messages(text: &str) -> Vec<ClientMessage> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
+        return vec![ClientMessage::Input {
+            data: text.as_bytes().to_vec(),
+        }];
+    };
+    match value.get("type").and_then(|value| value.as_str()) {
+        Some("resize") => {
+            let cols = value
+                .get("cols")
+                .and_then(|value| value.as_u64())
+                .unwrap_or(100)
+                .min(u16::MAX as u64) as u16;
+            let rows = value
+                .get("rows")
+                .and_then(|value| value.as_u64())
+                .unwrap_or(30)
+                .min(u16::MAX as u64) as u16;
+            vec![ClientMessage::Resize {
+                cols: cols.max(1),
+                rows: rows.max(1),
+                cell_width_px: 0,
+                cell_height_px: 0,
+            }]
+        }
+        Some("scroll") => {
+            let direction = match value.get("direction").and_then(|value| value.as_str()) {
+                Some("up") => AttachScrollDirection::Up,
+                Some("down") => AttachScrollDirection::Down,
+                _ => AttachScrollDirection::Down,
+            };
+            let lines = value
+                .get("lines")
+                .and_then(|value| value.as_u64())
+                .unwrap_or(3)
+                .clamp(1, u16::MAX as u64) as u16;
+            let column = value
+                .get("column")
+                .and_then(|value| value.as_u64())
+                .and_then(|value| u16::try_from(value).ok());
+            let row = value
+                .get("row")
+                .and_then(|value| value.as_u64())
+                .and_then(|value| u16::try_from(value).ok());
+            let modifiers = value
+                .get("modifiers")
+                .and_then(|value| value.as_u64())
+                .and_then(|value| u8::try_from(value).ok())
+                .unwrap_or(0);
+            vec![ClientMessage::AttachScroll {
+                source: AttachScrollSource::Wheel,
+                direction,
+                lines,
+                column,
+                row,
+                modifiers,
+            }]
+        }
+        Some("key") if value.get("code").and_then(|value| value.as_str()) == Some("Enter") => {
+            let modifiers = value
+                .get("modifiers")
+                .and_then(|value| value.as_u64())
+                .and_then(|value| u8::try_from(value).ok())
+                .unwrap_or(0);
+            vec![ClientMessage::InputEvents {
+                events: vec![ClientInputEvent::Key {
+                    code: ClientKeyCode::Enter,
+                    modifiers,
+                    kind: ClientKeyKind::Press,
+                }],
+            }]
+        }
+        Some("paste") => value
+            .get("text")
+            .and_then(|value| value.as_str())
+            .map(|text| {
+                vec![ClientMessage::InputEvents {
+                    events: vec![ClientInputEvent::Paste {
+                        text: text.to_string(),
+                    }],
+                }]
+            })
+            .unwrap_or_default(),
+        _ => value
+            .get("input")
+            .and_then(|value| value.as_str())
+            .map(|input| {
+                vec![ClientMessage::Input {
+                    data: input.as_bytes().to_vec(),
+                }]
+            })
+            .unwrap_or_default(),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3286,6 +3350,38 @@ mod tests {
             PROTOCOL_VERSION,
             "invalid local keybindings",
         ));
+    }
+
+    #[test]
+    fn terminal_text_messages_maps_paste_to_semantic_input_event() {
+        let messages = terminal_text_messages(
+            r#"{"type":"paste","text":"fn main() {\n    println!(\"hi\");\n}\n"}"#,
+        );
+
+        assert_eq!(
+            messages,
+            vec![ClientMessage::InputEvents {
+                events: vec![ClientInputEvent::Paste {
+                    text: "fn main() {\n    println!(\"hi\");\n}\n".to_string(),
+                }],
+            }]
+        );
+    }
+
+    #[test]
+    fn terminal_text_messages_keeps_legacy_input_json_and_plain_text() {
+        assert_eq!(
+            terminal_text_messages(r#"{"input":"abc"}"#),
+            vec![ClientMessage::Input {
+                data: b"abc".to_vec()
+            }]
+        );
+        assert_eq!(
+            terminal_text_messages("plain"),
+            vec![ClientMessage::Input {
+                data: b"plain".to_vec()
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route browser clipboard paste as semantic Herdr paste events instead of raw xterm/key input
- preserve multiline code and let the backend apply bracketed paste based on real terminal state
- bound large paste WebSocket frames and document the technical paste architecture

## Validation
- cargo fmt
- git diff --check
- node --test src/assets/app_core.test.mjs
- cargo test
- cargo build --release
- target/release/herdr-webui update-mac --verbose
- verified installed service serves updated desktop/mobile paste assets