### PR TITLE
Fix Git hunk editor compare alignment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Compatibility:
 
 | WebUI | Herdr | Protocol | Status | Notes |
 | --- | --- | --- | --- | --- |
-| `0.2.9` | `0.7.2` | `15` with `14` fallback | Current | Unifies workspace and worktree opening in one modal, adds always-discovered Git branches for worktree creation, shares refresh icon styling across Git/files/modals, and lets users continue worktree creation without pulling when fast-forward update detects diverging branches. |
+| `0.2.12` | `0.7.2` | `15` with `14` fallback | Current | Uses the same CodeMirror editor tooling for both sides of Git hunk editing, keeps the previous side read-only with line numbers on the right, and hides backing textareas so editable text is not duplicated below the highlighted editor. |
+| `0.2.11` | `0.7.2` | `15` with `14` fallback | Superseded | Uses the bundled JetBrainsMono Nerd Font stack when creating desktop xterm terminals, migrates the old desktop monospace default, and refreshes terminal metrics after the font loads. |
+| `0.2.9` | `0.7.2` | `15` with `14` fallback | Superseded | Unifies workspace and worktree opening in one modal, adds always-discovered Git branches for worktree creation, shares refresh icon styling across Git/files/modals, and lets users continue worktree creation without pulling when fast-forward update detects diverging branches. |
 | `0.2.8` | `0.7.2` | `15` with `14` fallback | Superseded | Restores terminal paste compatibility while keeping the performance fix: paste avoids xterm synchronous parsing and is sent as bounded WebSocket input chunks with backpressure. |
 | `0.2.7` | `0.7.2` | `15` with `14` fallback | Superseded | Fixes panel close reconciliation and terminal scroll/follow behavior. Superseded by 0.2.8 for terminal paste compatibility. |
 | `0.2.6` | `0.7.2` | `15` with `14` fallback | Tested | Adds configurable agent sorting and sidebar split, shared desktop/mobile terminal scrollback, file/folder browser search with editor readability improvements, and Git pull/push/rebase plus diff layout controls. |
@@ -38,7 +40,15 @@ Compatibility:
 | `0.0.45` | `0.7.1` | `14` | Tested | Improves embedded Git UI navigation with Escape handling, all-changes return behavior, split frontend assets, scoped file history controls, keyboard-owned drawer input, and per-file large diff loading. |
 | `0.0.45` | `0.7.0` | `14` | Minimum supported | Uses WebUI's legacy existing-branch worktree fallback when needed. |
 
-Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested. WebUI 0.2.9 treats Herdr 0.7.2 protocol 15 as tested and retries protocol 14 for compatible older Herdr 0.7.x servers.
+Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested. WebUI 0.2.12 treats Herdr 0.7.2 protocol 15 as tested and retries protocol 14 for compatible older Herdr 0.7.x servers.
+
+## 0.2.12 Release Notes
+
+### Git hunk editor compare alignment
+
+- Uses the shared CodeMirror editor for both previous and current hunk panes so text metrics, wrapping, and syntax highlighting align.
+- Keeps the previous pane read-only and moves its line numbers to the right side to match side-by-side compare expectations.
+- Hides the backing textareas that store hunk values so the current pane does not show duplicated plain text below the highlighted editor.
 
 ## 0.2.11 Release Notes
 

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -1319,6 +1319,8 @@ describe("app bundle load", () => {
     match(gitUiSource, /const sourceClass = side === "old" \? "git-ui-hunk-old-hidden" : "git-ui-hunk-current-hidden";/);
     ok(!gitUiSource.includes("<pre class=\"git-ui-editor-preview del\""));
     match(gitDiffCss, /\.git-ui-hunk-old-mount \.cm-content/);
+    match(gitDiffCss, /\.git-ui-hunk-old-mount \.cm-scroller \{\n\s+flex-direction: row-reverse;/);
+    match(gitDiffCss, /\.git-ui-hunk-old-mount \.cm-gutters \{\n\s+border-left: 1px solid var\(--border\);\n\s+border-right: 0;/);
     match(gitDiffCss, /\.git-ui-hunk-current-mount \.cm-content/);
   });
 });

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -1322,5 +1322,6 @@ describe("app bundle load", () => {
     match(gitDiffCss, /\.git-ui-hunk-old-mount \.cm-scroller \{\n\s+flex-direction: row-reverse;/);
     match(gitDiffCss, /\.git-ui-hunk-old-mount \.cm-gutters \{\n\s+border-left: 1px solid var\(--border\);\n\s+border-right: 0;/);
     match(gitDiffCss, /\.git-ui-hunk-current-mount \.cm-content/);
+    match(gitDiffCss, /\.git-ui-hunk-edit \{[\s\S]*?display: block;[\s\S]*?\.git-ui-hunk-editor textarea\.git-ui-hunk-edit-hidden \{\n\s+display: none;/);
   });
 });

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -1310,4 +1310,15 @@ describe("app bundle load", () => {
     match(gitUiSource, /function contextArrowsForChunk\(chunks, index\)/);
     match(gitUiSource, /const after = next \? hiddenGap\(chunk, next\) : false;/);
   });
+
+  it("uses the same editor mount tooling for previous and current hunk text", () => {
+    const gitDiffCss = readFileSync(new URL("./desktop/git_ui/diff.css", import.meta.url), "utf8");
+
+    match(gitUiSource, /git-ui-hunk-old-mount" data-hunk-index="\$\{hunk\.index\}" data-editor-side="old" data-readonly="true"/);
+    match(gitUiSource, /git-ui-hunk-current-mount" data-hunk-index="\$\{hunk\.index\}" data-editor-side="current" data-readonly="\$\{hunk\.newStart \? "false" : "true"\}"/);
+    match(gitUiSource, /const sourceClass = side === "old" \? "git-ui-hunk-old-hidden" : "git-ui-hunk-current-hidden";/);
+    ok(!gitUiSource.includes("<pre class=\"git-ui-editor-preview del\""));
+    match(gitDiffCss, /\.git-ui-hunk-old-mount \.cm-content/);
+    match(gitDiffCss, /\.git-ui-hunk-current-mount \.cm-content/);
+  });
 });

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -867,11 +867,7 @@
     const currentText = hunk.text || "";
     const readonly = hunk.newStart ? "" : " readonly";
     const meta = hunk.newStart ? `current lines ${hunk.newStart}-${hunk.newEnd}` : "no current lines";
-    return `<div class="git-ui-hunk-editor"><div class="git-ui-hunk-head"><span>${esc(hunk.header || "hunk")}</span><span class="git-ui-muted">${esc(meta)}</span></div><div class="git-ui-hunk-editor-grid"><section><div class="git-ui-editor-head"><strong>Previous</strong><span class="git-ui-muted">read-only</span></div><pre class="git-ui-editor-preview del"><code>${renderEditorLines(oldText, "old")}</code></pre></section><section><div class="git-ui-editor-head"><strong>Current</strong><span class="git-ui-muted">editable hunk</span></div><div class="git-ui-hunk-edit-mount" data-hunk-index="${hunk.index}" data-readonly="${hunk.newStart ? "false" : "true"}"></div><textarea class="git-ui-hunk-edit git-ui-hunk-edit-hidden" data-hunk-index="${hunk.index}" spellcheck="false"${readonly}>${esc(currentText)}</textarea></section></div></div>`;
-  }
-
-  function renderEditorLines(content, side) {
-    return String(content || "").split("\n").map((line) => `<span class="git-ui-editor-line ${side}">${highlight(line, active().file) || "\n"}</span>`).join("\n");
+    return `<div class="git-ui-hunk-editor"><div class="git-ui-hunk-head"><span>${esc(hunk.header || "hunk")}</span><span class="git-ui-muted">${esc(meta)}</span></div><div class="git-ui-hunk-editor-grid"><section><div class="git-ui-editor-head"><strong>Previous</strong><span class="git-ui-muted">read-only</span></div><div class="git-ui-hunk-edit-mount git-ui-hunk-old-mount" data-hunk-index="${hunk.index}" data-editor-side="old" data-readonly="true"></div><textarea class="git-ui-hunk-old git-ui-hunk-old-hidden git-ui-hunk-edit-hidden" data-hunk-index="${hunk.index}" spellcheck="false" readonly>${esc(oldText)}</textarea></section><section><div class="git-ui-editor-head"><strong>Current</strong><span class="git-ui-muted">editable hunk</span></div><div class="git-ui-hunk-edit-mount git-ui-hunk-current-mount" data-hunk-index="${hunk.index}" data-editor-side="current" data-readonly="${hunk.newStart ? "false" : "true"}"></div><textarea class="git-ui-hunk-edit git-ui-hunk-current-hidden git-ui-hunk-edit-hidden" data-hunk-index="${hunk.index}" spellcheck="false"${readonly}>${esc(currentText)}</textarea></section></div></div>`;
   }
 
   function buildEditableHunks(file) {
@@ -1492,18 +1488,26 @@
   function mountSideEditors() {
     const view = active() || {};
     if (!window.HerdrEditor || !view.sideEditor) return;
-    document.querySelectorAll(".git-ui-hunk-edit-mount[data-hunk-index]").forEach((mount) => {
+    const mounts = Array.from(document.querySelectorAll(".git-ui-hunk-edit-mount[data-hunk-index]"));
+    const mountAll = () => mounts.forEach((mount) => {
       const index = Number(mount.dataset.hunkIndex || 0);
-      const textarea = document.querySelector(`.git-ui-hunk-edit-hidden[data-hunk-index="${index}"]`);
+      const side = mount.dataset.editorSide || "current";
+      const sourceClass = side === "old" ? "git-ui-hunk-old-hidden" : "git-ui-hunk-current-hidden";
+      const textarea = document.querySelector(`.${sourceClass}[data-hunk-index="${index}"]`);
       if (!textarea) return;
       window.HerdrEditor.create({
         parent: mount,
         path: view.file || view.sideEditor.path || "",
         content: textarea.value,
         readonly: mount.dataset.readonly === "true",
-        onChange(value) { textarea.value = value; },
+        onChange: side === "old" ? null : function (value) { textarea.value = value; },
       });
     });
+    if (!window.HerdrCodeMirror && window.HerdrEditor.ensureCodeMirror) {
+      window.HerdrEditor.ensureCodeMirror().then(() => mountAll()).catch(() => mountAll());
+      return;
+    }
+    mountAll();
   }
 
   function draftKey(view) {

--- a/src/assets/desktop/git_ui/diff.css
+++ b/src/assets/desktop/git_ui/diff.css
@@ -157,6 +157,9 @@
   background: var(--bg);
   box-shadow: inset 0 0 0 2px rgba(56, 139, 253, 0.18);
 }
+.git-ui-hunk-editor textarea.git-ui-hunk-edit-hidden {
+  display: none;
+}
 .git-ui-hunk-edit[readonly] {
   color: var(--muted);
   cursor: not-allowed;

--- a/src/assets/desktop/git_ui/diff.css
+++ b/src/assets/desktop/git_ui/diff.css
@@ -70,6 +70,13 @@
   background: rgba(248, 81, 73, 0.1);
   border-left: 4px solid #da3633;
 }
+.git-ui-hunk-old-mount .cm-scroller {
+  flex-direction: row-reverse;
+}
+.git-ui-hunk-old-mount .cm-gutters {
+  border-left: 1px solid var(--border);
+  border-right: 0;
+}
 .git-ui-hunk-current-mount .cm-content,
 .git-ui-hunk-current-mount .herdr-editor-code {
   background: rgba(46, 160, 67, 0.1);

--- a/src/assets/desktop/git_ui/diff.css
+++ b/src/assets/desktop/git_ui/diff.css
@@ -50,6 +50,9 @@
   overflow: hidden;
 }
 .git-ui-hunk-edit-mount .herdr-editor {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+  height: 100%;
   min-height: 180px;
 }
 .git-ui-hunk-edit-mount .herdr-editor-head {
@@ -57,6 +60,20 @@
 }
 .git-ui-hunk-edit-mount .herdr-editor-mount {
   min-height: 180px;
+  overflow: hidden;
+}
+.git-ui-hunk-edit-mount .cm-editor {
+  height: 100%;
+}
+.git-ui-hunk-old-mount .cm-content,
+.git-ui-hunk-old-mount .herdr-editor-code {
+  background: rgba(248, 81, 73, 0.1);
+  border-left: 4px solid #da3633;
+}
+.git-ui-hunk-current-mount .cm-content,
+.git-ui-hunk-current-mount .herdr-editor-code {
+  background: rgba(46, 160, 67, 0.1);
+  border-left: 4px solid #1b7c3d;
 }
 .git-ui-split-editor {
   display: grid;


### PR DESCRIPTION
## Summary

- Use shared CodeMirror editor tooling for both sides of Git hunk editing.
- Keep the previous hunk pane read-only, with line numbers on the right.
- Hide backing hunk textareas to avoid duplicate unhighlighted text below the editor.
- Prepare v0.2.12 release notes and package version.

## Validation

- `make test`
- `cargo fmt --check`
- `cargo check --target-dir target`
- Local deploy via `make update-mac`
- Deployed CSS/JS smoke checks on `https://127.0.0.1:8787`
