### PR TITLE
Prepare v0.2.14 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "herdr-webui"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.13"
+version = "0.2.14"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"


### PR DESCRIPTION
Bumps the static package version to 0.2.14 for the conditional layout.updated subscription hotfix (#49).

Protocol 15 backends reject unknown subscription types, so subscribing to layout.updated unconditionally broke all event subscriptions for older backends. #49 detects the backend protocol before subscribing.