### PR TITLE
Use bundled Nerd Font in desktop terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "herdr-webui"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Compatibility:
 
 Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested. WebUI 0.2.9 treats Herdr 0.7.2 protocol 15 as tested and retries protocol 14 for compatible older Herdr 0.7.x servers.
 
+## 0.2.11 Release Notes
+
+### Terminal Nerd Font icons
+
+- Uses the bundled JetBrainsMono Nerd Font stack when creating desktop xterm terminals so powerline and language icons render by default.
+- Migrates the old desktop monospace terminal default to the bundled Nerd Font stack while preserving custom user font-family settings.
+- Refreshes the desktop terminal after the web font loads so glyph metrics and icon rendering settle without reconnecting.
+
 ## 0.2.10 Release Notes
 
 ### HTTPS by default

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -185,7 +185,8 @@ describe("app bundle load", () => {
     ok(!source.includes('terminal.querySelector(".xterm-viewport")'));
     ok(!source.includes('terminal.querySelector(".xterm-rows")'));
     ok(!source.includes('shell.style.width ='));
-    ok(!source.includes("fontFamily: terminalFontFamily()"));
+    match(desktopTerminalSource, /fontFamily: terminalFontFamily\(\)/);
+    match(desktopTerminalSource, /refreshTerminalAfterFontLoad\(target\)/);
     match(source, /theme: terminalTheme\(\)/);
     match(source, /term\.options\.theme = terminalTheme\(\)/);
     match(source, /term\.setOption\("theme", terminalTheme\(\)\)/);
@@ -394,6 +395,8 @@ describe("app bundle load", () => {
     match(source, /id="optTerminalFontFamily"/);
     match(source, /id="optTerminalLinks"/);
     match(source, /JetBrainsMono Nerd Font/);
+    match(source, /LEGACY_TERMINAL_FONT_FAMILY/);
+    match(source, /HerdrAppHelpers\.resolveTerminalFontFamily\(""\)/);
     match(source, /handleGlobalShortcut/);
     match(source, /isShortcutPrefix/);
     match(source, /runPrefixedShortcut/);
@@ -403,6 +406,19 @@ describe("app bundle load", () => {
     match(source, /applyTerminalLinks/);
     match(source, /registerLinkProvider/);
     match(source, /buffer\.viewportY/);
+  });
+
+  it("migrates the old desktop monospace terminal default to the bundled Nerd Font", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    const normalized = vm.runInContext(
+      `normalizeOptions({ terminalFontFamily: "ui-monospace,SFMono-Regular,Menlo,monospace" }).terminalFontFamily`,
+      ctx,
+    );
+
+    match(normalized, /Herdr JetBrainsMono Nerd Font Mono/);
+    match(normalized, /Symbols Nerd Font Mono/);
   });
 
   it("normalizes configurable shortcut prefixes", () => {

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -926,6 +926,7 @@ function normalizeShortcutPrefix(value, fallback = DEFAULT_GLOBAL_SHORTCUT_PREFI
 }
 let themeMode = normalizeThemeMode(localStorage.getItem("herdr-web-theme")),
   lastEffectiveTheme = null;
+const LEGACY_TERMINAL_FONT_FAMILY = "ui-monospace,SFMono-Regular,Menlo,monospace";
 const defaultOptions = {
   overflow: false,
   terminalOverflowOptIn: false,
@@ -941,7 +942,7 @@ const defaultOptions = {
   webuiShortcuts: DEFAULT_WEBUI_SHORTCUTS,
   gitShortcuts: DEFAULT_GIT_SHORTCUTS,
   searchShortcut: "off",
-  terminalFontFamily: "ui-monospace,SFMono-Regular,Menlo,monospace",
+  terminalFontFamily: HerdrAppHelpers.resolveTerminalFontFamily(""),
   terminalLinks: true,
   agentSortMode: "off",
   agentStatusOrder: ["blocked", "idle", "done", "other", "working"],
@@ -1040,9 +1041,13 @@ function normalizeOptions(value) {
     String(next.searchShortcut || "").toLowerCase() === "off"
       ? "off"
       : normalizeShortcutPrefix(next.searchShortcut, "off");
-  next.terminalFontFamily =
-    String(next.terminalFontFamily || "").trim().slice(0, 200) ||
-    defaultOptions.terminalFontFamily;
+  next.terminalFontFamily = String(next.terminalFontFamily || "").trim().slice(0, 260);
+  if (
+    !next.terminalFontFamily ||
+    next.terminalFontFamily === LEGACY_TERMINAL_FONT_FAMILY
+  ) {
+    next.terminalFontFamily = defaultOptions.terminalFontFamily;
+  }
   next.terminalLinks = next.terminalLinks !== false;
   if (!["off", "attention", "attention_inverted"].includes(next.agentSortMode))
     next.agentSortMode = defaultOptions.agentSortMode;
@@ -1728,17 +1733,21 @@ function shiftEnterSequence() {
   return "\n";
 }
 function terminalFontFamily() {
-  return options.terminalFontFamily || defaultOptions.terminalFontFamily;
+  return HerdrAppHelpers.resolveTerminalFontFamily(options.terminalFontFamily);
 }
 function applyTerminalFont() {
   if (!term) return;
+  const family = terminalFontFamily();
   try {
-    term.options.fontFamily = terminalFontFamily();
+    term.options.fontFamily = family;
   } catch (e) {
     try {
-      term.setOption("fontFamily", terminalFontFamily());
+      term.setOption("fontFamily", family);
     } catch (_) {}
   }
+  try {
+    term.refresh(0, Math.max(0, (term.rows || 1) - 1));
+  } catch (_) {}
 }
 function applyTheme() {
   themeMode = normalizeThemeMode(themeMode);

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -75,9 +75,11 @@ function connectTerminal() {
     term = new Terminal({
       convertEol: false,
       theme: terminalTheme(),
+      fontFamily: terminalFontFamily(),
       scrollback: 10000,
     });
     term.open(terminal);
+    refreshTerminalAfterFontLoad(target);
     applyTerminalLinks();
     applyTheme();
     term.onData(sendInputData);
@@ -188,6 +190,20 @@ function connectTerminal() {
       scheduleRefreshBurst();
     }
   };
+}
+function refreshTerminalAfterFontLoad(terminalKey) {
+  const fonts = globalThis.document && globalThis.document.fonts;
+  if (!fonts || !fonts.load) return;
+  Promise.all([
+    fonts.load('14px "Herdr JetBrainsMono Nerd Font Mono"'),
+    fonts.ready,
+  ])
+    .then(() => {
+      if (!term || connectedTerminalId !== terminalKey) return;
+      applyTerminalFont();
+      fitTerminalSurface();
+    })
+    .catch(() => {});
 }
 function applyTerminalLinks() {
   if (terminalLinkProvider && terminalLinkProvider.dispose) {


### PR DESCRIPTION
## Summary
- use the bundled JetBrainsMono Nerd Font stack when creating desktop xterm terminals
- migrate the old stored desktop monospace default to the Nerd Font stack while preserving custom fonts
- refresh the terminal after the bundled font loads so icons and metrics settle
- bump release notes/version to v0.2.11

## Validation
- node --test src/assets/*.test.mjs
- cargo fmt --check
- cargo test --target-dir target
- local release build and update-mac smoke