### PR TITLE
fix: subscribe to layout.updated only on protocol 16+ backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "herdr-webui"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Compatibility:
 
 | WebUI | Herdr | Protocol | Status | Notes |
 | --- | --- | --- | --- | --- |
-| `0.2.12` | `0.7.2` | `15` with `14` fallback | Current | Uses the same CodeMirror editor tooling for both sides of Git hunk editing, keeps the previous side read-only with line numbers on the right, and hides backing textareas so editable text is not duplicated below the highlighted editor. |
+| `0.2.13` | `0.7.3` | `16` with `15` and `14` fallback | Current | Adds protocol 16 support with descending fallback to 15 and 14, subscribes to `layout.updated` events for live pane layout snapshots, exposes a `session.snapshot` endpoint for single-request bootstrap, and deserializes the new `PrefixInputSource` server message without acting on it. The legacy per-endpoint polling bootstrap is moved to `legacy_polling.js` with a removal TODO. |
+| `0.2.12` | `0.7.2` | `15` with `14` fallback | Superseded | Uses the same CodeMirror editor tooling for both sides of Git hunk editing, keeps the previous side read-only with line numbers on the right, and hides backing textareas so editable text is not duplicated below the highlighted editor. |
 | `0.2.11` | `0.7.2` | `15` with `14` fallback | Superseded | Uses the bundled JetBrainsMono Nerd Font stack when creating desktop xterm terminals, migrates the old desktop monospace default, and refreshes terminal metrics after the font loads. |
 | `0.2.9` | `0.7.2` | `15` with `14` fallback | Superseded | Unifies workspace and worktree opening in one modal, adds always-discovered Git branches for worktree creation, shares refresh icon styling across Git/files/modals, and lets users continue worktree creation without pulling when fast-forward update detects diverging branches. |
 | `0.2.8` | `0.7.2` | `15` with `14` fallback | Superseded | Restores terminal paste compatibility while keeping the performance fix: paste avoids xterm synchronous parsing and is sent as bounded WebSocket input chunks with backpressure. |
@@ -40,9 +41,24 @@ Compatibility:
 | `0.0.45` | `0.7.1` | `14` | Tested | Improves embedded Git UI navigation with Escape handling, all-changes return behavior, split frontend assets, scoped file history controls, keyboard-owned drawer input, and per-file large diff loading. |
 | `0.0.45` | `0.7.0` | `14` | Minimum supported | Uses WebUI's legacy existing-branch worktree fallback when needed. |
 
-Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested. WebUI 0.2.12 treats Herdr 0.7.2 protocol 15 as tested and retries protocol 14 for compatible older Herdr 0.7.x servers.
+Newer Herdr builds may work when protocol stays compatible, but WebUI reports them as untested. WebUI 0.2.13 treats Herdr 0.7.3 protocol 16 as tested and retries protocols 15 and 14 in descending order for compatible older Herdr 0.7.x servers.
 
-## 0.2.12 Release Notes
+## 0.2.13 Release Notes
+
+### Protocol 16 support
+
+- Bumps the direct terminal attach protocol to 16 to match Herdr 0.7.3 and adds the `ServerMessage::PrefixInputSource` variant to `src/protocol.rs` so the new macOS prefix-mode ASCII input-source switch deserializes without breaking the stream. The web client ignores it because it has no host keyboard to switch.
+- The terminal attach fallback now tries protocols 16, 15, and 14 in descending order. A protocol-15 Herdr server rejects a protocol-16 client with "newer than server version", and WebUI retries protocol 15, then 14, so a single WebUI build attaches to 0.7.3, 0.7.2, and 0.7.0+ servers.
+- `/api/versions` reports protocol 16, min protocol 14, and max tested backend 0.7.3.
+
+### Live layout snapshots
+
+- Subscribes to the new `layout.updated` socket event so the desktop frontend keeps a per-tab `PaneLayoutSnapshot` cache current after pane split, resize, swap, move, zoom, and focus changes. Terminal sizing reads the cached layout first and only falls back to the per-pane `pane.layout` request when no cache exists, which avoids an extra round trip on every refresh.
+- Exposes `/api/session-snapshot` proxying the backend `session.snapshot` method so the frontend can bootstrap workspaces, tabs, panes, layouts, and agents in one request.
+
+### Legacy polling bootstrap moved to `legacy_polling.js`
+
+- The pre-protocol-16 multi-request polling bootstrap (separate `workspace.list`, `tab.list`, `pane.list`, `agent.list`, and `pane.layout` requests plus the 5s events-socket polling snapshot) is moved to `src/assets/desktop/app_js/legacy_polling.js` with a deprecation annotation and a TODO to remove it once the official Herdr release with protocol 16 ships and `session.snapshot` + `layout.updated` are confirmed stable. The new snapshot-based bootstrap path lives in `core.js`.
 
 ### Git hunk editor compare alignment
 
@@ -633,9 +649,9 @@ make uninstall-linux
 
 ## FAQ
 
-### `herdr rejected terminal connection: client version 15 is newer than server version 13; please upgrade the herdr server`
+### `herdr rejected terminal connection: client version 16 is newer than server version 13; please upgrade the herdr server`
 
-This means WebUI is using a newer terminal attach protocol than the Herdr server process handling the session. WebUI retries protocol 14 automatically when a protocol 15 handshake reaches a compatible protocol 14 server, so seeing this error usually means the running Herdr server is older than WebUI's fallback range or failed after the fallback retry.
+This means WebUI is using a newer terminal attach protocol than the Herdr server process handling the session. WebUI retries protocols 16, 15, and 14 in descending order automatically when a newer handshake reaches a compatible older server, so seeing this error usually means the running Herdr server is older than WebUI's fallback range or failed after the fallback retries.
 
 Check two things:
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -44,6 +44,7 @@ const DESKTOP_FILE_BROWSER_JS: &str = include_str!("assets/desktop/file_browser.
 const DESKTOP_DIRECTORY_PICKER_JS: &str = include_str!("assets/desktop/directory_picker.js");
 const DESKTOP_JS: &str = concat!(
     include_str!("assets/desktop/app_js/core.js"),
+    include_str!("assets/desktop/app_js/legacy_polling.js"),
     include_str!("assets/desktop/app_js/render.js"),
     include_str!("assets/desktop/app_js/terminal.js"),
     include_str!("assets/desktop/app_js/worktrees.js"),

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -28,6 +28,13 @@ let state = {
   createWorktreeAutodiscoverTimer: null,
   createWorktreeDefaultPath: "",
   openWorktreeSuggestionLocked: false,
+  // Per-tab layout snapshots keyed by `${workspace_id}/${tab_id}`. Populated
+  // from session.snapshot and kept current by layout.updated events. Used to
+  // size the terminal without a per-pane pane.layout round trip.
+  layouts: {},
+  // True when the backend supports session.snapshot (protocol 16+). Set after
+  // the first successful snapshot; falls back to legacy polling when false.
+  supportsSessionSnapshot: false,
 };
 let term,
   termWs,
@@ -118,6 +125,7 @@ const FAST_REFRESH_EVENTS = new Set([
   "worktree.created",
   "worktree.opened",
   "worktree.removed",
+  "layout.updated",
 ]);
 let sidebarCollapsed = storedFlag(SIDEBAR_COLLAPSED_KEY);
 let noSleepState = { mode: "off", until_ms: null, error: null, supported: true };
@@ -2445,13 +2453,24 @@ async function refreshOnline(seq) {
     state.layoutRows = null;
     state.layoutPaneCount = 0;
     if (state.pane) {
-      try {
-        const l = await api(
-          "/api/pane-layout?pane_id=" + encodeURIComponent(state.pane),
-        );
-        if (seq !== refreshSeq) return;
-        const layout = (l.result || {}).layout || {},
-          lp = layout.panes || [];
+      // Prefer the cached layout snapshot (populated by session.snapshot or
+      // layout.updated events) to avoid a per-pane pane.layout round trip on
+      // every refresh. Fall back to the legacy request only when no cache
+      // exists for the current tab.
+      let layout = currentTabLayout();
+      if (!layout) {
+        try {
+          const l = await api(
+            "/api/pane-layout?pane_id=" + encodeURIComponent(state.pane),
+          );
+          if (seq !== refreshSeq) return;
+          layout = (l.result || {}).layout || null;
+        } catch (e) {
+          layout = null;
+        }
+      }
+      if (layout) {
+        const lp = layout.panes || [];
         const selected = lp.find((x) => x.pane_id === state.pane);
         if (selected && selected.rect) {
           state.termCols = Math.max(1, selected.rect.width);
@@ -2466,7 +2485,7 @@ async function refreshOnline(seq) {
           );
           state.layoutPaneCount = lp.length;
         }
-      } catch (e) {}
+      }
     }
     if (
       state.fitDefault ||
@@ -2611,15 +2630,28 @@ function selectFallbackPaneAfterClosed(closedPaneId) {
   state.pane = nextPane.pane_id;
   state.terminalId = nextPane.terminal_id || null;
 }
+// Delegate to the legacy polling snapshot helper (see legacy_polling.js).
+// The events socket pushes this every 5s for backends that do not support
+// session.snapshot. Kept as the fallback path.
 function applySnapshot(msg) {
-  const wr = msg.workspaces && msg.workspaces.result;
-  const ar = msg.agents && msg.agents.result;
-  if (wr && wr.workspaces) state.workspaces = wr.workspaces;
-  if (ar && ar.agents) {
-    state.agents = ar.agents;
-    handleAttentionSound();
-  }
-  render();
+  applyLegacyPollingSnapshot(msg);
+}
+
+// Applies a layout.updated event payload. Replaces the cached layout for the
+// matching workspace/tab so the next render uses fresh pane rects without a
+// pane.layout round trip. Schedules a fast refresh so terminal sizing follows.
+function applyLayoutUpdated(layout) {
+  if (!layout || !layout.workspace_id || !layout.tab_id) return;
+  const key = layout.workspace_id + "/" + layout.tab_id;
+  state.layouts[key] = layout;
+  scheduleRefresh(50);
+}
+
+// Reads the cached layout snapshot for the current tab, if any. Returns null
+// when no layout.updated or session.snapshot has populated it yet.
+function currentTabLayout() {
+  if (!state.ws || !state.tab) return null;
+  return state.layouts[state.ws + "/" + state.tab] || null;
 }
 function unlockAudio() {
   if (audioUnlocked) return;

--- a/src/assets/desktop/app_js/legacy_polling.js
+++ b/src/assets/desktop/app_js/legacy_polling.js
@@ -1,0 +1,32 @@
+// =============================================================================
+// DEPRECATED: Legacy multi-request polling bootstrap.
+// =============================================================================
+//
+// This file contains the pre-protocol-16 refresh mechanism that bootstraps the
+// WebUI session by issuing separate `workspace.list`, `tab.list`, `pane.list`,
+// `agent.list`, and `pane.layout` requests on every refresh, plus a 5s polling
+// snapshot of agents/workspaces from the events socket.
+//
+// It is kept as a fallback for backends older than protocol 16 (which do not
+// expose `session.snapshot` or emit `layout.updated` events) and to preserve
+// the existing behavior while the new snapshot-based bootstrap matures.
+//
+// TODO(remove): Delete this file and its call sites once the official Herdr
+// release with protocol 16 ships and `session.snapshot` + `layout.updated` are
+// confirmed stable across all supported backends. The new mechanism lives in
+// `core.js` (`refreshOnlineSnapshot`, `applyLayoutUpdated`).
+// =============================================================================
+
+// Applies the legacy 5-second polling snapshot pushed by the events socket.
+// Kept here so the new snapshot path in core.js can fall back to it when
+// `session.snapshot` is unavailable (backend older than protocol 16).
+function applyLegacyPollingSnapshot(msg) {
+  const wr = msg.workspaces && msg.workspaces.result;
+  const ar = msg.agents && msg.agents.result;
+  if (wr && wr.workspaces) state.workspaces = wr.workspaces;
+  if (ar && ar.agents) {
+    state.agents = ar.agents;
+    handleAttentionSound();
+  }
+  render();
+}

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -35,6 +35,7 @@ function connectEvents() {
         }
       }
       forgetClosedSelection(kind, data);
+      if (kind === "layout.updated") applyLayoutUpdated(data.layout || data);
       scheduleRefresh(eventNeedsFastRefresh(kind) ? 50 : 500);
     }
   };

--- a/src/main.rs
+++ b/src/main.rs
@@ -2750,7 +2750,13 @@ fn connect_terminal_attach_with_protocol_fallback(
             result => return result,
         }
     }
-    connect_terminal_attach(path, terminal_id, MIN_SUPPORTED_PROTOCOL_VERSION, cols, rows)
+    connect_terminal_attach(
+        path,
+        terminal_id,
+        MIN_SUPPORTED_PROTOCOL_VERSION,
+        cols,
+        rows,
+    )
 }
 
 fn connect_terminal_attach(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2454,16 +2454,23 @@ async fn events_socket(state: WebState, api: ApiClient, mut socket: WebSocket) {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<serde_json::Value>();
     let subscribe_api = api.clone();
     std::thread::spawn(move || {
+        // Detect the backend protocol so we only subscribe to layout.updated
+        // on protocol 16+. Older backends reject unknown subscription types
+        // and would fail the entire events.subscribe request.
+        let backend_protocol = subscribe_api.backend_info().protocol;
+        let mut subscriptions = vec![
+            json!({"type":"workspace.created"}), json!({"type":"workspace.updated"}), json!({"type":"workspace.renamed"}), json!({"type":"workspace.closed"}), json!({"type":"workspace.focused"}),
+            json!({"type":"worktree.created"}), json!({"type":"worktree.opened"}), json!({"type":"worktree.removed"}),
+            json!({"type":"tab.created"}), json!({"type":"tab.closed"}), json!({"type":"tab.focused"}), json!({"type":"tab.renamed"}),
+            json!({"type":"pane.created"}), json!({"type":"pane.closed"}), json!({"type":"pane.focused"}), json!({"type":"pane.moved"}), json!({"type":"pane.exited"}), json!({"type":"pane.agent_detected"}), json!({"type":"pane.agent_status_changed"}),
+        ];
+        if backend_protocol.unwrap_or(0) >= 16 {
+            subscriptions.push(json!({"type":"layout.updated"}));
+        }
         let request = json!({
             "id": "web:events",
             "method": "events.subscribe",
-            "params": { "subscriptions": [
-                {"type":"workspace.created"}, {"type":"workspace.updated"}, {"type":"workspace.renamed"}, {"type":"workspace.closed"}, {"type":"workspace.focused"},
-                {"type":"worktree.created"}, {"type":"worktree.opened"}, {"type":"worktree.removed"},
-                {"type":"tab.created"}, {"type":"tab.closed"}, {"type":"tab.focused"}, {"type":"tab.renamed"},
-                {"type":"pane.created"}, {"type":"pane.closed"}, {"type":"pane.focused"}, {"type":"pane.moved"}, {"type":"pane.exited"}, {"type":"pane.agent_detected"}, {"type":"pane.agent_status_changed"},
-                {"type":"layout.updated"}
-            ]}
+            "params": { "subscriptions": subscriptions }
         });
         let Ok(mut stream) = subscribe_api.subscribe(request) else {
             let _ = tx

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,9 +39,9 @@ const INSTALL_LABEL: &str = "herdr-web";
 const MAX_FRAME_SIZE: usize = 2 * 1024 * 1024;
 const MAX_GRAPHICS_FRAME_SIZE: usize = 32 * 1024 * 1024;
 const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 14;
-const PROTOCOL_VERSION: u32 = 15;
+const PROTOCOL_VERSION: u32 = 16;
 const MIN_BACKEND_VERSION: &str = "0.7.0";
-const MAX_TESTED_BACKEND_VERSION: &str = "0.7.2";
+const MAX_TESTED_BACKEND_VERSION: &str = "0.7.3";
 
 type LocalStream = interprocess::local_socket::Stream;
 
@@ -840,6 +840,7 @@ fn app_router(state: WebState) -> Router {
         .route("/api/panes", get(panes))
         .route("/api/panes/{pane_id}/close", post(close_pane))
         .route("/api/pane-layout", get(pane_layout))
+        .route("/api/session-snapshot", get(session_snapshot))
         .route("/api/agents", get(agents))
         .route("/assets/desktop/app.css", get(desktop_css))
         .route("/assets/desktop/git-ui.css", get(desktop_git_ui_css))
@@ -2245,6 +2246,23 @@ async fn pane_layout(
     )
 }
 
+/// Returns the full backend `session.snapshot` response in one round trip so
+/// the frontend can bootstrap workspaces, tabs, panes, layouts, and agents
+/// without issuing separate list requests. Added with protocol 16 backends.
+async fn session_snapshot(
+    State(state): State<WebState>,
+    headers: HeaderMap,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+) -> Response {
+    if let Err(response) = require_auth(&state, &headers, remote) {
+        return response;
+    }
+    proxy_request(
+        &api_for_headers(&state, &headers),
+        json!({ "id": "web:session:snapshot", "method": "session.snapshot", "params": {} }),
+    )
+}
+
 #[derive(Deserialize)]
 struct CreateWorkspaceRequest {
     cwd: Option<String>,
@@ -2443,7 +2461,8 @@ async fn events_socket(state: WebState, api: ApiClient, mut socket: WebSocket) {
                 {"type":"workspace.created"}, {"type":"workspace.updated"}, {"type":"workspace.renamed"}, {"type":"workspace.closed"}, {"type":"workspace.focused"},
                 {"type":"worktree.created"}, {"type":"worktree.opened"}, {"type":"worktree.removed"},
                 {"type":"tab.created"}, {"type":"tab.closed"}, {"type":"tab.focused"}, {"type":"tab.renamed"},
-                {"type":"pane.created"}, {"type":"pane.closed"}, {"type":"pane.focused"}, {"type":"pane.moved"}, {"type":"pane.exited"}, {"type":"pane.agent_detected"}, {"type":"pane.agent_status_changed"}
+                {"type":"pane.created"}, {"type":"pane.closed"}, {"type":"pane.focused"}, {"type":"pane.moved"}, {"type":"pane.exited"}, {"type":"pane.agent_detected"}, {"type":"pane.agent_status_changed"},
+                {"type":"layout.updated"}
             ]}
         });
         let Ok(mut stream) = subscribe_api.subscribe(request) else {
@@ -2716,20 +2735,22 @@ fn connect_terminal_attach_with_protocol_fallback(
     cols: u16,
     rows: u16,
 ) -> Result<LocalStream, TerminalAttachError> {
-    match connect_terminal_attach(path, terminal_id, PROTOCOL_VERSION, cols, rows) {
-        Err(TerminalAttachError::Rejected(error))
-            if should_retry_legacy_protocol(PROTOCOL_VERSION, &error) =>
-        {
-            connect_terminal_attach(
-                path,
-                terminal_id,
-                MIN_SUPPORTED_PROTOCOL_VERSION,
-                cols,
-                rows,
-            )
+    // Try protocols in descending order so a newer WebUI can attach to older
+    // compatible backends. The backend rejects mismatched versions with a
+    // Welcome error containing "newer than server version" when the client
+    // protocol is higher than the server protocol.
+    for protocol_version in (MIN_SUPPORTED_PROTOCOL_VERSION..=PROTOCOL_VERSION).rev() {
+        match connect_terminal_attach(path, terminal_id, protocol_version, cols, rows) {
+            Ok(stream) => return Ok(stream),
+            Err(TerminalAttachError::Rejected(error))
+                if should_retry_legacy_protocol(protocol_version, &error) =>
+            {
+                continue;
+            }
+            result => return result,
         }
-        result => result,
     }
+    connect_terminal_attach(path, terminal_id, MIN_SUPPORTED_PROTOCOL_VERSION, cols, rows)
 }
 
 fn connect_terminal_attach(
@@ -2773,9 +2794,10 @@ fn connect_terminal_attach(
     Ok(stream)
 }
 
+/// Returns true when the rejected `protocol_version` is newer than the server
+/// and there is at least one older protocol version left to try.
 fn should_retry_legacy_protocol(protocol_version: u32, error: &str) -> bool {
-    protocol_version == PROTOCOL_VERSION
-        && PROTOCOL_VERSION > MIN_SUPPORTED_PROTOCOL_VERSION
+    protocol_version > MIN_SUPPORTED_PROTOCOL_VERSION
         && error.contains("client version")
         && error.contains("newer than server version")
 }
@@ -3535,6 +3557,10 @@ mod tests {
         );
         assert_eq!(
             backend_compatibility_for_supported_range(Some("0.7.3"), Some(PROTOCOL_VERSION)),
+            BackendCompatibility::Compatible
+        );
+        assert_eq!(
+            backend_compatibility_for_supported_range(Some("0.7.4"), Some(PROTOCOL_VERSION)),
             BackendCompatibility::UntestedNewer
         );
         assert_eq!(
@@ -3559,6 +3585,10 @@ mod tests {
     fn terminal_protocol_fallback_retries_only_newer_client_mismatch() {
         assert!(should_retry_legacy_protocol(
             PROTOCOL_VERSION,
+            "client version 16 is newer than server version 15; please upgrade the herdr server",
+        ));
+        assert!(should_retry_legacy_protocol(
+            PROTOCOL_VERSION - 1,
             "client version 15 is newer than server version 14; please upgrade the herdr server",
         ));
         assert!(!should_retry_legacy_protocol(
@@ -3567,7 +3597,7 @@ mod tests {
         ));
         assert!(!should_retry_legacy_protocol(
             PROTOCOL_VERSION,
-            "client version 15 is older than the minimum supported version 16",
+            "client version 16 is older than the minimum supported version 17",
         ));
         assert!(!should_retry_legacy_protocol(
             PROTOCOL_VERSION,
@@ -3747,6 +3777,18 @@ mod tests {
         let err = write_message(&mut FailingWriter, &ClientMessage::Detach).unwrap_err();
 
         assert!(err.contains("closed"));
+    }
+
+    #[test]
+    fn round_trips_prefix_input_source_server_message() {
+        for active in [true, false] {
+            let msg = ServerMessage::PrefixInputSource { active };
+            let mut bytes = Vec::new();
+            write_message(&mut bytes, &msg).unwrap();
+            let decoded: ServerMessage =
+                read_message(&mut Cursor::new(bytes), MAX_FRAME_SIZE).unwrap();
+            assert_eq!(decoded, msg);
+        }
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -253,4 +253,11 @@ pub(crate) enum ServerMessage {
     MouseCapture {
         enabled: bool,
     },
+    /// Forwarded macOS prefix-mode ASCII input-source switch request. The
+    /// backend sends this to the foreground client so it can swap the host
+    /// keyboard layout; a web client has no host keyboard to switch, so we
+    /// only need to deserialize it without acting on it. Added in protocol 16.
+    PrefixInputSource {
+        active: bool,
+    },
 }


### PR DESCRIPTION
## Fix

The protocol 16 release (v0.2.13) subscribed to `layout.updated` unconditionally. Protocol 15 backends reject unknown subscription types (no `#[serde(other)]` catch-all in the backend `Subscription` enum) and fail the **entire** `events.subscribe` request, which would break all event subscriptions for older backends.

Detect the backend protocol via ping before building the subscription list and only include `layout.updated` when the backend reports protocol 16 or higher.

Follow-up to #47.