### PR TITLE
fix: terminal flicker and last line cutoff

### DIFF
--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -125,7 +125,6 @@ const FAST_REFRESH_EVENTS = new Set([
   "worktree.created",
   "worktree.opened",
   "worktree.removed",
-  "layout.updated",
 ]);
 let sidebarCollapsed = storedFlag(SIDEBAR_COLLAPSED_KEY);
 let noSleepState = { mode: "off", until_ms: null, error: null, supported: true };
@@ -2639,12 +2638,35 @@ function applySnapshot(msg) {
 
 // Applies a layout.updated event payload. Replaces the cached layout for the
 // matching workspace/tab so the next render uses fresh pane rects without a
-// pane.layout round trip. Schedules a fast refresh so terminal sizing follows.
+// pane.layout round trip. Only triggers a terminal resize when the layout for
+// the currently focused tab changed, avoiding a full refresh storm.
 function applyLayoutUpdated(layout) {
   if (!layout || !layout.workspace_id || !layout.tab_id) return;
   const key = layout.workspace_id + "/" + layout.tab_id;
   state.layouts[key] = layout;
-  scheduleRefresh(50);
+  // Only act when the current tab's layout changed. A full refreshOnline
+  // re-fetches all tabs/panes/agents and can cause flicker, so we update
+  // terminal sizing directly instead.
+  if (state.ws === layout.workspace_id && state.tab === layout.tab_id && state.pane) {
+    const lp = layout.panes || [];
+    const selected = lp.find((x) => x.pane_id === state.pane);
+    if (selected && selected.rect) {
+      const prevCols = state.termCols;
+      const prevRows = state.termRows;
+      state.termCols = Math.max(1, selected.rect.width);
+      state.termRows = Math.max(1, selected.rect.height);
+      state.layoutCols = Math.max(1, (layout.area || {}).width || state.termCols);
+      state.layoutRows = Math.max(1, (layout.area || {}).height || state.termRows);
+      state.layoutPaneCount = lp.length;
+      // Only reconnect the terminal if the size actually changed.
+      if (prevCols !== state.termCols || prevRows !== state.termRows) {
+        if (typeof connectTerminal === "function") connectTerminal();
+      } else {
+        // Size unchanged, just update the surface dimensions.
+        if (typeof fitTerminalSurface === "function") fitTerminalSurface();
+      }
+    }
+  }
 }
 
 // Reads the cached layout snapshot for the current tab, if any. Returns null

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -35,8 +35,14 @@ function connectEvents() {
         }
       }
       forgetClosedSelection(kind, data);
-      if (kind === "layout.updated") applyLayoutUpdated(data.layout || data);
-      scheduleRefresh(eventNeedsFastRefresh(kind) ? 50 : 500);
+      if (kind === "layout.updated") {
+        applyLayoutUpdated(data.layout || data);
+        // layout.updated is handled directly by applyLayoutUpdated which
+        // updates terminal sizing without a full refresh. Skip the refresh
+        // to avoid flicker and unnecessary re-fetches.
+      } else {
+        scheduleRefresh(eventNeedsFastRefresh(kind) ? 50 : 500);
+      }
     }
   };
   ws.onclose = () => {
@@ -575,7 +581,16 @@ function fitTerminalSurface() {
     terminal.style.minHeight = height + "px";
   } else {
     terminal.style.width = "100%";
-    terminal.style.height = "";
+    // Cap the terminal height to the shell's inner height so the last row
+    // is not scrolled off when the backend layout rows produce a surface
+    // taller than the shell. Use the shell client height minus the padding
+    // (8px top + 8px bottom = 16px) as the upper bound.
+    const shellHeight = shell ? Math.max(0, shell.clientHeight - 16) : 0;
+    if (shellHeight > 0 && height > shellHeight) {
+      terminal.style.height = shellHeight + "px";
+    } else {
+      terminal.style.height = "";
+    }
     terminal.style.minWidth = "0";
     terminal.style.minHeight = "0";
   }


### PR DESCRIPTION
## Fixes

### Terminal flicker and lag from layout.updated events
The `layout.updated` event handler called `scheduleRefresh(50)` on every layout change, triggering a full `refreshOnline()` that re-fetched all tabs/panes/agents and re-evaluated terminal sizing. This caused flicker and lag, especially during split/resize operations.

Now `applyLayoutUpdated` updates terminal sizing **directly** from the cached `PaneLayoutSnapshot`:
- Only acts when the layout for the **currently focused tab** changed
- Only calls `connectTerminal()` when the `termCols`/`termRows` actually changed
- Otherwise just calls `fitTerminalSurface()` to update dimensions
- `layout.updated` removed from `FAST_REFRESH_EVENTS` and the event handler skips `scheduleRefresh` for it entirely

### Last terminal row cut off
When backend layout dimensions produced a terminal surface height (`Math.ceil(rowHeight * rows)`) taller than the shell, the last row was scrolled off and invisible.

`fitTerminalSurface` now caps the terminal element height to the shell's inner height (`clientHeight - 16px` padding) when not in overflow mode, so the last row stays visible.