### PR TITLE
Add HTTPS serving by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,48 @@
 version = 4
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -64,6 +102,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,10 +174,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "const-oid"
@@ -169,6 +250,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,14 +283,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -213,6 +324,22 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -266,6 +393,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -277,12 +415,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "herdr-webui"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "axum",
+ "axum-server",
  "bincode",
  "interprocess",
+ "rcgen",
  "serde",
  "serde_json",
  "sha2",
@@ -354,6 +519,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -380,6 +546,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "interprocess"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,7 +565,7 @@ dependencies = [
  "libc",
  "recvmsg",
  "widestring",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -397,6 +573,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "libc"
@@ -436,14 +622,30 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -456,6 +658,18 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -516,7 +730,20 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -524,6 +751,70 @@ name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -620,6 +911,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,8 +945,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -689,6 +992,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,7 +1023,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -716,6 +1038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +1057,19 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -804,6 +1149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +1201,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -858,10 +1218,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "zerocopy"
@@ -882,6 +1315,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"
@@ -9,8 +9,10 @@ description = "Web UI for an existing Herdr server"
 
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 bincode = { version = "2", features = ["serde"] }
 interprocess = "2.4.2"
+rcgen = "0.13"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Compatibility:
 
 Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested. WebUI 0.2.9 treats Herdr 0.7.2 protocol 15 as tested and retries protocol 14 for compatible older Herdr 0.7.x servers.
 
+## 0.2.10 Release Notes
+
+### HTTPS by default
+
+- Serves WebUI over HTTPS by default.
+- Generates and reuses a per-user app self-signed certificate at `~/.config/herdr/tls/self-signed-cert.pem` and `self-signed-key.pem` when no certificate files are available.
+- Keeps generated certificates independent from repos and worktrees, so restarts and reinstalls reuse the same local certificate until those files are deleted.
+- Adds `--https off|auto|self-signed|files` plus `--tls-cert` and `--tls-key` for opting out or using external certificates such as Let’s Encrypt files.
+- Persists TLS options in macOS LaunchAgent and Linux systemd install/update flows.
+
 ## 0.2.9 Release Notes
 
 ### Workspace and worktree opening
@@ -256,11 +266,11 @@ HERDR_WEB_HERDR_BIN=/opt/homebrew/bin/herdr make run-web-local
 ## CLI
 
 ```text
-herdr-webui [--verbose] [--bind HOST:PORT] [--session NAME] [--api-socket PATH] [--client-socket PATH]
+herdr-webui [--verbose] [--bind HOST:PORT] [--https off|auto|self-signed|files] [--tls-cert PATH --tls-key PATH] [--session NAME] [--api-socket PATH] [--client-socket PATH]
 herdr-webui --version
-herdr-webui install-mac [--verbose] [--bind HOST:PORT] [--session NAME]
+herdr-webui install-mac [--verbose] [--bind HOST:PORT] [--https off|auto|self-signed|files] [--tls-cert PATH --tls-key PATH] [--session NAME]
 herdr-webui update-mac [--verbose]
-herdr-webui install-linux [--bind HOST:PORT] [--session NAME]
+herdr-webui install-linux [--bind HOST:PORT] [--https off|auto|self-signed|files] [--tls-cert PATH --tls-key PATH] [--session NAME]
 herdr-webui update-linux
 herdr-webui start-mac | start [--verbose]
 herdr-webui stop-mac | stop [--verbose]
@@ -273,6 +283,26 @@ herdr-webui uninstall-linux
 ```
 
 Use `--verbose`, `-v`, or `HERDR_WEB_VERBOSE=1` with macOS service commands to print LaunchAgent diagnostics, including UID/EUID, launchctl domain, service target, plist path, and launchctl stderr.
+
+### HTTPS
+
+WebUI serves HTTPS by default. On startup it uses configured certificate files when available; otherwise it generates local self-signed certificates so local builds, installed services, and CI smoke runs work without external certificate tooling:
+
+```sh
+herdr-webui --https
+```
+
+The default mode is `auto`: WebUI checks whether configured certificate files are available; if not, it creates and reuses `~/.config/herdr/tls/self-signed-cert.pem` and `self-signed-key.pem` with `localhost`, `127.0.0.1`, and `::1` subject alternative names. Browsers will still warn because the fallback certificate is not trusted by the OS, but the transport is encrypted and works without network callbacks.
+
+Use existing certificates, including Let's Encrypt certificates managed outside WebUI, with:
+
+```sh
+herdr-webui --https files --tls-cert /path/fullchain.pem --tls-key /path/privkey.pem
+```
+
+Passing `--tls-cert` and `--tls-key` also enables `--https files` automatically. WebUI does not run ACME challenges itself, so GitHub Actions and local builds stay deterministic and do not need public DNS or port 80/443 access.
+
+If either configured cert file is missing when HTTPS starts, WebUI falls back to the generated self-signed certificate instead of failing startup. Use `--https off` to opt out and serve plain HTTP when you explicitly need it.
 
 ## Project Layout
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fs;
-use std::future::IntoFuture;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -14,6 +13,7 @@ use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use axum_server::tls_rustls::RustlsConfig;
 use interprocess::TryClone as _;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -71,6 +71,22 @@ struct WebConfig {
     session: Option<String>,
     api_socket: Option<PathBuf>,
     client_socket: Option<PathBuf>,
+    tls: TlsConfig,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TlsConfig {
+    mode: TlsMode,
+    cert_path: Option<PathBuf>,
+    key_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum TlsMode {
+    Off,
+    Auto,
+    SelfSigned,
+    Files,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -176,6 +192,10 @@ impl WebConfig {
         let mut session = None;
         let mut api_socket = None;
         let mut client_socket = None;
+        let mut tls_mode = TlsMode::Auto;
+        let mut tls_mode_set = false;
+        let mut cert_path = None;
+        let mut key_path = None;
         let mut index = 0;
         while index < args.len() {
             match args[index].as_str() {
@@ -202,6 +222,27 @@ impl WebConfig {
                         Some(PathBuf::from(required_arg(args, index, "--client-socket")?));
                     index += 2;
                 }
+                "--https" => {
+                    if args
+                        .get(index + 1)
+                        .is_some_and(|value| !value.starts_with('-'))
+                    {
+                        tls_mode = parse_tls_mode(required_arg(args, index, "--https")?)?;
+                        index += 2;
+                    } else {
+                        tls_mode = TlsMode::Auto;
+                        index += 1;
+                    }
+                    tls_mode_set = true;
+                }
+                "--tls-cert" => {
+                    cert_path = Some(PathBuf::from(required_arg(args, index, "--tls-cert")?));
+                    index += 2;
+                }
+                "--tls-key" => {
+                    key_path = Some(PathBuf::from(required_arg(args, index, "--tls-key")?));
+                    index += 2;
+                }
                 "help" | "--help" | "-h" => {
                     print_help();
                     std::process::exit(0);
@@ -214,12 +255,33 @@ impl WebConfig {
                 }
             }
         }
+        if !tls_mode_set && (cert_path.is_some() || key_path.is_some()) {
+            tls_mode = TlsMode::Auto;
+        }
         Ok(Self {
             bind,
             session,
             api_socket,
             client_socket,
+            tls: TlsConfig {
+                mode: tls_mode,
+                cert_path,
+                key_path,
+            },
         })
+    }
+}
+
+fn parse_tls_mode(value: &str) -> io::Result<TlsMode> {
+    match value {
+        "off" => Ok(TlsMode::Off),
+        "auto" => Ok(TlsMode::Auto),
+        "self-signed" | "selfsigned" | "self" => Ok(TlsMode::SelfSigned),
+        "files" | "cert" => Ok(TlsMode::Files),
+        other => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid --https mode: {other}; use off, auto, self-signed, or files"),
+        )),
     }
 }
 
@@ -251,11 +313,11 @@ fn print_help() {
 }
 
 fn help_text() -> &'static str {
-    "herdr-webui [--verbose] [--bind HOST:PORT] [--session NAME] [--api-socket PATH] [--client-socket PATH]\n\
+    "herdr-webui [--verbose] [--bind HOST:PORT] [--https off|auto|self-signed|files] [--tls-cert PATH --tls-key PATH] [--session NAME] [--api-socket PATH] [--client-socket PATH]\n\
 herdr-webui --version\n\
-herdr-webui install-mac [--verbose] [--bind HOST:PORT] [--session NAME]\n\
+herdr-webui install-mac [--verbose] [--bind HOST:PORT] [--https off|auto|self-signed|files] [--tls-cert PATH --tls-key PATH] [--session NAME]\n\
 herdr-webui update-mac [--verbose]\n\
-herdr-webui install-linux [--bind HOST:PORT] [--session NAME]\n\
+herdr-webui install-linux [--bind HOST:PORT] [--https off|auto|self-signed|files] [--tls-cert PATH --tls-key PATH] [--session NAME]\n\
 herdr-webui update-linux\n\
 herdr-webui start-mac | start [--verbose]\n\
 herdr-webui stop-mac | stop [--verbose]\n\
@@ -586,12 +648,13 @@ async fn main() -> io::Result<()> {
         workspace_orders: Arc::new(Mutex::new(HashMap::new())),
     };
 
-    serve_rebindable(state, rebind_rx).await
+    serve_rebindable(state, rebind_rx, config.tls).await
 }
 
 async fn serve_rebindable(
     state: WebState,
     mut rebind_rx: tokio::sync::watch::Receiver<SocketAddr>,
+    tls: TlsConfig,
 ) -> io::Result<()> {
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .map_err(io::Error::other)?;
@@ -603,21 +666,37 @@ async fn serve_rebindable(
         let listener = match tokio::net::TcpListener::bind(bind).await {
             Ok(listener) => listener,
             Err(err) => {
-                eprintln!("failed to bind http://{bind}: {err}");
+                eprintln!("failed to bind {}://{bind}: {err}", tls.scheme());
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
                 continue;
             }
         };
-        eprintln!("herdr-webui listening on http://{bind}");
+        eprintln!("herdr-webui listening on {}://{bind}", tls.scheme());
         let mut shutdown_rx = rebind_rx.clone();
-        let server = axum::serve(
-            listener,
-            app_router(state.clone()).into_make_service_with_connect_info::<SocketAddr>(),
-        )
-        .with_graceful_shutdown(async move {
-            let _ = shutdown_rx.changed().await;
-        })
-        .into_future();
+        let router = app_router(state.clone()).into_make_service_with_connect_info::<SocketAddr>();
+        let tls_config = tls.rustls_config().await?;
+        let server = async move {
+            match tls_config {
+                Some(tls_config) => {
+                    let handle = axum_server::Handle::new();
+                    let shutdown_handle = handle.clone();
+                    tokio::spawn(async move {
+                        let _ = shutdown_rx.changed().await;
+                        shutdown_handle.graceful_shutdown(None);
+                    });
+                    axum_server::from_tcp_rustls(listener.into_std()?, tls_config)
+                        .handle(handle)
+                        .serve(router)
+                        .await
+                }
+                None => axum::serve(listener, router)
+                    .with_graceful_shutdown(async move {
+                        let _ = shutdown_rx.changed().await;
+                    })
+                    .await
+                    .map_err(io::Error::other),
+            }
+        };
         tokio::pin!(server);
         tokio::select! {
             _ = sigterm.recv() => return Ok(()),
@@ -627,6 +706,78 @@ async fn serve_rebindable(
             }
         }
     }
+}
+
+impl TlsConfig {
+    fn scheme(&self) -> &'static str {
+        match self.mode {
+            TlsMode::Off => "http",
+            TlsMode::Auto | TlsMode::SelfSigned | TlsMode::Files => "https",
+        }
+    }
+
+    async fn rustls_config(&self) -> io::Result<Option<RustlsConfig>> {
+        match self.mode {
+            TlsMode::Off => Ok(None),
+            TlsMode::Auto | TlsMode::Files => {
+                if let Some((cert, key)) = self.available_cert_files() {
+                    return Ok(Some(RustlsConfig::from_pem_file(cert, key).await?));
+                }
+                if matches!(self.mode, TlsMode::Files) {
+                    eprintln!("configured TLS certificate files are not available; generating a self-signed certificate");
+                }
+                let (cert, key) = ensure_self_signed_cert()?;
+                Ok(Some(RustlsConfig::from_pem_file(cert, key).await?))
+            }
+            TlsMode::SelfSigned => {
+                let (cert, key) = ensure_self_signed_cert()?;
+                Ok(Some(RustlsConfig::from_pem_file(cert, key).await?))
+            }
+        }
+    }
+
+    fn available_cert_files(&self) -> Option<(&Path, &Path)> {
+        let cert = self.cert_path.as_deref()?;
+        let key = self.key_path.as_deref()?;
+        (cert.exists() && key.exists()).then_some((cert, key))
+    }
+}
+
+fn ensure_self_signed_cert() -> io::Result<(PathBuf, PathBuf)> {
+    let (cert_path, key_path) = self_signed_cert_paths(&config_dir());
+    if cert_path.exists() && key_path.exists() {
+        return Ok((cert_path, key_path));
+    }
+    let dir = cert_path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "self-signed cert path has no parent directory",
+        )
+    })?;
+    fs::create_dir_all(&dir)?;
+    let subject_alt_names = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "::1".to_string(),
+    ];
+    let certified = rcgen::generate_simple_self_signed(subject_alt_names)
+        .map_err(|err| io::Error::other(err.to_string()))?;
+    fs::write(&cert_path, certified.cert.pem())?;
+    fs::write(&key_path, certified.key_pair.serialize_pem())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&key_path, fs::Permissions::from_mode(0o600))?;
+    }
+    Ok((cert_path, key_path))
+}
+
+fn self_signed_cert_paths(config_dir: &Path) -> (PathBuf, PathBuf) {
+    let dir = config_dir.join("tls");
+    (
+        dir.join("self-signed-cert.pem"),
+        dir.join("self-signed-key.pem"),
+    )
 }
 
 fn app_router(state: WebState) -> Router {
@@ -2734,6 +2885,14 @@ mod tests {
         assert_eq!(config.session, None);
         assert_eq!(config.api_socket, None);
         assert_eq!(config.client_socket, None);
+        assert_eq!(config.tls.mode, TlsMode::Auto);
+    }
+
+    #[test]
+    fn parses_https_off_opt_out() {
+        let args = ["--https", "off"].map(String::from);
+
+        assert_eq!(WebConfig::parse(&args).unwrap().tls.mode, TlsMode::Off);
     }
 
     #[test]
@@ -2747,6 +2906,12 @@ mod tests {
             "/tmp/api.sock",
             "--client-socket",
             "/tmp/client.sock",
+            "--https",
+            "files",
+            "--tls-cert",
+            "/tmp/cert.pem",
+            "--tls-key",
+            "/tmp/key.pem",
         ]
         .map(String::from);
 
@@ -2762,6 +2927,59 @@ mod tests {
             config.client_socket.as_deref(),
             Some(Path::new("/tmp/client.sock"))
         );
+        assert_eq!(config.tls.mode, TlsMode::Files);
+        assert_eq!(
+            config.tls.cert_path.as_deref(),
+            Some(Path::new("/tmp/cert.pem"))
+        );
+        assert_eq!(
+            config.tls.key_path.as_deref(),
+            Some(Path::new("/tmp/key.pem"))
+        );
+    }
+
+    #[test]
+    fn parses_https_modes_and_infers_auto_mode() {
+        let bare_https = ["--https"].map(String::from);
+        let auto = ["--https", "auto"].map(String::from);
+        let self_signed = ["--https", "self-signed"].map(String::from);
+        let files = ["--tls-cert", "/tmp/cert.pem", "--tls-key", "/tmp/key.pem"].map(String::from);
+
+        assert_eq!(
+            WebConfig::parse(&bare_https).unwrap().tls.mode,
+            TlsMode::Auto
+        );
+        assert_eq!(WebConfig::parse(&auto).unwrap().tls.mode, TlsMode::Auto);
+        assert_eq!(
+            WebConfig::parse(&self_signed).unwrap().tls.mode,
+            TlsMode::SelfSigned
+        );
+        assert_eq!(WebConfig::parse(&files).unwrap().tls.mode, TlsMode::Auto);
+    }
+
+    #[test]
+    fn tls_files_mode_allows_missing_paths_for_self_signed_fallback() {
+        let missing_key = ["--https", "files", "--tls-cert", "/tmp/cert.pem"].map(String::from);
+
+        let config = WebConfig::parse(&missing_key).unwrap();
+
+        assert_eq!(config.tls.mode, TlsMode::Files);
+        assert_eq!(
+            config.tls.cert_path.as_deref(),
+            Some(Path::new("/tmp/cert.pem"))
+        );
+        assert_eq!(config.tls.key_path, None);
+    }
+
+    #[test]
+    fn self_signed_cert_paths_are_stable_per_user_config() {
+        let config = Path::new("/home/alice/.config/herdr");
+
+        let (cert, key) = self_signed_cert_paths(config);
+
+        assert_eq!(cert, config.join("tls/self-signed-cert.pem"));
+        assert_eq!(key, config.join("tls/self-signed-key.pem"));
+        assert!(!cert.starts_with("/home/alice/project"));
     }
 
     #[test]
@@ -2785,6 +3003,7 @@ mod tests {
         let missing = ["--bind"].map(String::from);
         let invalid_bind = ["--bind", "not-a-socket"].map(String::from);
         let unknown = ["--unknown"].map(String::from);
+        let invalid_https = ["--https", "letsencrypt"].map(String::from);
 
         assert_eq!(
             WebConfig::parse(&missing).unwrap_err().kind(),
@@ -2796,6 +3015,10 @@ mod tests {
         );
         assert_eq!(
             WebConfig::parse(&unknown).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert_eq!(
+            WebConfig::parse(&invalid_https).unwrap_err().kind(),
             io::ErrorKind::InvalidInput
         );
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::{WebConfig, INSTALL_LABEL};
+use crate::{TlsMode, WebConfig, INSTALL_LABEL};
 
 pub fn install_macos(config: WebConfig) -> io::Result<()> {
     ensure_macos_user_context()?;
@@ -21,7 +21,7 @@ pub fn install_macos(config: WebConfig) -> io::Result<()> {
     launchctl_required(&["kickstart", "-k", &service])?;
     println!("Installed {INSTALL_LABEL} at {}", plist.display());
     println!("Installed binary at {}", install_bin.display());
-    println!("Open http://{}", config.bind);
+    println!("Open {}://{}", config.tls.scheme(), config.bind);
     Ok(())
 }
 
@@ -92,7 +92,7 @@ pub fn install_linux(config: WebConfig) -> io::Result<()> {
     systemctl_user(&["enable", "--now", &format!("{INSTALL_LABEL}.service")])?;
     println!("Installed {INSTALL_LABEL} at {}", service.display());
     println!("Installed binary at {}", install_bin.display());
-    println!("Open http://{}", config.bind);
+    println!("Open {}://{}", config.tls.scheme(), config.bind);
     Ok(())
 }
 
@@ -230,6 +230,7 @@ fn mac_plist_xml(config: &WebConfig, install_bin: &Path) -> io::Result<String> {
         args.push("    <string>--session</string>".to_string());
         args.push(format!("    <string>{}</string>", xml_escape(session)));
     }
+    append_mac_tls_args(config, &mut args);
     Ok(format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -284,6 +285,7 @@ fn linux_service_unit(config: &WebConfig, install_bin: &Path) -> String {
         exec.push_str(" --session ");
         exec.push_str(&systemd_escape_arg(session));
     }
+    append_systemd_tls_args(config, &mut exec);
     let env = std::env::var("HERDR_WEB_HERDR_BIN")
         .ok()
         .filter(|value| !value.is_empty())
@@ -297,6 +299,69 @@ fn linux_service_unit(config: &WebConfig, install_bin: &Path) -> String {
     format!(
         "[Unit]\nDescription=Herdr WebUI\nAfter=network.target\n\n[Service]\nType=simple\n{env}ExecStart={exec}\nRestart=always\nRestartSec=2\n\n[Install]\nWantedBy=default.target\n"
     )
+}
+
+fn append_mac_tls_args(config: &WebConfig, args: &mut Vec<String>) {
+    match config.tls.mode {
+        TlsMode::Off => {}
+        TlsMode::Auto => {
+            args.push("    <string>--https</string>".to_string());
+            args.push("    <string>auto</string>".to_string());
+            append_mac_tls_file_args(config, args);
+        }
+        TlsMode::SelfSigned => {
+            args.push("    <string>--https</string>".to_string());
+            args.push("    <string>self-signed</string>".to_string());
+        }
+        TlsMode::Files => {
+            args.push("    <string>--https</string>".to_string());
+            args.push("    <string>files</string>".to_string());
+            append_mac_tls_file_args(config, args);
+        }
+    }
+}
+
+fn append_mac_tls_file_args(config: &WebConfig, args: &mut Vec<String>) {
+    if let Some(cert) = &config.tls.cert_path {
+        args.push("    <string>--tls-cert</string>".to_string());
+        args.push(format!(
+            "    <string>{}</string>",
+            xml_escape(&cert.display().to_string())
+        ));
+    }
+    if let Some(key) = &config.tls.key_path {
+        args.push("    <string>--tls-key</string>".to_string());
+        args.push(format!(
+            "    <string>{}</string>",
+            xml_escape(&key.display().to_string())
+        ));
+    }
+}
+
+fn append_systemd_tls_args(config: &WebConfig, exec: &mut String) {
+    match config.tls.mode {
+        TlsMode::Off => {}
+        TlsMode::Auto => {
+            exec.push_str(" --https auto");
+            append_systemd_tls_file_args(config, exec);
+        }
+        TlsMode::SelfSigned => exec.push_str(" --https self-signed"),
+        TlsMode::Files => {
+            exec.push_str(" --https files");
+            append_systemd_tls_file_args(config, exec);
+        }
+    }
+}
+
+fn append_systemd_tls_file_args(config: &WebConfig, exec: &mut String) {
+    if let Some(cert) = &config.tls.cert_path {
+        exec.push_str(" --tls-cert ");
+        exec.push_str(&systemd_escape_arg(&cert.display().to_string()));
+    }
+    if let Some(key) = &config.tls.key_path {
+        exec.push_str(" --tls-key ");
+        exec.push_str(&systemd_escape_arg(&key.display().to_string()));
+    }
 }
 
 fn systemd_escape_arg(value: &str) -> String {
@@ -466,6 +531,11 @@ mod tests {
             session: Some("work".to_string()),
             api_socket: None,
             client_socket: None,
+            tls: crate::TlsConfig {
+                mode: TlsMode::Off,
+                cert_path: None,
+                key_path: None,
+            },
         };
 
         let unit = linux_service_unit(&config, Path::new("/tmp/herdr-webui"));
@@ -482,6 +552,11 @@ mod tests {
             session: Some("work session's path".to_string()),
             api_socket: None,
             client_socket: None,
+            tls: crate::TlsConfig {
+                mode: TlsMode::SelfSigned,
+                cert_path: None,
+                key_path: None,
+            },
         };
 
         let unit = linux_service_unit(&config, Path::new("/tmp/herdr webui"));
@@ -496,6 +571,11 @@ mod tests {
             session: Some("work".to_string()),
             api_socket: None,
             client_socket: None,
+            tls: crate::TlsConfig {
+                mode: TlsMode::Files,
+                cert_path: Some(PathBuf::from("/tmp/cert.pem")),
+                key_path: Some(PathBuf::from("/tmp/key.pem")),
+            },
         };
 
         let plist = mac_plist_xml(&config, Path::new("/tmp/herdr-webui")).unwrap();
@@ -505,6 +585,12 @@ mod tests {
         assert!(plist.contains("<string>127.0.0.1:8787</string>"));
         assert!(plist.contains("<string>--session</string>"));
         assert!(plist.contains("<string>work</string>"));
+        assert!(plist.contains("<string>--https</string>"));
+        assert!(plist.contains("<string>files</string>"));
+        assert!(plist.contains("<string>--tls-cert</string>"));
+        assert!(plist.contains("<string>/tmp/cert.pem</string>"));
+        assert!(plist.contains("<string>--tls-key</string>"));
+        assert!(plist.contains("<string>/tmp/key.pem</string>"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- serve HTTPS by default with auto fallback to generated local self-signed certificates
- add --https off|auto|self-signed|files and cert/key options
- persist TLS args in macOS/Linux service install paths
- document local self-signed and external certificate usage

## Validation
- cargo fmt --check
- cargo test --target-dir target
- cargo build --release --target-dir target
- HTTPS smoke with generated self-signed cert
- HTTP smoke with --https off
- local deploy with herdr-webui update-mac