### PR TITLE
feat: add temporary terminal overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "herdr-webui"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "axum",
  "axum-server",

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -11,6 +11,7 @@ const SHARED_CORE_JS: &str = include_str!("assets/shared/core.js");
 const SHARED_FILE_TREE_JS: &str = include_str!("assets/shared/file_tree.js");
 const SHARED_EDITOR_JS: &str = include_str!("assets/shared/editor.js");
 const SHARED_TERMINAL_SCROLL_JS: &str = include_str!("assets/shared/terminal_scroll.js");
+const SHARED_TEMP_TERMINAL_JS: &str = include_str!("assets/shared/temp_terminal.js");
 const VENDOR_CODEMIRROR_JS: &str = include_str!("assets/vendor/codemirror.bundle.js");
 const APP_BOOT_JS: &str = include_str!("assets/app_boot.js");
 const DESKTOP_CSS: &str = concat!(
@@ -127,6 +128,13 @@ pub(crate) async fn shared_editor_js() -> Response {
 pub(crate) async fn shared_terminal_scroll_js() -> Response {
     static_text(
         SHARED_TERMINAL_SCROLL_JS,
+        "application/javascript; charset=utf-8",
+    )
+}
+
+pub(crate) async fn shared_temp_terminal_js() -> Response {
+    static_text(
+        SHARED_TEMP_TERMINAL_JS,
         "application/javascript; charset=utf-8",
     )
 }

--- a/src/assets/app.html
+++ b/src/assets/app.html
@@ -17,7 +17,7 @@
           ><button class="mini" id="shortcutsToggle" title="Shortcuts">?</button
           ><button class="mini" id="settingsToggle" title="Settings">⚙</button
           ><button class="btn" id="newWs" title="Open or create workspace">＋</button
-          ><button class="mini" id="tempTerminalToggle" title="Temporary terminal">▢</button>
+          ><button class="mini temp-terminal-toggle" id="tempTerminalToggle" title="Temporary terminal" aria-label="Temporary terminal"><span class="temp-terminal-icon" aria-hidden="true"><span class="temp-terminal-icon-glyph"></span><span class="temp-terminal-icon-label">T</span></span></button>
         </div>
         <div class="section">
           <div class="muted" id="versions">webui - · backend -</div>

--- a/src/assets/app.html
+++ b/src/assets/app.html
@@ -16,7 +16,8 @@
           ><button class="mini" id="themeToggle" title="Toggle theme">☾</button
           ><button class="mini" id="shortcutsToggle" title="Shortcuts">?</button
           ><button class="mini" id="settingsToggle" title="Settings">⚙</button
-          ><button class="btn" id="newWs" title="Open or create workspace">＋</button>
+          ><button class="btn" id="newWs" title="Open or create workspace">＋</button
+          ><button class="mini" id="tempTerminalToggle" title="Temporary terminal">▢</button>
         </div>
         <div class="section">
           <div class="muted" id="versions">webui - · backend -</div>
@@ -108,6 +109,17 @@
         >
         <div class="modal-actions">
           <button class="btn" id="settingsClose">Close</button>
+        </div>
+      </div>
+    </div>
+    <div class="modal-backdrop temp-terminal-backdrop" id="tempTerminalModal">
+      <div class="temp-terminal-modal" role="dialog" aria-modal="true" aria-labelledby="tempTerminalTitle">
+        <div class="temp-terminal-head">
+          <h2 id="tempTerminalTitle">Temporary terminal</h2>
+          <button class="temp-terminal-close" id="tempTerminalClose" title="Close" aria-label="Close temporary terminal">✕</button>
+        </div>
+        <div class="temp-terminal-body">
+          <div class="terminal" id="tempTerminal"></div>
         </div>
       </div>
     </div>

--- a/src/assets/app_boot.js
+++ b/src/assets/app_boot.js
@@ -58,6 +58,7 @@
     loadScript("/assets/shared/file-tree.js");
     loadScript("/assets/shared/editor.js");
     loadScript("/assets/shared/terminal-scroll.js");
+    loadScript("/assets/shared/temp-terminal.js");
     if (mobile) {
       loadScript("/assets/mobile/core.js");
       loadScript("/assets/mobile/attention.js");

--- a/src/assets/desktop/app_css/modals.css
+++ b/src/assets/desktop/app_css/modals.css
@@ -233,3 +233,36 @@
   gap: 8px;
   justify-content: flex-end;
 }
+.temp-terminal-toggle {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+}
+.temp-terminal-icon {
+  align-items: center;
+  color: currentColor;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0;
+  height: 18px;
+  justify-content: center;
+  line-height: 1;
+  width: 18px;
+}
+.temp-terminal-icon-glyph {
+  background: currentColor;
+  display: block;
+  height: 12px;
+  mask-image: url("/assets/icons/terminal.svg");
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  width: 16px;
+}
+.temp-terminal-icon-label {
+  display: block;
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: -0.5px;
+  margin-top: -1px;
+}

--- a/src/assets/desktop/app_css/modals.css
+++ b/src/assets/desktop/app_css/modals.css
@@ -142,3 +142,62 @@
 .context-menu button:hover {
   background: var(--border);
 }
+
+/* Ephemeral temporary terminal overlay */
+.temp-terminal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: none;
+  place-items: center;
+  background: #000c;
+  z-index: 1200;
+}
+.temp-terminal-modal {
+  background: var(--panel);
+  border: 1px solid var(--border2);
+  border-radius: 14px;
+  box-shadow: 0 18px 50px #000a;
+  width: 90vw;
+  max-width: 1200px;
+  height: 80vh;
+  max-height: 800px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.temp-terminal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.temp-terminal-head h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+.temp-terminal-close {
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+.temp-terminal-close:hover {
+  background: var(--border);
+  color: var(--fg);
+}
+.temp-terminal-body {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+  padding: 4px;
+}
+.temp-terminal-body .terminal {
+  width: 100%;
+  height: 100%;
+}

--- a/src/assets/desktop/app_css/modals.css
+++ b/src/assets/desktop/app_css/modals.css
@@ -201,3 +201,35 @@
   width: 100%;
   height: 100%;
 }
+.temp-terminal-modal {
+  position: relative;
+}
+.temp-terminal-confirm {
+  position: absolute;
+  inset: 0;
+  display: none;
+  place-items: center;
+  background: #0009;
+  z-index: 2;
+}
+.temp-terminal-confirm-card {
+  background: var(--panel);
+  border: 1px solid var(--border2);
+  border-radius: 12px;
+  box-shadow: 0 14px 40px #000a;
+  max-width: 360px;
+  padding: 16px;
+}
+.temp-terminal-confirm-card h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+.temp-terminal-confirm-card p {
+  color: var(--muted);
+  margin: 0 0 14px;
+}
+.temp-terminal-confirm-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -596,11 +596,6 @@ if (globalThis.HerdrTempTerminal && el("tempTerminalModal")) {
   const tempTerminalClose = el("tempTerminalClose");
   const tempTerminalModal = el("tempTerminalModal");
   if (tempTerminalToggle) tempTerminalToggle.onclick = () => tempTerminal.open();
-  if (tempTerminalClose) tempTerminalClose.onclick = () => tempTerminal.close();
-  if (tempTerminalModal) {
-    tempTerminalModal.addEventListener("click", (event) => {
-      if (event.target === tempTerminalModal) tempTerminal.close();
-    });
-  }
+  if (tempTerminalClose) tempTerminalClose.onclick = () => tempTerminal.requestClose();
   window.addEventListener("resize", () => tempTerminal.handleResize());
 }

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -577,3 +577,30 @@ loadNoSleep();
 loadVersions();
 refresh();
 connectEvents();
+
+// Ephemeral temporary terminal overlay.
+if (globalThis.HerdrTempTerminal && el("tempTerminalModal")) {
+  tempTerminal = globalThis.HerdrTempTerminal.create({
+    el,
+    state,
+    wsUrl,
+    api,
+    modalId: "tempTerminalModal",
+    containerId: "tempTerminal",
+    buttonId: "tempTerminalToggle",
+    closeId: "tempTerminalClose",
+    fontFamilyFn: terminalFontFamily,
+    themeFn: terminalTheme,
+  });
+  const tempTerminalToggle = el("tempTerminalToggle");
+  const tempTerminalClose = el("tempTerminalClose");
+  const tempTerminalModal = el("tempTerminalModal");
+  if (tempTerminalToggle) tempTerminalToggle.onclick = () => tempTerminal.open();
+  if (tempTerminalClose) tempTerminalClose.onclick = () => tempTerminal.close();
+  if (tempTerminalModal) {
+    tempTerminalModal.addEventListener("click", (event) => {
+      if (event.target === tempTerminalModal) tempTerminal.close();
+    });
+  }
+  window.addEventListener("resize", () => tempTerminal.handleResize());
+}

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -71,7 +71,8 @@ let term,
   shortcutPrefixTimer = null,
   searchFramePending = false,
   searchResults = [],
-  searchSelectedIndex = 0;
+  searchSelectedIndex = 0,
+  tempTerminal = null;
 const SIDEBAR_COLLAPSED_KEY = "herdr-web-sidebar-collapsed";
 const DEFAULT_GLOBAL_SHORTCUT_PREFIX = "Ctrl+B";
 const DEFAULT_WEBUI_SHORTCUTS = {
@@ -2551,6 +2552,7 @@ function eventNeedsFastRefresh(kind) {
 }
 function forgetClosedSelection(kind, data) {
   if (kind === "pane.exited" && data && data.pane_id) {
+    if (tempTerminal && tempTerminal.handlePaneExited) tempTerminal.handlePaneExited(data.pane_id);
     closePaneById(data.pane_id)
       .then(() => scheduleRefresh(50))
       .catch(() => {});

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -456,6 +456,7 @@ function modalOpen() {
     "worktreeOpenModal",
     "shortcutsModal",
     "searchPalette",
+    "tempTerminalModal",
   ].some((id) => {
     const m = el(id);
     return m && m.style.display && m.style.display !== "none";

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -780,3 +780,36 @@ body.mobile-keyboard-open .mobile-screen.terminal-active .mobile-tabs {
   width: 100%;
   height: 100%;
 }
+.temp-terminal-modal {
+  position: relative;
+}
+.temp-terminal-confirm {
+  position: absolute;
+  inset: 0;
+  display: none;
+  place-items: center;
+  background: #0009;
+  z-index: 2;
+}
+.temp-terminal-confirm-card {
+  background: var(--panel, #1e1e2e);
+  border: 1px solid var(--border2, #45475a);
+  border-radius: 12px;
+  box-shadow: 0 14px 40px #000a;
+  max-width: min(360px, 84vw);
+  padding: 16px;
+}
+.temp-terminal-confirm-card h3 {
+  color: var(--fg, #cdd6f4);
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+.temp-terminal-confirm-card p {
+  color: var(--muted, #a6adc8);
+  margin: 0 0 14px;
+}
+.temp-terminal-confirm-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -722,3 +722,61 @@ body.mobile-keyboard-open .mobile-screen.terminal-active .mobile-tabs {
     grid-column: 1 / -1;
   }
 }
+
+/* Ephemeral temporary terminal overlay (mobile) */
+.temp-terminal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: none;
+  place-items: center;
+  background: #000c;
+  z-index: 1200;
+}
+.temp-terminal-modal {
+  background: var(--panel, #1e1e2e);
+  border: 1px solid var(--border2, #45475a);
+  border-radius: 14px;
+  margin: auto;
+  width: 95vw;
+  height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.temp-terminal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border, #313244);
+  flex-shrink: 0;
+}
+.temp-terminal-head h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg, #cdd6f4);
+}
+.temp-terminal-close {
+  background: transparent;
+  border: 0;
+  color: var(--muted, #a6adc8);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+.temp-terminal-close:hover {
+  background: var(--border, #313244);
+  color: var(--fg, #cdd6f4);
+}
+.temp-terminal-body {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+  padding: 4px;
+}
+.temp-terminal-body .terminal {
+  width: 100%;
+  height: 100%;
+}

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -813,3 +813,36 @@ body.mobile-keyboard-open .mobile-screen.terminal-active .mobile-tabs {
   gap: 8px;
   justify-content: flex-end;
 }
+.temp-terminal-toggle {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+}
+.temp-terminal-icon {
+  align-items: center;
+  color: currentColor;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0;
+  height: 18px;
+  justify-content: center;
+  line-height: 1;
+  width: 18px;
+}
+.temp-terminal-icon-glyph {
+  background: currentColor;
+  display: block;
+  height: 12px;
+  mask-image: url("/assets/icons/terminal.svg");
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  width: 16px;
+}
+.temp-terminal-icon-label {
+  display: block;
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: -0.5px;
+  margin-top: -1px;
+}

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -46,6 +46,7 @@
     mobileAttention,
     mobileSettings,
     mobileTerminal,
+    mobileTempTerminal,
     mobileFileBrowser,
     mobileWorktrees;
 
@@ -130,7 +131,12 @@
 
   function wsUrl(path) {
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
-    return `${proto}//${location.host}${path}`;
+    const sep = path.includes("?") ? "&" : "?";
+    const session =
+      state.session && state.session !== "default"
+        ? sep + "session=" + encodeURIComponent(state.session)
+        : "";
+    return `${proto}//${location.host}${path}${session}`;
   }
 
   function currentWorkspace() {
@@ -261,6 +267,7 @@
           <button class="mobile-btn" id="mobileBack" title="Home">←</button>
           <div class="mobile-context"><strong id="mobileTitle">Herdr</strong><span id="mobileMeta">Loading</span></div>
           <button class="mobile-btn" id="mobileSettings" title="Settings">⚙</button>
+          <button class="mobile-btn" id="mobileTempTerminal" title="Temporary terminal">▢</button>
         </header>
         <main class="mobile-screen" id="mobileScreen"></main>
         <nav class="mobile-nav">
@@ -272,9 +279,23 @@
           <button data-screen="git">Git</button>
           <button data-screen="terminal">Terminal</button>
         </nav>
+      </div>
+      <div class="temp-terminal-backdrop" id="tempTerminalModal">
+        <div class="temp-terminal-modal" role="dialog" aria-modal="true" aria-labelledby="tempTerminalTitle">
+          <div class="temp-terminal-head">
+            <h2 id="tempTerminalTitle">Temporary terminal</h2>
+            <button class="temp-terminal-close" id="tempTerminalClose" title="Close" aria-label="Close temporary terminal">✕</button>
+          </div>
+          <div class="temp-terminal-body">
+            <div class="terminal" id="tempTerminal"></div>
+          </div>
+        </div>
       </div>`;
     el("mobileBack").onclick = () => showScreen("home");
     el("mobileSettings").onclick = () => showScreen("settings");
+    el("mobileTempTerminal").onclick = () => mobileTempTerminal && mobileTempTerminal.open();
+    const tempClose = el("tempTerminalClose");
+    if (tempClose) tempClose.onclick = () => mobileTempTerminal && mobileTempTerminal.close();
     document.querySelectorAll(".mobile-nav button").forEach((button) => {
       button.onclick = () => showScreen(button.dataset.screen);
     });
@@ -763,7 +784,17 @@
     if (eventWs || !globalThis.WebSocket) return;
     const ws = new WebSocket(wsUrl("/ws/events"));
     eventWs = ws;
-    ws.onmessage = () => refresh();
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+        const evt = msg && msg.event;
+        const kind = evt && (evt.event || evt.type);
+        const data = (evt && evt.data) || {};
+        if (kind === "pane.exited" && mobileTempTerminal && mobileTempTerminal.handlePaneExited)
+          mobileTempTerminal.handlePaneExited(data.pane_id);
+      } catch (_) {}
+      refresh();
+    };
     ws.onclose = () => {
       if (eventWs === ws) eventWs = null;
       setTimeout(connectEvents, 1500);
@@ -786,6 +817,23 @@
     window,
   });
   mobileTerminal = globalThis.HerdrMobileTerminal.create({ el, state, wsUrl });
+  mobileTempTerminal = globalThis.HerdrTempTerminal.create({
+    el,
+    state,
+    wsUrl,
+    api,
+    modalId: "tempTerminalModal",
+    containerId: "tempTerminal",
+    fontFamilyFn: () => {
+      try {
+        const parsed = JSON.parse(localStorage.getItem("herdr-web-options") || "{}");
+        return globalThis.HerdrAppHelpers.resolveTerminalFontFamily(parsed.terminalFontFamily);
+      } catch (_) {
+        return globalThis.HerdrAppHelpers.resolveTerminalFontFamily("");
+      }
+    },
+  });
+  window.addEventListener("resize", () => mobileTempTerminal.handleResize());
   mobileSettings = globalThis.HerdrMobileSettings.create({
     applyTheme,
     escapeHtml,

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -267,7 +267,7 @@
           <button class="mobile-btn" id="mobileBack" title="Home">←</button>
           <div class="mobile-context"><strong id="mobileTitle">Herdr</strong><span id="mobileMeta">Loading</span></div>
           <button class="mobile-btn" id="mobileSettings" title="Settings">⚙</button>
-          <button class="mobile-btn" id="mobileTempTerminal" title="Temporary terminal">▢</button>
+          <button class="mobile-btn temp-terminal-toggle" id="mobileTempTerminal" title="Temporary terminal" aria-label="Temporary terminal"><span class="temp-terminal-icon" aria-hidden="true"><span class="temp-terminal-icon-glyph"></span><span class="temp-terminal-icon-label">T</span></span></button>
         </header>
         <main class="mobile-screen" id="mobileScreen"></main>
         <nav class="mobile-nav">

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -295,7 +295,7 @@
     el("mobileSettings").onclick = () => showScreen("settings");
     el("mobileTempTerminal").onclick = () => mobileTempTerminal && mobileTempTerminal.open();
     const tempClose = el("tempTerminalClose");
-    if (tempClose) tempClose.onclick = () => mobileTempTerminal && mobileTempTerminal.close();
+    if (tempClose) tempClose.onclick = () => mobileTempTerminal && mobileTempTerminal.requestClose();
     document.querySelectorAll(".mobile-nav button").forEach((button) => {
       button.onclick = () => showScreen(button.dataset.screen);
     });

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -1,0 +1,263 @@
+/**
+ * Ephemeral temporary terminal overlay.
+ *
+ * Opens a modal with a fresh xterm.js Terminal that connects to a new
+ * Herdr tab/pane created via the existing tab.create API.  The terminal
+ * is purely ephemeral: when the modal closes (X button, websocket drop,
+ * or server-side pane.exited event) the tab is closed via tab.close and
+ * all local state is discarded.  No server-side persistence is needed.
+ *
+ * Used by both desktop and mobile layouts.
+ */
+(function () {
+  function createTempTerminal(opts) {
+    var el = opts.el;
+    var state = opts.state;
+    var wsUrl = opts.wsUrl;
+    var api = opts.api;
+    var modalId = opts.modalId;
+    var containerId = opts.containerId;
+    var buttonId = opts.buttonId;
+    var closeId = opts.closeId;
+    var fontFamilyFn = opts.fontFamilyFn || function () { return "monospace"; };
+    var themeFn = opts.themeFn || function () { return {}; };
+
+    var term = null;
+    var termWs = null;
+    var createdTabId = null;
+    var createdPaneId = null;
+    var createdWorkspaceId = null;
+    var isOpen = false;
+    var closing = false;
+    var inputEncoder = new TextEncoder();
+    var writeQueue = [];
+    var writeFlushPending = false;
+    var resizeTimer = null;
+    var linkProvider = null;
+
+    function open() {
+      if (isOpen) return;
+      if (!state.ws) return;
+      isOpen = true;
+      closing = false;
+      var modal = el(modalId);
+      if (modal) modal.style.display = "grid";
+      var container = el(containerId);
+      if (container) container.innerHTML = "";
+      createTerminalSession();
+    }
+
+    function close() {
+      if (!isOpen) return;
+      isOpen = false;
+      closing = true;
+      disconnectWs();
+      disposeTerm();
+      var modal = el(modalId);
+      if (modal) modal.style.display = "none";
+      closeTab();
+      createdTabId = null;
+      createdPaneId = null;
+      createdWorkspaceId = null;
+    }
+
+    function createTerminalSession() {
+      if (!state.ws) { close(); return; }
+      api("/api/tabs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ workspace_id: state.ws, label: "temp" }),
+      }).then(function (res) {
+        var tab = res && res.result && res.result.tab;
+        if (!tab || !tab.tab_id) { close(); return; }
+        if (!isOpen) {
+          closeTabById(tab.tab_id);
+          return;
+        }
+        createdTabId = tab.tab_id;
+        createdWorkspaceId = state.ws;
+        return findCreatedPane(0);
+      }).then(function (pane) {
+        if (!isOpen || !pane) return;
+        if (!pane.terminal_id) { close(); return; }
+        createdPaneId = pane.pane_id || null;
+        connectTerminalWs(pane.terminal_id);
+      }).catch(function () { close(); });
+    }
+
+    function findCreatedPane(attempt) {
+      return api("/api/panes?workspace_id=" + encodeURIComponent(createdWorkspaceId || state.ws))
+        .then(function (res) {
+          var panes = (res.result && res.result.panes) || [];
+          var pane = panes.find(function (p) { return p.tab_id === createdTabId; });
+          if (pane || attempt >= 8) return pane || null;
+          return new Promise(function (resolve) {
+            setTimeout(function () { resolve(findCreatedPane(attempt + 1)); }, 100);
+          });
+        });
+    }
+
+    function connectTerminalWs(terminalId) {
+      var container = el(containerId);
+      if (!container) return;
+      var cols = 80, rows = 24;
+      if (container.clientWidth && container.clientHeight) {
+        cols = Math.max(40, Math.floor(container.clientWidth / 9));
+        rows = Math.max(10, Math.floor(container.clientHeight / 18));
+      }
+      if (!term) {
+        term = new Terminal({
+          convertEol: false,
+          fontFamily: fontFamilyFn(),
+          scrollback: 5000,
+          theme: themeFn(),
+        });
+        term.open(container);
+        term.onData(function (data) { sendInput(data); });
+        try { term.focus(); } catch (e) {}
+      }
+      try { term.resize(cols, rows); } catch (e) {}
+      var url = wsUrl(
+        "/ws/terminal?terminal_id=" + encodeURIComponent(terminalId) +
+        "&cols=" + cols + "&rows=" + rows +
+        "&temporary_tab_id=" + encodeURIComponent(createdTabId || "")
+      );
+      var ws = new WebSocket(url);
+      termWs = ws;
+      ws.binaryType = "arraybuffer";
+      ws.onopen = function () {
+        if (termWs === ws && term) try { term.focus(); } catch (e) {}
+      };
+      ws.onmessage = function (event) {
+        if (termWs !== ws) return;
+        enqueueFrame(typeof event.data === "string" ? event.data : new Uint8Array(event.data));
+      };
+      ws.onclose = function () {
+        if (termWs === ws) termWs = null;
+        if (isOpen && !closing) {
+          // Server-side terminal exited (e.g. user typed exit) or connection dropped.
+          close();
+        }
+      };
+    }
+
+    function disconnectWs() {
+      if (termWs) {
+        termWs.onclose = null;
+        try { termWs.close(); } catch (e) {}
+        termWs = null;
+      }
+    }
+
+    function disposeTerm() {
+      writeQueue = [];
+      writeFlushPending = false;
+      if (linkProvider && linkProvider.dispose) {
+        try { linkProvider.dispose(); } catch (e) {}
+      }
+      linkProvider = null;
+      if (term) {
+        try { term.dispose(); } catch (e) {}
+        term = null;
+      }
+      var container = el(containerId);
+      if (container) container.innerHTML = "";
+    }
+
+    function closeTab() {
+      if (!createdTabId) return;
+      var tabId = createdTabId;
+      createdTabId = null;
+      closeTabById(tabId);
+    }
+
+    function closeTabById(tabId) {
+      if (!tabId) return;
+      api("/api/tabs/" + encodeURIComponent(tabId) + "/close", { method: "POST" })
+        .catch(function () {});
+    }
+
+    function sendInput(data) {
+      if (!termWs || termWs.readyState !== 1 || !data) return;
+      var bytes = inputEncoder.encode(data);
+      if (bytes.length <= 64 * 1024 && termWs.bufferedAmount < 65536) {
+        termWs.send(bytes);
+        return;
+      }
+      var chunkSize = 16 * 1024;
+      for (var i = 0; i < bytes.length; i += chunkSize)
+        termWs.send(bytes.slice(i, i + chunkSize));
+    }
+
+    function enqueueFrame(data) {
+      var size = typeof data === "string" ? data.length : data.length;
+      if (!writeFlushPending && writeQueue.length === 0 && term && size <= 8192) {
+        writeFrame(data);
+        return;
+      }
+      writeQueue.push(data);
+      if (writeFlushPending) return;
+      writeFlushPending = true;
+      requestAnimationFrame(flushFrames);
+    }
+
+    function flushFrames() {
+      writeFlushPending = false;
+      if (!writeQueue.length || !term) return;
+      var frames = writeQueue;
+      writeQueue = [];
+      var data = frames.every(function (f) { return typeof f === "string"; })
+        ? frames.join("")
+        : coalesceBytes(frames);
+      writeFrame(data);
+    }
+
+    function coalesceBytes(frames) {
+      var encoded = frames.map(function (f) {
+        return typeof f === "string" ? inputEncoder.encode(f) : f;
+      });
+      var total = encoded.reduce(function (s, f) { return s + f.length; }, 0);
+      var merged = new Uint8Array(total);
+      var off = 0;
+      for (var i = 0; i < encoded.length; i++) {
+        merged.set(encoded[i], off);
+        off += encoded[i].length;
+      }
+      return merged;
+    }
+
+    function writeFrame(data) {
+      if (!term) return;
+      try { term.write(data); } catch (e) { try { term.write(data); } catch (e2) {} }
+    }
+
+    function isVisible() { return isOpen; }
+
+    function handlePaneExited(paneId) {
+      if (isOpen && paneId && createdPaneId === paneId) close();
+    }
+
+    function handleResize() {
+      if (!isOpen || !term) return;
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(function () {
+        resizeTimer = null;
+        if (!isOpen || !term) return;
+        var container = el(containerId);
+        if (!container) return;
+        var cols = Math.max(40, Math.floor(container.clientWidth / 9));
+        var rows = Math.max(10, Math.floor(container.clientHeight / 18));
+        try { term.resize(cols, rows); } catch (e) {}
+        if (termWs && termWs.readyState === 1) {
+          try {
+            termWs.send(JSON.stringify({ type: "resize", cols: cols, rows: rows }));
+          } catch (e) {}
+        }
+      }, 100);
+    }
+
+    return { open: open, close: close, isVisible: isVisible, handleResize: handleResize, handlePaneExited: handlePaneExited };
+  }
+
+  globalThis.HerdrTempTerminal = { create: createTempTerminal };
+})();

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -34,6 +34,7 @@
     var writeFlushPending = false;
     var resizeTimer = null;
     var linkProvider = null;
+    var confirmVisible = false;
 
     function open() {
       if (isOpen) return;
@@ -47,8 +48,14 @@
       createTerminalSession();
     }
 
+    function requestClose() {
+      if (!isOpen) return;
+      showCloseConfirm();
+    }
+
     function close() {
       if (!isOpen) return;
+      hideCloseConfirm();
       isOpen = false;
       closing = true;
       disconnectWs();
@@ -59,6 +66,57 @@
       createdTabId = null;
       createdPaneId = null;
       createdWorkspaceId = null;
+    }
+
+    function showCloseConfirm() {
+      var modal = el(modalId);
+      if (!modal) return;
+      var confirm = modal.querySelector(".temp-terminal-confirm");
+      if (!confirm) {
+        confirm = document.createElement("div");
+        confirm.className = "temp-terminal-confirm";
+        confirm.innerHTML =
+          '<div class="temp-terminal-confirm-card" role="alertdialog" aria-modal="true" aria-labelledby="tempTerminalConfirmTitle" aria-describedby="tempTerminalConfirmMessage">' +
+          '<h3 id="tempTerminalConfirmTitle">Close temporary terminal?</h3>' +
+          '<p id="tempTerminalConfirmMessage">This will stop the temporary terminal session.</p>' +
+          '<div class="temp-terminal-confirm-actions">' +
+          '<button type="button" class="tab add temp-terminal-confirm-cancel">Cancel</button>' +
+          '<button type="button" class="btn temp-terminal-confirm-close">Close</button>' +
+          '</div></div>';
+        modal.appendChild(confirm);
+        confirm.querySelector(".temp-terminal-confirm-close").onclick = function () { close(); };
+        confirm.querySelector(".temp-terminal-confirm-cancel").onclick = hideCloseConfirm;
+      }
+      confirmVisible = true;
+      confirm.style.display = "grid";
+      document.addEventListener("keydown", closeConfirmKeydown, true);
+      var closeButton = confirm.querySelector(".temp-terminal-confirm-close");
+      if (closeButton) closeButton.focus();
+    }
+
+    function hideCloseConfirm() {
+      if (!confirmVisible) return;
+      confirmVisible = false;
+      document.removeEventListener("keydown", closeConfirmKeydown, true);
+      var modal = el(modalId);
+      var confirm = modal && modal.querySelector(".temp-terminal-confirm");
+      if (confirm) confirm.style.display = "none";
+      if (term) {
+        try { term.focus(); } catch (e) {}
+      }
+    }
+
+    function closeConfirmKeydown(event) {
+      if (!confirmVisible) return;
+      if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        close();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        hideCloseConfirm();
+      }
     }
 
     function createTerminalSession() {
@@ -256,7 +314,7 @@
       }, 100);
     }
 
-    return { open: open, close: close, isVisible: isVisible, handleResize: handleResize, handlePaneExited: handlePaneExited };
+    return { open: open, requestClose: requestClose, close: close, isVisible: isVisible, handleResize: handleResize, handlePaneExited: handlePaneExited };
   }
 
   globalThis.HerdrTempTerminal = { create: createTempTerminal };

--- a/src/main.rs
+++ b/src/main.rs
@@ -2629,7 +2629,8 @@ async fn terminal_socket(
 
     loop {
         tokio::select! {
-            Some(bytes) = out_rx.recv() => {
+            message = out_rx.recv() => {
+                let Some(bytes) = message else { break; };
                 if socket.send(Message::Binary(bytes.into())).await.is_err() { break; }
             }
             message = socket.recv() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -859,6 +859,10 @@ fn app_router(state: WebState) -> Router {
             "/assets/shared/terminal-scroll.js",
             get(shared_terminal_scroll_js),
         )
+        .route(
+            "/assets/shared/temp-terminal.js",
+            get(shared_temp_terminal_js),
+        )
         .route("/assets/desktop/git-ui.js", get(desktop_git_ui_js))
         .route(
             "/assets/desktop/file-browser.js",
@@ -2537,6 +2541,7 @@ struct TerminalQuery {
     cols: Option<u16>,
     rows: Option<u16>,
     session: Option<String>,
+    temporary_tab_id: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -2559,10 +2564,22 @@ async fn terminal_ws(
         .as_deref()
         .map(|session| client_socket_path_for(Some(session)))
         .unwrap_or_else(|| client_socket_for_headers(&state, &headers));
-    ws.on_upgrade(move |socket| terminal_socket(client_socket_path, query, socket))
+    let api = query
+        .session
+        .as_deref()
+        .map(|session| ApiClient {
+            socket_path: api_socket_path_for(Some(session)),
+        })
+        .unwrap_or_else(|| api_for_headers(&state, &headers));
+    ws.on_upgrade(move |socket| terminal_socket(client_socket_path, api, query, socket))
 }
 
-async fn terminal_socket(path: PathBuf, query: TerminalQuery, mut socket: WebSocket) {
+async fn terminal_socket(
+    path: PathBuf,
+    api: ApiClient,
+    query: TerminalQuery,
+    mut socket: WebSocket,
+) {
     let terminal_id = query.terminal_id.clone();
     let cols = query.cols.unwrap_or(100).max(1);
     let rows = query.rows.unwrap_or(30).max(1);
@@ -2633,6 +2650,15 @@ async fn terminal_socket(path: PathBuf, query: TerminalQuery, mut socket: WebSoc
         }
     }
     let _ = in_tx.send(ClientMessage::Detach);
+    if let Some(tab_id) = query
+        .temporary_tab_id
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        let _ = api.request_value(
+            json!({ "id": "web:temp-terminal:close", "method": "tab.close", "params": { "tab_id": tab_id } }),
+        );
+    }
 }
 
 fn terminal_text_messages(text: &str) -> Vec<ClientMessage> {


### PR DESCRIPTION
## Summary
- add an ephemeral temporary terminal overlay for desktop and mobile
- tie temporary terminal lifecycle to browser websocket/session, close button confirmation, and backend exit
- close `/ws/terminal` when backend terminal stream ends so xterm sessions close after `exit`
- add temporary terminal header icon using terminal glyph with a `T` marker

## Validation
- `node --check` for shared, mobile, and concatenated desktop JS
- `cargo check`
- `cargo build --release`
- local `update-mac` deploy
- API/WebSocket smoke test: created temp tab, connected to `/ws/terminal`, sent `exit\n`, verified websocket closed and temp tab auto-closed
