### PR TITLE
Show branch and tag refs in git log

### DIFF
--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -1193,7 +1193,8 @@
     const data = await api(`/api/git-ui/log?cwd=${encodeURIComponent(view.cwd)}&all=${view.logAll ? "true" : "false"}`);
     const selected = view.selectedLogCommits || [];
     const compare = Actions.selectedLogToolbar(selected);
-    replaceContent(version, `<div class="git-ui-log-scope-head"><span class="git-ui-toolbar-title">History scope</span><button class="git-ui-btn ${!view.logAll ? "active" : ""}" onclick="HerdrGitUi.setLogAll(false)">Current branch</button><button class="git-ui-btn ${view.logAll ? "active" : ""}" onclick="HerdrGitUi.setLogAll(true)">All branches</button>${compare}</div><div class="git-ui-log">${(data.lines || []).map(renderLogLine).join("")}</div>`);
+    const commitsByHash = logCommitMap(data.commits || []);
+    replaceContent(version, `<div class="git-ui-log-scope-head"><span class="git-ui-toolbar-title">History scope</span><button class="git-ui-btn ${!view.logAll ? "active" : ""}" onclick="HerdrGitUi.setLogAll(false)">Current branch</button><button class="git-ui-btn ${view.logAll ? "active" : ""}" onclick="HerdrGitUi.setLogAll(true)">All branches</button>${compare}</div><div class="git-ui-log">${(data.lines || []).map((line) => renderLogLine(line, commitsByHash)).join("")}</div>`);
     if (view.pendingLogScrollHash) {
       const hash = view.pendingLogScrollHash;
       view.pendingLogScrollHash = "";
@@ -1201,16 +1202,73 @@
     }
   }
 
-  function renderLogLine(line) {
+  function logCommitMap(commits) {
+    const map = {};
+    commits.forEach((commit) => {
+      const hash = String((commit && commit.hash) || "");
+      if (!hash) return;
+      map[hash] = commit;
+      map[hash.slice(0, 8)] = commit;
+      map[hash.slice(0, 12)] = commit;
+    });
+    return map;
+  }
+
+  function renderLogLine(line, commitsByHash) {
     const parsed = parseLogGraphLine(line);
     const graph = parsed.graph;
     const hash = parsed.hash;
     const detail = splitLogDecorations(parsed.message);
-    const labels = detail.labels.map((label) => `<span>${esc(label)}</span>`).join("");
+    const commit = (commitsByHash && commitsByHash[hash]) || {};
+    const refs = Array.isArray(commit.refs) && commit.refs.length ? commit.refs : detail.labels;
+    const labels = refs.map(renderLogRefLabel).join("");
     const selected = hash && (((active() || {}).selectedLogCommits || []).includes(hash));
     const click = hash ? ` onclick="HerdrGitUi.selectLogCommit(event,'${arg(hash)}')"` : "";
     const cls = hash ? (selected ? " selected" : "") : " graph-only";
-    return `<div class="git-ui-log-row${cls}" data-log-hash="${esc(hash)}" title="${esc(detail.message)}"${click}>${renderGraph(graph, !!hash)}<span class="git-ui-log-msg">${hash ? `<strong>${esc(hash)}</strong> ` : ""}${esc(detail.message)}</span><span class="git-ui-log-labels">${labels}</span></div>`;
+    const title = logLineTitle(hash, detail.message, commit, refs);
+    return `<div class="git-ui-log-row${cls}" data-log-hash="${esc(hash)}" title="${esc(title)}"${click}>${renderGraph(graph, !!hash)}<span class="git-ui-log-msg">${hash ? `<strong>${esc(hash)}</strong> ` : ""}${esc(detail.message)}</span><span class="git-ui-log-labels">${labels}</span></div>`;
+  }
+
+  function renderLogRefLabel(ref) {
+    const text = cleanLogRefLabel(ref);
+    return `<span class="git-ui-log-label ${esc(logRefKind(ref))}" title="${esc(logRefTitle(ref))}">${esc(text)}</span>`;
+  }
+
+  function cleanLogRefLabel(ref) {
+    return String(ref || "").trim();
+  }
+
+  function logRefKind(ref) {
+    const text = String(ref || "").trim();
+    if (/^tag:\s*/i.test(text)) return "tag";
+    if (/^HEAD\b/.test(text)) return "head";
+    if (text.includes("/")) return "remote";
+    return "branch";
+  }
+
+  function logRefTitle(ref) {
+    const text = String(ref || "").trim();
+    if (!text) return "Git ref";
+    const tag = text.match(/^tag:\s*(.+)$/i);
+    if (tag) return `Tag: ${tag[1]}`;
+    const head = text.match(/^HEAD\s*->\s*(.+)$/);
+    if (head) return `Current branch: ${head[1]}`;
+    if (text === "HEAD") return "HEAD";
+    if (text.includes("/")) return `Remote branch: ${text}`;
+    return `Branch: ${text}`;
+  }
+
+  function logLineTitle(hash, message, commit, refs) {
+    if (!hash) return message || "";
+    const lines = [`Commit: ${commit.hash || hash}`];
+    if (message) lines.push(`Message: ${message}`);
+    if (commit.author) lines.push(`Author: ${commit.author}`);
+    if (commit.date) lines.push(`Date: ${commit.date}`);
+    if (refs && refs.length) {
+      lines.push("Refs:");
+      refs.forEach((ref) => lines.push(`- ${logRefTitle(ref)}`));
+    }
+    return lines.join("\n");
   }
 
   function scrollToLogCommit(hash) {

--- a/src/assets/desktop/git_ui/log.css
+++ b/src/assets/desktop/git_ui/log.css
@@ -131,14 +131,31 @@
   gap: 4px;
   justify-content: flex-end;
 }
-.git-ui-log-labels span {
+.git-ui-log-label {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
   border: 1px solid var(--border2);
   border-radius: 999px;
   color: var(--accent);
   font-size: 11px;
+  font-weight: 700;
   max-width: 150px;
   overflow: hidden;
   padding: 1px 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.git-ui-log-label.head {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--border2));
+}
+.git-ui-log-label.branch {
+  color: var(--accent);
+}
+.git-ui-log-label.remote {
+  color: color-mix(in srgb, var(--accent) 75%, var(--muted));
+}
+.git-ui-log-label.tag {
+  background: color-mix(in srgb, #f9e2af 18%, transparent);
+  border-color: color-mix(in srgb, #f9e2af 55%, var(--border2));
+  color: #f9e2af;
 }

--- a/src/git_ui/log.rs
+++ b/src/git_ui/log.rs
@@ -60,11 +60,35 @@ pub(super) struct GitUiApplyPatchRequest {
 }
 
 /// Reconstruct a git log graph line so it no longer contains the null-byte
-/// (`%x00`) separators emitted by `--format=%H%x00%an%x00%ar%x00%s`.
+/// (`%x00`) separators emitted by `--format=%H%x00%an%x00%ar%x00%D%x00%s`.
 ///
 /// Commit lines become a human-readable `--oneline`-style string
-/// (`<graph_prefix><short-hash> <message>`). Graph-only and empty lines are
-/// passed through unchanged, since they never contain null bytes.
+/// (`<graph_prefix><short-hash> (<refs>) <message>`). Graph-only and empty
+/// lines are passed through unchanged, since they never contain null bytes.
+fn split_log_refs(refs: &str) -> Vec<String> {
+    refs.split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn log_refs_field<'a>(parts: &'a [&'a str]) -> &'a str {
+    if parts.len() > 4 {
+        parts.get(3).copied().unwrap_or("")
+    } else {
+        ""
+    }
+}
+
+fn log_message_field<'a>(parts: &'a [&'a str]) -> &'a str {
+    if parts.len() > 4 {
+        parts.get(4).copied().unwrap_or("")
+    } else {
+        parts.get(3).copied().unwrap_or("")
+    }
+}
+
 fn reconstruct_log_line(line: &str) -> String {
     let raw = line.trim();
     if raw.is_empty() {
@@ -83,10 +107,16 @@ fn reconstruct_log_line(line: &str) -> String {
     }
     let hash = &raw[start..end];
     let parts: Vec<&str> = raw[end..].split('\0').collect();
-    let message = parts.get(3).map(|s| s.trim()).unwrap_or("");
+    let refs = log_refs_field(&parts).trim();
+    let message = log_message_field(&parts).trim();
     let graph_prefix = &raw[..start];
     let short = &hash[..8.min(hash.len())];
-    format!("{}{} {}", graph_prefix, short, message)
+    match (refs.is_empty(), message.is_empty()) {
+        (true, true) => format!("{}{}", graph_prefix, short),
+        (true, false) => format!("{}{} {}", graph_prefix, short, message),
+        (false, true) => format!("{}{} ({})", graph_prefix, short, refs),
+        (false, false) => format!("{}{} ({}) {}", graph_prefix, short, refs, message),
+    }
 }
 
 fn git_ui_log_blocking(
@@ -101,7 +131,7 @@ fn git_ui_log_blocking(
         "--date=relative",
         "--max-count",
         &max,
-        "--format=%H%x00%an%x00%ar%x00%s",
+        "--format=%H%x00%an%x00%ar%x00%D%x00%s",
     ];
     if all {
         args.push("--all");
@@ -131,10 +161,16 @@ fn git_ui_log_blocking(
                     let parts: Vec<&str> = raw[end..].split('\0').collect();
                     let author = parts.get(1).map(|s| s.trim()).unwrap_or("").to_string();
                     let date = parts.get(2).map(|s| s.trim()).unwrap_or("").to_string();
-                    let message = parts.get(3).map(|s| s.trim()).unwrap_or("").to_string();
-                    Some(
-                        json!({ "hash": hash, "author": author, "date": date, "message": message }),
-                    )
+                    let refs_text = log_refs_field(&parts).trim().to_string();
+                    let refs = split_log_refs(&refs_text);
+                    let message = log_message_field(&parts).trim().to_string();
+                    Some(json!({
+                        "hash": hash,
+                        "author": author,
+                        "date": date,
+                        "message": message,
+                        "refs": refs,
+                    }))
                 })
                 .collect::<Vec<_>>();
             let display_lines = lines
@@ -144,6 +180,49 @@ fn git_ui_log_blocking(
             Ok(Json(json!({ "commits": commits, "lines": display_lines })).into_response())
         }
         Err(err) => Err((StatusCode::BAD_GATEWAY, err)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{reconstruct_log_line, split_log_refs};
+
+    #[test]
+    fn reconstruct_log_line_keeps_branch_and_tag_decorations() {
+        let line = concat!(
+            "* 1234567890abcdef",
+            "\0Alice",
+            "\0",
+            "2 days ago",
+            "\0HEAD -> main, origin/main, tag: v1.0",
+            "\0Add feature"
+        );
+
+        assert_eq!(
+            reconstruct_log_line(line),
+            "* 12345678 (HEAD -> main, origin/main, tag: v1.0) Add feature"
+        );
+    }
+
+    #[test]
+    fn reconstruct_log_line_supports_legacy_lines_without_refs() {
+        let line = concat!(
+            "| * 1234567890abcdef",
+            "\0Alice",
+            "\0",
+            "2 days ago",
+            "\0Add feature"
+        );
+
+        assert_eq!(reconstruct_log_line(line), "| * 12345678 Add feature");
+    }
+
+    #[test]
+    fn split_log_refs_trims_empty_entries() {
+        assert_eq!(
+            split_log_refs(" main, tag: v1.0, , origin/main "),
+            vec!["main", "tag: v1.0", "origin/main"]
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- include git ref decorations in the git log API
- show branch, remote, HEAD, and tag badges in the git log UI
- add hover details with commit metadata and refs

## Tests
- cargo test
- node --check src/assets/desktop/git_ui.js