### PR TITLE
Unify header search section controls

### DIFF
--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -357,6 +357,8 @@ describe("app bundle load", () => {
     match(sharedContentSearchCss, /herdr-content-search-context-arrow/);
     match(sharedContentSearchCss, /herdr-content-search-hit/);
     match(sharedContentSearchCss, /font-weight: 700/);
+    match(workspaceSearchSource, /preserveExpanded/);
+    match(searchSource, /renderSearchPalettePreservingScroll/);
     const editorSource = readFileSync(new URL("./vendor/codemirror_entry.mjs", import.meta.url), "utf8");
     match(editorSource, /foldGutter/);
     match(editorSource, /foldKeymap/);
@@ -389,6 +391,22 @@ describe("app bundle load", () => {
     match(readFileSync(new URL("./mobile/settings.js", import.meta.url), "utf8"), /setFileContentSearchContextLines/);
     match(gitUiSource, /placeholder="Filter files"/);
     match(gitUiSource, /filterFiles/);
+  });
+
+  it("keeps content search file expansion when context is reloaded", () => {
+    const ctx = context();
+    ctx.localStorage.setItem("herdr-web-options", JSON.stringify({ fileContentSearchDefaultExpanded: false }));
+    vm.runInContext(readFileSync(new URL("./shared/workspace_search.js", import.meta.url), "utf8"), ctx);
+    const helper = ctx.HerdrWorkspaceSearch;
+
+    const state = helper.createContentState({ expanded: { "src/a.js": true, "src/b.js": false } });
+    helper.applyContentResults(state, { files: [{ path: "src/a.js" }, { path: "src/b.js" }], total_matches: 2 }, false, { preserveExpanded: true });
+
+    equal(state.expanded["src/a.js"], true);
+    equal(state.expanded["src/b.js"], false);
+
+    helper.applyContentResults(state, { files: [{ path: "src/a.js" }], total_matches: 1 }, false);
+    equal(state.expanded["src/a.js"], false);
   });
 
   it("renders new workspace modal with manual folder field", () => {

--- a/src/assets/desktop/app_css/base.css
+++ b/src/assets/desktop/app_css/base.css
@@ -187,6 +187,14 @@ body.light {
 .mini:hover {
   background: var(--border2);
 }
+.mini.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
+.mini.active:hover {
+  background: color-mix(in srgb, var(--accent), var(--fg) 12%);
+}
 .no-sleep-control {
   max-width: 118px;
   appearance: none;

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -304,13 +304,6 @@ el("optHeaderSearchEnabled").onchange = () => {
   saveOptions();
   applyOptions();
 };
-for (const [id, key] of [["optSearchWorkspacesEnabled", "searchWorkspacesEnabled"], ["optSearchFilesEnabled", "searchFilesEnabled"], ["optSearchFoldersEnabled", "searchFoldersEnabled"], ["optSearchContentEnabled", "searchContentEnabled"]]) {
-  const node = el(id);
-  if (node) node.onchange = () => {
-    options[key] = node.checked;
-    saveOptions();
-  };
-}
 el("optFileBrowserPathSearch").onchange = () => {
   options.fileBrowserPathSearch = el("optFileBrowserPathSearch").checked;
   saveOptions();

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -299,6 +299,11 @@ el("optFileBrowserLineNumbers").onchange = () => {
   options.fileBrowserLineNumbers = el("optFileBrowserLineNumbers").checked;
   saveOptions();
 };
+el("optHeaderSearchEnabled").onchange = () => {
+  options.headerSearchEnabled = el("optHeaderSearchEnabled").checked;
+  saveOptions();
+  applyOptions();
+};
 for (const [id, key] of [["optSearchWorkspacesEnabled", "searchWorkspacesEnabled"], ["optSearchFilesEnabled", "searchFilesEnabled"], ["optSearchFoldersEnabled", "searchFoldersEnabled"], ["optSearchContentEnabled", "searchContentEnabled"]]) {
   const node = el(id);
   if (node) node.onchange = () => {
@@ -306,11 +311,6 @@ for (const [id, key] of [["optSearchWorkspacesEnabled", "searchWorkspacesEnabled
     saveOptions();
   };
 }
-const searchSectionOrder = el("optSearchSectionOrder");
-if (searchSectionOrder) searchSectionOrder.oninput = () => {
-  options.searchSectionOrder = searchSectionOrder.value.trim();
-  saveOptions();
-};
 el("optFileBrowserPathSearch").onchange = () => {
   options.fileBrowserPathSearch = el("optFileBrowserPathSearch").checked;
   saveOptions();

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -1013,6 +1013,13 @@ const searchSectionGroupKeys = searchSectionGroups.map(([key]) => key);
 const searchSectionGroupByKey = Object.fromEntries(
   searchSectionGroups.map((group) => [group[0], group]),
 );
+function searchSectionOptionKey(key) {
+  return { workspaces: "searchWorkspacesEnabled", files: "searchFilesEnabled", content: "searchContentEnabled" }[key] || "";
+}
+function searchSectionEnabled(key) {
+  const optionKey = searchSectionOptionKey(key);
+  return !optionKey || options[optionKey] !== false;
+}
 function normalizeAgentStatusOrder(value) {
   const seen = new Set();
   const order = [];
@@ -1411,7 +1418,7 @@ if (showTabActivitySetting && !el("optTreeIndentPx"))
     .closest("label")
     .insertAdjacentHTML(
       "afterend",
-      '<label class="option"><span>Tree indentation<small>Pixels added per folder level in file trees.</small></span><input id="optTreeIndentPx" type="number" min="0" max="40" step="1"></label><label class="option"><input type="checkbox" id="optFileBrowserAllowParent"><span>File browser parent folders<small>Allow Files to go above the workspace/worktree directory with the ... row.</small></span></label><label class="option"><input type="checkbox" id="optFileBrowserGitStatus"><span>File browser git status colors<small>Color files and directories in the file browser by Git status: red for deleted, yellow for modified, green for new.</small></span></label><label class="option"><input type="checkbox" id="optFileBrowserLineNumbers"><span>File browser line numbers<small>Show line numbers by default when previewing text files.</small></span></label><label class="option"><input type="checkbox" id="optHeaderSearchEnabled"><span>Header search button and shortcut<small>Show the header magnifier and allow the configured search shortcut to open the palette.</small></span></label><label class="option"><input type="checkbox" id="optSearchWorkspacesEnabled"><span>Header search workspaces<small>Show workspaces, worktrees, panels, and agents in the header search.</small></span></label><label class="option"><input type="checkbox" id="optSearchFilesEnabled"><span>Header search files<small>Search file paths for the selected workspace/worktree.</small></span></label><label class="option"><input type="checkbox" id="optSearchFoldersEnabled"><span>Header search folders<small>Search folder paths for the selected workspace/worktree.</small></span></label><label class="option"><input type="checkbox" id="optSearchContentEnabled"><span>Header search file contents<small>Search text contents for the selected workspace/worktree.</small></span></label><div class="option" id="optSearchSectionOrder"><span>Header search section order<small>Use arrows to move result sections in the palette.</small></span><div id="searchSectionOrderList" class="agent-sort-list"></div></div><label class="option"><input type="checkbox" id="optFileBrowserPathSearch"><span>File/folder backend search<small>Enable backend path search for the header search file and folder sections.</small></span></label><label class="option"><span>File/folder search page size<small>Backend result count loaded per lazy page.</small></span><input id="optFileBrowserSearchPageSize" type="number" min="10" max="500" step="10"></label><label class="option"><span>Content search minimum characters<small>Minimum typed characters before searching file contents.</small></span><input id="optFileContentSearchMinChars" type="number" min="1" max="20" step="1"></label><label class="option"><span>Content search page size<small>Backend file groups loaded per lazy page.</small></span><input id="optFileContentSearchPageSize" type="number" min="10" max="500" step="10"></label><label class="option"><span>Content search context lines<small>Default lines above and below each match.</small></span><input id="optFileContentSearchContextLines" type="number" min="0" max="20" step="1"></label><label class="option"><span>Content search auto-collapse<small>Collapse file groups when result files exceed this count. 0 means never auto-collapse.</small></span><input id="optFileContentSearchAutoCollapseFiles" type="number" min="0" max="200" step="1"></label><label class="option"><input type="checkbox" id="optFileContentSearchDefaultExpanded"><span>Content results expanded by default<small>Expand each file group when content results load. Auto-collapse can still collapse very large result sets.</small></span></label><label class="option"><span>Content search matches per file<small>Initial match count loaded per file before lazy expansion.</small></span><input id="optFileContentSearchMatchesPerFile" type="number" min="1" max="50" step="1"></label>',
+      '<label class="option"><span>Tree indentation<small>Pixels added per folder level in file trees.</small></span><input id="optTreeIndentPx" type="number" min="0" max="40" step="1"></label><label class="option"><input type="checkbox" id="optFileBrowserAllowParent"><span>File browser parent folders<small>Allow Files to go above the workspace/worktree directory with the ... row.</small></span></label><label class="option"><input type="checkbox" id="optFileBrowserGitStatus"><span>File browser git status colors<small>Color files and directories in the file browser by Git status: red for deleted, yellow for modified, green for new.</small></span></label><label class="option"><input type="checkbox" id="optFileBrowserLineNumbers"><span>File browser line numbers<small>Show line numbers by default when previewing text files.</small></span></label><label class="option"><input type="checkbox" id="optHeaderSearchEnabled"><span>Header search button and shortcut<small>Show the header magnifier and allow the configured search shortcut to open the palette.</small></span></label><div class="option" id="optSearchSectionOrder"><span>Header search section order<small>Use arrows to move sections. Use the middle button to show or hide each section.</small></span><div id="searchSectionOrderList" class="agent-sort-list"></div></div><label class="option"><input type="checkbox" id="optFileBrowserPathSearch"><span>File/folder backend search<small>Enable backend path search for the header search file and folder sections.</small></span></label><label class="option"><span>File/folder search page size<small>Backend result count loaded per lazy page.</small></span><input id="optFileBrowserSearchPageSize" type="number" min="10" max="500" step="10"></label><label class="option"><span>Content search minimum characters<small>Minimum typed characters before searching file contents.</small></span><input id="optFileContentSearchMinChars" type="number" min="1" max="20" step="1"></label><label class="option"><span>Content search page size<small>Backend file groups loaded per lazy page.</small></span><input id="optFileContentSearchPageSize" type="number" min="10" max="500" step="10"></label><label class="option"><span>Content search context lines<small>Default lines above and below each match.</small></span><input id="optFileContentSearchContextLines" type="number" min="0" max="20" step="1"></label><label class="option"><span>Content search auto-collapse<small>Collapse file groups when result files exceed this count. 0 means never auto-collapse.</small></span><input id="optFileContentSearchAutoCollapseFiles" type="number" min="0" max="200" step="1"></label><label class="option"><input type="checkbox" id="optFileContentSearchDefaultExpanded"><span>Content results expanded by default<small>Expand each file group when content results load. Auto-collapse can still collapse very large result sets.</small></span></label><label class="option"><span>Content search matches per file<small>Initial match count loaded per file before lazy expansion.</small></span><input id="optFileContentSearchMatchesPerFile" type="number" min="1" max="50" step="1"></label>',
     );
 groupSettingsSections();
 function groupSettingsSections() {
@@ -1426,7 +1433,7 @@ function groupSettingsSections() {
     {
       title: "File browser",
       desc: "Tree display, navigation, and Git status colors.",
-      ids: ["optTreeIndentPx", "optFileBrowserAllowParent", "optFileBrowserGitStatus", "optFileBrowserLineNumbers", "optHeaderSearchEnabled", "optSearchWorkspacesEnabled", "optSearchFilesEnabled", "optSearchFoldersEnabled", "optSearchContentEnabled", "optSearchSectionOrder", "optFileBrowserPathSearch", "optFileBrowserSearchPageSize", "optFileContentSearchMinChars", "optFileContentSearchPageSize", "optFileContentSearchContextLines", "optFileContentSearchAutoCollapseFiles", "optFileContentSearchDefaultExpanded", "optFileContentSearchMatchesPerFile"],
+      ids: ["optTreeIndentPx", "optFileBrowserAllowParent", "optFileBrowserGitStatus", "optFileBrowserLineNumbers", "optHeaderSearchEnabled", "optSearchSectionOrder", "optFileBrowserPathSearch", "optFileBrowserSearchPageSize", "optFileContentSearchMinChars", "optFileContentSearchPageSize", "optFileContentSearchContextLines", "optFileContentSearchAutoCollapseFiles", "optFileContentSearchDefaultExpanded", "optFileContentSearchMatchesPerFile"],
     },
     {
       title: "Terminal input",
@@ -1590,10 +1597,6 @@ function applyOptions() {
     fileBrowserGitStatus = el("optFileBrowserGitStatus"),
     fileBrowserLineNumbers = el("optFileBrowserLineNumbers"),
     headerSearchEnabled = el("optHeaderSearchEnabled"),
-    searchWorkspacesEnabled = el("optSearchWorkspacesEnabled"),
-    searchFilesEnabled = el("optSearchFilesEnabled"),
-    searchFoldersEnabled = el("optSearchFoldersEnabled"),
-    searchContentEnabled = el("optSearchContentEnabled"),
     fileBrowserPathSearch = el("optFileBrowserPathSearch"),
     fileBrowserSearchPageSize = el("optFileBrowserSearchPageSize"),
     fileContentSearchMinChars = el("optFileContentSearchMinChars"),
@@ -1662,14 +1665,6 @@ function applyOptions() {
     fileBrowserLineNumbers.checked = !!options.fileBrowserLineNumbers;
   if (headerSearchEnabled)
     headerSearchEnabled.checked = options.headerSearchEnabled !== false;
-  if (searchWorkspacesEnabled)
-    searchWorkspacesEnabled.checked = options.searchWorkspacesEnabled !== false;
-  if (searchFilesEnabled)
-    searchFilesEnabled.checked = options.searchFilesEnabled !== false;
-  if (searchFoldersEnabled)
-    searchFoldersEnabled.checked = options.searchFoldersEnabled !== false;
-  if (searchContentEnabled)
-    searchContentEnabled.checked = options.searchContentEnabled !== false;
   renderSearchSectionOrderSettings();
   if (fileBrowserPathSearch)
     fileBrowserPathSearch.checked = options.fileBrowserPathSearch !== false;
@@ -1765,9 +1760,17 @@ function renderSearchSectionOrderSettings() {
   list.innerHTML = normalizeSearchSectionOrder(options.searchSectionOrder)
     .map((key, index, order) => {
       const [, label, desc] = searchSectionGroupByKey[key] || [key, key, ""];
-      return `<div class="agent-sort-row" data-section="${escapeAttr(key)}"><span class="agent-sort-chip gray"><strong>${escapeHtml(label)}</strong><small>${escapeHtml(desc)}</small></span><span class="agent-sort-buttons"><button type="button" class="mini" ${index === 0 ? "disabled" : ""} onclick="moveSearchSectionGroup('${escapeAttr(key)}',-1)">↑</button><button type="button" class="mini" ${index === order.length - 1 ? "disabled" : ""} onclick="moveSearchSectionGroup('${escapeAttr(key)}',1)">↓</button></span></div>`;
+      const enabled = searchSectionEnabled(key);
+      return `<div class="agent-sort-row" data-section="${escapeAttr(key)}"><span class="agent-sort-chip gray"><strong>${escapeHtml(label)}</strong><small>${escapeHtml(desc)}</small></span><span class="agent-sort-buttons"><button type="button" class="mini" ${index === 0 ? "disabled" : ""} onclick="moveSearchSectionGroup('${escapeAttr(key)}',-1)" title="Move ${escapeAttr(label)} up">↑</button><button type="button" class="mini ${enabled ? "active" : ""}" onclick="toggleSearchSectionGroup('${escapeAttr(key)}')" title="${enabled ? "Hide" : "Show"} ${escapeAttr(label)}">${enabled ? "Shown" : "Hidden"}</button><button type="button" class="mini" ${index === order.length - 1 ? "disabled" : ""} onclick="moveSearchSectionGroup('${escapeAttr(key)}',1)" title="Move ${escapeAttr(label)} down">↓</button></span></div>`;
     })
     .join("");
+}
+function toggleSearchSectionGroup(key) {
+  const optionKey = searchSectionOptionKey(String(key || ""));
+  if (!optionKey) return;
+  options[optionKey] = options[optionKey] === false;
+  saveOptions();
+  applyOptions();
 }
 function moveSearchSectionGroup(key, delta) {
   const order = normalizeSearchSectionOrder(options.searchSectionOrder);

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -950,6 +950,7 @@ const defaultOptions = {
   webuiShortcuts: DEFAULT_WEBUI_SHORTCUTS,
   gitShortcuts: DEFAULT_GIT_SHORTCUTS,
   searchShortcut: "off",
+  headerSearchEnabled: true,
   terminalFontFamily: HerdrAppHelpers.resolveTerminalFontFamily(""),
   terminalLinks: true,
   agentSortMode: "off",
@@ -1003,6 +1004,15 @@ const workingFirstAgentStatusOrder = [
   "done",
   "idle",
 ];
+const searchSectionGroups = [
+  ["workspaces", "Workspaces", "Workspaces, worktrees, panels, agents"],
+  ["files", "Files", "File path results for current workspace"],
+  ["content", "Content", "Text matches for current workspace"],
+];
+const searchSectionGroupKeys = searchSectionGroups.map(([key]) => key);
+const searchSectionGroupByKey = Object.fromEntries(
+  searchSectionGroups.map((group) => [group[0], group]),
+);
 function normalizeAgentStatusOrder(value) {
   const seen = new Set();
   const order = [];
@@ -1015,6 +1025,20 @@ function normalizeAgentStatusOrder(value) {
   for (const key of defaultOptions.agentStatusOrder) {
     if (!seen.has(key)) order.push(key);
   }
+  return order;
+}
+function normalizeSearchSectionOrder(value) {
+  const seen = new Set();
+  const order = [];
+  const parts = Array.isArray(value) ? value : String(value || "").split(",");
+  for (const part of parts) {
+    const key = String(part || "").trim().toLowerCase();
+    if (searchSectionGroupKeys.includes(key) && !seen.has(key)) {
+      seen.add(key);
+      order.push(key);
+    }
+  }
+  for (const key of searchSectionGroupKeys) if (!seen.has(key)) order.push(key);
   return order;
 }
 function normalizeSidebarWorkspacePercent(value) {
@@ -1063,6 +1087,7 @@ function normalizeOptions(value) {
     String(next.searchShortcut || "").toLowerCase() === "off"
       ? "off"
       : normalizeShortcutPrefix(next.searchShortcut, "off");
+  next.headerSearchEnabled = next.headerSearchEnabled !== false;
   next.terminalFontFamily = String(next.terminalFontFamily || "").trim().slice(0, 260);
   if (
     !next.terminalFontFamily ||
@@ -1111,7 +1136,7 @@ function normalizeOptions(value) {
   next.searchFilesEnabled = next.searchFilesEnabled !== false;
   next.searchFoldersEnabled = next.searchFoldersEnabled !== false;
   next.searchContentEnabled = next.searchContentEnabled !== false;
-  next.searchSectionOrder = String(next.searchSectionOrder || "workspaces,files,content").trim() || "workspaces,files,content";
+  next.searchSectionOrder = normalizeSearchSectionOrder(next.searchSectionOrder).join(",");
   next.fileBrowserPathSearch = next.fileBrowserPathSearch !== false;
   next.fileBrowserSearchPageSize = Math.max(10, Math.min(500, Number(next.fileBrowserSearchPageSize) || 100));
   next.fileContentSearchMinChars = Math.max(1, Math.min(20, Number(next.fileContentSearchMinChars) || 3));
@@ -1386,7 +1411,7 @@ if (showTabActivitySetting && !el("optTreeIndentPx"))
     .closest("label")
     .insertAdjacentHTML(
       "afterend",
-      '<label class="option"><span>Tree indentation<small>Pixels added per folder level in file trees.</small></span><input id="optTreeIndentPx" type="number" min="0" max="40" step="1"></label><label class="option"><input type="checkbox" id="optFileBrowserAllowParent"><span>File browser parent folders<small>Allow Files to go above the workspace/worktree directory with the ... row.</small></span></label><label class="option"><input type="checkbox" id="optFileBrowserGitStatus"><span>File browser git status colors<small>Color files and directories in the file browser by Git status: red for deleted, yellow for modified, green for new.</small></span></label><label class="option"><input type="checkbox" id="optFileBrowserLineNumbers"><span>File browser line numbers<small>Show line numbers by default when previewing text files.</small></span></label><label class="option"><input type="checkbox" id="optSearchWorkspacesEnabled"><span>Header search workspaces<small>Show workspaces, worktrees, panels, and agents in the header search.</small></span></label><label class="option"><input type="checkbox" id="optSearchFilesEnabled"><span>Header search files<small>Search file paths for the selected workspace/worktree.</small></span></label><label class="option"><input type="checkbox" id="optSearchFoldersEnabled"><span>Header search folders<small>Search folder paths for the selected workspace/worktree.</small></span></label><label class="option"><input type="checkbox" id="optSearchContentEnabled"><span>Header search file contents<small>Search text contents for the selected workspace/worktree.</small></span></label><label class="option"><span>Header search section order<small>Comma list using workspaces, files, content.</small></span><input id="optSearchSectionOrder" placeholder="workspaces,files,content"></label><label class="option"><input type="checkbox" id="optFileBrowserPathSearch"><span>File/folder backend search<small>Enable backend path search for the header search file and folder sections.</small></span></label><label class="option"><span>File/folder search page size<small>Backend result count loaded per lazy page.</small></span><input id="optFileBrowserSearchPageSize" type="number" min="10" max="500" step="10"></label><label class="option"><span>Content search minimum characters<small>Minimum typed characters before searching file contents.</small></span><input id="optFileContentSearchMinChars" type="number" min="1" max="20" step="1"></label><label class="option"><span>Content search page size<small>Backend file groups loaded per lazy page.</small></span><input id="optFileContentSearchPageSize" type="number" min="10" max="500" step="10"></label><label class="option"><span>Content search context lines<small>Default lines above and below each match.</small></span><input id="optFileContentSearchContextLines" type="number" min="0" max="20" step="1"></label><label class="option"><span>Content search auto-collapse<small>Collapse file groups when result files exceed this count. 0 means never auto-collapse.</small></span><input id="optFileContentSearchAutoCollapseFiles" type="number" min="0" max="200" step="1"></label><label class="option"><input type="checkbox" id="optFileContentSearchDefaultExpanded"><span>Content results expanded by default<small>Expand each file group when content results load. Auto-collapse can still collapse very large result sets.</small></span></label><label class="option"><span>Content search matches per file<small>Initial match count loaded per file before lazy expansion.</small></span><input id="optFileContentSearchMatchesPerFile" type="number" min="1" max="50" step="1"></label>',
+      '<label class="option"><span>Tree indentation<small>Pixels added per folder level in file trees.</small></span><input id="optTreeIndentPx" type="number" min="0" max="40" step="1"></label><label class="option"><input type="checkbox" id="optFileBrowserAllowParent"><span>File browser parent folders<small>Allow Files to go above the workspace/worktree directory with the ... row.</small></span></label><label class="option"><input type="checkbox" id="optFileBrowserGitStatus"><span>File browser git status colors<small>Color files and directories in the file browser by Git status: red for deleted, yellow for modified, green for new.</small></span></label><label class="option"><input type="checkbox" id="optFileBrowserLineNumbers"><span>File browser line numbers<small>Show line numbers by default when previewing text files.</small></span></label><label class="option"><input type="checkbox" id="optHeaderSearchEnabled"><span>Header search button and shortcut<small>Show the header magnifier and allow the configured search shortcut to open the palette.</small></span></label><label class="option"><input type="checkbox" id="optSearchWorkspacesEnabled"><span>Header search workspaces<small>Show workspaces, worktrees, panels, and agents in the header search.</small></span></label><label class="option"><input type="checkbox" id="optSearchFilesEnabled"><span>Header search files<small>Search file paths for the selected workspace/worktree.</small></span></label><label class="option"><input type="checkbox" id="optSearchFoldersEnabled"><span>Header search folders<small>Search folder paths for the selected workspace/worktree.</small></span></label><label class="option"><input type="checkbox" id="optSearchContentEnabled"><span>Header search file contents<small>Search text contents for the selected workspace/worktree.</small></span></label><div class="option" id="optSearchSectionOrder"><span>Header search section order<small>Use arrows to move result sections in the palette.</small></span><div id="searchSectionOrderList" class="agent-sort-list"></div></div><label class="option"><input type="checkbox" id="optFileBrowserPathSearch"><span>File/folder backend search<small>Enable backend path search for the header search file and folder sections.</small></span></label><label class="option"><span>File/folder search page size<small>Backend result count loaded per lazy page.</small></span><input id="optFileBrowserSearchPageSize" type="number" min="10" max="500" step="10"></label><label class="option"><span>Content search minimum characters<small>Minimum typed characters before searching file contents.</small></span><input id="optFileContentSearchMinChars" type="number" min="1" max="20" step="1"></label><label class="option"><span>Content search page size<small>Backend file groups loaded per lazy page.</small></span><input id="optFileContentSearchPageSize" type="number" min="10" max="500" step="10"></label><label class="option"><span>Content search context lines<small>Default lines above and below each match.</small></span><input id="optFileContentSearchContextLines" type="number" min="0" max="20" step="1"></label><label class="option"><span>Content search auto-collapse<small>Collapse file groups when result files exceed this count. 0 means never auto-collapse.</small></span><input id="optFileContentSearchAutoCollapseFiles" type="number" min="0" max="200" step="1"></label><label class="option"><input type="checkbox" id="optFileContentSearchDefaultExpanded"><span>Content results expanded by default<small>Expand each file group when content results load. Auto-collapse can still collapse very large result sets.</small></span></label><label class="option"><span>Content search matches per file<small>Initial match count loaded per file before lazy expansion.</small></span><input id="optFileContentSearchMatchesPerFile" type="number" min="1" max="50" step="1"></label>',
     );
 groupSettingsSections();
 function groupSettingsSections() {
@@ -1401,7 +1426,7 @@ function groupSettingsSections() {
     {
       title: "File browser",
       desc: "Tree display, navigation, and Git status colors.",
-      ids: ["optTreeIndentPx", "optFileBrowserAllowParent", "optFileBrowserGitStatus", "optFileBrowserLineNumbers", "optSearchWorkspacesEnabled", "optSearchFilesEnabled", "optSearchFoldersEnabled", "optSearchContentEnabled", "optSearchSectionOrder", "optFileBrowserPathSearch", "optFileBrowserSearchPageSize", "optFileContentSearchMinChars", "optFileContentSearchPageSize", "optFileContentSearchContextLines", "optFileContentSearchAutoCollapseFiles", "optFileContentSearchDefaultExpanded", "optFileContentSearchMatchesPerFile"],
+      ids: ["optTreeIndentPx", "optFileBrowserAllowParent", "optFileBrowserGitStatus", "optFileBrowserLineNumbers", "optHeaderSearchEnabled", "optSearchWorkspacesEnabled", "optSearchFilesEnabled", "optSearchFoldersEnabled", "optSearchContentEnabled", "optSearchSectionOrder", "optFileBrowserPathSearch", "optFileBrowserSearchPageSize", "optFileContentSearchMinChars", "optFileContentSearchPageSize", "optFileContentSearchContextLines", "optFileContentSearchAutoCollapseFiles", "optFileContentSearchDefaultExpanded", "optFileContentSearchMatchesPerFile"],
     },
     {
       title: "Terminal input",
@@ -1564,11 +1589,11 @@ function applyOptions() {
     fileBrowserAllowParent = el("optFileBrowserAllowParent"),
     fileBrowserGitStatus = el("optFileBrowserGitStatus"),
     fileBrowserLineNumbers = el("optFileBrowserLineNumbers"),
+    headerSearchEnabled = el("optHeaderSearchEnabled"),
     searchWorkspacesEnabled = el("optSearchWorkspacesEnabled"),
     searchFilesEnabled = el("optSearchFilesEnabled"),
     searchFoldersEnabled = el("optSearchFoldersEnabled"),
     searchContentEnabled = el("optSearchContentEnabled"),
-    searchSectionOrder = el("optSearchSectionOrder"),
     fileBrowserPathSearch = el("optFileBrowserPathSearch"),
     fileBrowserSearchPageSize = el("optFileBrowserSearchPageSize"),
     fileContentSearchMinChars = el("optFileContentSearchMinChars"),
@@ -1635,6 +1660,8 @@ function applyOptions() {
     fileBrowserGitStatus.checked = !!options.fileBrowserGitStatus;
   if (fileBrowserLineNumbers)
     fileBrowserLineNumbers.checked = !!options.fileBrowserLineNumbers;
+  if (headerSearchEnabled)
+    headerSearchEnabled.checked = options.headerSearchEnabled !== false;
   if (searchWorkspacesEnabled)
     searchWorkspacesEnabled.checked = options.searchWorkspacesEnabled !== false;
   if (searchFilesEnabled)
@@ -1643,8 +1670,7 @@ function applyOptions() {
     searchFoldersEnabled.checked = options.searchFoldersEnabled !== false;
   if (searchContentEnabled)
     searchContentEnabled.checked = options.searchContentEnabled !== false;
-  if (searchSectionOrder)
-    searchSectionOrder.value = options.searchSectionOrder || "workspaces,files,content";
+  renderSearchSectionOrderSettings();
   if (fileBrowserPathSearch)
     fileBrowserPathSearch.checked = options.fileBrowserPathSearch !== false;
   if (fileBrowserSearchPageSize)
@@ -1677,6 +1703,11 @@ function applyOptions() {
     explorationDefaultDirectory.value = options.explorationDefaultDirectory || "";
   for (const module of settingsModules) {
     if (typeof module.apply === "function") module.apply(options);
+  }
+  const searchButtonHead = el("searchButtonHead");
+  if (searchButtonHead) {
+    searchButtonHead.hidden = options.headerSearchEnabled === false;
+    searchButtonHead.disabled = options.headerSearchEnabled === false;
   }
   syncGitWorkspaceToggle();
   syncThemeColorInputs();
@@ -1724,6 +1755,29 @@ function moveAgentStatusGroup(key, delta) {
   saveOptions();
   applyOptions();
   render();
+}
+function renderSearchSectionOrderSettings() {
+  const list = el("searchSectionOrderList"),
+    container = el("optSearchSectionOrder");
+  if (!list || !container) return;
+  const disabled = options.headerSearchEnabled === false;
+  container.classList.toggle("disabled", disabled);
+  list.innerHTML = normalizeSearchSectionOrder(options.searchSectionOrder)
+    .map((key, index, order) => {
+      const [, label, desc] = searchSectionGroupByKey[key] || [key, key, ""];
+      return `<div class="agent-sort-row" data-section="${escapeAttr(key)}"><span class="agent-sort-chip gray"><strong>${escapeHtml(label)}</strong><small>${escapeHtml(desc)}</small></span><span class="agent-sort-buttons"><button type="button" class="mini" ${index === 0 ? "disabled" : ""} onclick="moveSearchSectionGroup('${escapeAttr(key)}',-1)">↑</button><button type="button" class="mini" ${index === order.length - 1 ? "disabled" : ""} onclick="moveSearchSectionGroup('${escapeAttr(key)}',1)">↓</button></span></div>`;
+    })
+    .join("");
+}
+function moveSearchSectionGroup(key, delta) {
+  const order = normalizeSearchSectionOrder(options.searchSectionOrder);
+  const index = order.indexOf(key);
+  const nextIndex = index + delta;
+  if (index < 0 || nextIndex < 0 || nextIndex >= order.length) return;
+  [order[index], order[nextIndex]] = [order[nextIndex], order[index]];
+  options.searchSectionOrder = order.join(",");
+  saveOptions();
+  applyOptions();
 }
 function setSidebarWorkspacePercent(value) {
   options.sidebarWorkspacePercent = normalizeSidebarWorkspacePercent(value);
@@ -1910,6 +1964,11 @@ function setupSessionChrome() {
     b.textContent = "⌕";
     head.insertBefore(b, el("newWs"));
     b.onclick = () => openSearchPalette();
+  }
+  const searchButton = el("searchButtonHead");
+  if (searchButton) {
+    searchButton.hidden = options.headerSearchEnabled === false;
+    searchButton.disabled = options.headerSearchEnabled === false;
   }
   if (!el("themeToggleHead")) {
     const b = document.createElement("button");

--- a/src/assets/desktop/file_browser.js
+++ b/src/assets/desktop/file_browser.js
@@ -269,6 +269,8 @@
   function renderPreservingScroll() {
     const side = document.querySelector(".file-browser-side");
     const top = side ? side.scrollTop : state.filterScrollTop || 0;
+    const contentPane = document.querySelector(".file-browser-content-pane-body");
+    const contentTop = contentPane ? contentPane.scrollTop : 0;
     const active = document.activeElement;
     const refocusFilter = active && active.id === "fileBrowserFilter";
     const refocusSide = !refocusFilter && side && active === side;
@@ -277,6 +279,8 @@
     render();
     const next = document.querySelector(".file-browser-side");
     if (next) next.scrollTop = top;
+    const nextContentPane = document.querySelector(".file-browser-content-pane-body");
+    if (nextContentPane) nextContentPane.scrollTop = contentTop;
     if (refocusFilter) {
       const input = document.getElementById("fileBrowserFilter");
       if (input) {
@@ -888,12 +892,12 @@
     toggleFile(encodedPath) {
       const path = decodeURIComponent(encodedPath);
       state.contentSearch.expanded[path] = !state.contentSearch.expanded[path];
-      render();
+      renderPreservingScroll();
     },
     async loadFile(encodedPath) {
       try { await loadContentSearchFile(decodeURIComponent(encodedPath)); }
       catch (error) { state.contentSearch.error = error.message || String(error); }
-      render();
+      renderPreservingScroll();
     },
     openFile(encodedPath) { loadFile(decodeURIComponent(encodedPath)); },
     openMatch(encodedPath, encodedMatchId) {
@@ -904,11 +908,11 @@
     },
     expandAll() {
       for (const file of state.contentSearch.files || []) state.contentSearch.expanded[file.path] = true;
-      render();
+      renderPreservingScroll();
     },
     collapseAll() {
       state.contentSearch.expanded = {};
-      render();
+      renderPreservingScroll();
     },
     editSnippet(encodedPath, encodedMatchId) {
       const path = decodeURIComponent(encodedPath);
@@ -965,7 +969,7 @@
       state.contentSearch.contextLines = nextContext;
       try { await loadContentSearchFile(path, nextContext); }
       catch (error) { state.contentSearch.error = error.message || String(error); }
-      render();
+      renderPreservingScroll();
     },
   };
 })();

--- a/src/assets/desktop/search.js
+++ b/src/assets/desktop/search.js
@@ -20,9 +20,12 @@ function createSearchPaletteState() {
 }
 
 function openSearchPalette() {
+  try {
+    if (JSON.parse(localStorage.getItem("herdr-web-options") || "{}").headerSearchEnabled === false) return false;
+  } catch (_) {}
   const modal = el("searchPalette"),
     input = el("searchPaletteInput");
-  if (!modal || !input) return;
+  if (!modal || !input) return false;
   const previousScope = searchPaletteState.pathKind || "file";
   searchPaletteState = createSearchPaletteState();
   searchPaletteState.pathKind = previousScope;
@@ -30,6 +33,7 @@ function openSearchPalette() {
   modal.style.display = "grid";
   renderSearchPalette();
   setTimeout(() => input.focus(), 0);
+  return true;
 }
 
 function closeSearchPalette() {

--- a/src/assets/desktop/search.js
+++ b/src/assets/desktop/search.js
@@ -322,7 +322,15 @@ async function runPathSearch(seq, query, cwd, append) {
   }
 }
 
-async function runContentSearchForPalette(seq, query, cwd, append) {
+function renderSearchPalettePreservingScroll() {
+  const container = el("searchPaletteResults");
+  const top = container ? container.scrollTop : 0;
+  renderSearchPalette();
+  const next = el("searchPaletteResults");
+  if (next) next.scrollTop = top;
+}
+
+async function runContentSearchForPalette(seq, query, cwd, append, options = {}) {
   const helper = window.HerdrWorkspaceSearch;
   const opts = helper.settings();
   searchPaletteState.content.query = query;
@@ -334,11 +342,11 @@ async function runContentSearchForPalette(seq, query, cwd, append) {
   const offset = append ? searchPaletteState.content.offset : 0;
   searchPaletteState.content.loading = true;
   searchPaletteState.content.error = "";
-  renderSearchPalette();
+  (options.preserveScroll ? renderSearchPalettePreservingScroll : renderSearchPalette)();
   try {
     const data = await helper.searchContent({ cwd, query, offset, contextLines: searchPaletteState.content.contextLines });
     if (seq !== searchPaletteState.requestSeq) return;
-    helper.applyContentResults(searchPaletteState.content, data, append);
+    helper.applyContentResults(searchPaletteState.content, data, append, { preserveExpanded: !!options.preserveExpanded });
   } catch (error) {
     if (seq !== searchPaletteState.requestSeq) return;
     searchPaletteState.content.error = error.message || String(error);
@@ -539,7 +547,7 @@ const HerdrSearchPalette = {
     runWorkspaceSearch(false);
   },
   loadMorePaths() { runPathSearch(++searchPaletteState.requestSeq, searchPaletteState.query, window.HerdrWorkspaceSearch.workspaceCwd(currentSearchWorkspace()), true).then(renderSearchPalette); },
-  loadMoreContent() { runContentSearchForPalette(++searchPaletteState.requestSeq, searchPaletteState.query, window.HerdrWorkspaceSearch.workspaceCwd(currentSearchWorkspace()), true).then(renderSearchPalette); },
+  loadMoreContent() { runContentSearchForPalette(++searchPaletteState.requestSeq, searchPaletteState.query, window.HerdrWorkspaceSearch.workspaceCwd(currentSearchWorkspace()), true, { preserveScroll: true }).then(renderSearchPalettePreservingScroll); },
 };
 
 const HerdrSearchPaletteTree = {
@@ -579,12 +587,14 @@ const HerdrSearchPaletteContent = {
   expandSnippet(_path, _match, _direction) {
     const helper = window.HerdrWorkspaceSearch;
     if (!helper) return;
+    const path = decodeURIComponent(_path || "");
     const opts = helper ? helper.settings() : { contextLines: 2 };
     const current = Number(searchPaletteState.content.contextLines ?? opts.contextLines ?? 2);
     searchPaletteState.content.contextLines = window.HerdrLineContext && window.HerdrLineContext.nextContextSize
       ? window.HerdrLineContext.nextContextSize(current, { min: 3, max: 20 })
       : Math.min(20, current < 3 ? 3 : current * 2);
-    runContentSearchForPalette(++searchPaletteState.requestSeq, searchPaletteState.query, helper.workspaceCwd(currentSearchWorkspace()), false).then(renderSearchPalette);
+    if (path) searchPaletteState.content.expanded[path] = true;
+    runContentSearchForPalette(++searchPaletteState.requestSeq, searchPaletteState.query, helper.workspaceCwd(currentSearchWorkspace()), false, { preserveExpanded: true, preserveScroll: true }).then(renderSearchPalettePreservingScroll);
   },
 };
 

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -126,6 +126,11 @@ body.light {
   color: var(--fg);
   font-weight: 800;
 }
+.mobile-btn.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
 .mobile-btn.primary {
   background: var(--accent);
   border-color: var(--accent);

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -325,6 +325,12 @@
     const workspace = currentWorkspace();
     el("mobileTitle").textContent = workspaceTitle(workspace);
     el("mobileMeta").textContent = contextMeta(workspace);
+    const searchButton = el("mobileSearch");
+    if (searchButton) {
+      const disabled = headerSearchDisabled();
+      searchButton.hidden = disabled;
+      searchButton.disabled = disabled;
+    }
     document.querySelectorAll(".mobile-nav button").forEach((button) => {
       button.classList.toggle("active", button.dataset.screen === state.screen);
       button.innerHTML = mobileNavLabel(button.dataset.screen);
@@ -348,6 +354,14 @@
     else if (state.screen === "terminal") renderTerminalScreen(screen);
     else screen.innerHTML = renderHome();
     syncBrowserFavicon();
+  }
+
+  function headerSearchDisabled() {
+    try {
+      return JSON.parse(localStorage.getItem("herdr-web-options") || "{}").headerSearchEnabled === false;
+    } catch (_) {
+      return false;
+    }
   }
 
   function applyTreeIndent() {
@@ -806,6 +820,7 @@
   };
 
   function openMobileSearch() {
+    if (headerSearchDisabled()) return;
     const sheet = el("mobileSearchSheet");
     const input = el("mobileSearchInput");
     if (!sheet || !input) return;
@@ -1256,11 +1271,13 @@
     setFileBrowserLineNumbers: mobileSettings.setFileBrowserLineNumbers,
     setFileBrowserPathSearch: mobileSettings.setFileBrowserPathSearch,
     setFileBrowserSearchPageSize: mobileSettings.setFileBrowserSearchPageSize,
+    setHeaderSearchEnabled: mobileSettings.setHeaderSearchEnabled,
     setSearchWorkspacesEnabled: mobileSettings.setSearchWorkspacesEnabled,
     setSearchFilesEnabled: mobileSettings.setSearchFilesEnabled,
     setSearchFoldersEnabled: mobileSettings.setSearchFoldersEnabled,
     setSearchContentEnabled: mobileSettings.setSearchContentEnabled,
     setSearchSectionOrder: mobileSettings.setSearchSectionOrder,
+    moveSearchSection: mobileSettings.moveSearchSection,
     setFileContentSearchMinChars: mobileSettings.setFileContentSearchMinChars,
     setFileContentSearchPageSize: mobileSettings.setFileContentSearchPageSize,
     setFileContentSearchAutoCollapseFiles: mobileSettings.setFileContentSearchAutoCollapseFiles,

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -973,7 +973,15 @@
     if (seq === mobileSearch.requestSeq) mobileSearch.pathLoading = false;
   }
 
-  async function runMobileContentSearch(seq, query, cwd, append) {
+  function renderMobileSearchPreservingScroll() {
+    const box = el("mobileSearchResults");
+    const top = box ? box.scrollTop : 0;
+    renderMobileSearch();
+    const next = el("mobileSearchResults");
+    if (next) next.scrollTop = top;
+  }
+
+  async function runMobileContentSearch(seq, query, cwd, append, options = {}) {
     const helper = globalThis.HerdrWorkspaceSearch;
     const opts = helper.settings();
     mobileSearch.content.query = query;
@@ -984,12 +992,12 @@
     }
     mobileSearch.content.loading = true;
     mobileSearch.content.error = "";
-    renderMobileSearch();
+    (options.preserveScroll ? renderMobileSearchPreservingScroll : renderMobileSearch)();
     try {
       const offset = append ? mobileSearch.content.offset : 0;
       const data = await helper.searchContent({ cwd, query, offset, contextLines: mobileSearch.content.contextLines });
       if (seq !== mobileSearch.requestSeq) return;
-      helper.applyContentResults(mobileSearch.content, data, append);
+      helper.applyContentResults(mobileSearch.content, data, append, { preserveExpanded: !!options.preserveExpanded });
     } catch (error) {
       if (seq !== mobileSearch.requestSeq) return;
       mobileSearch.content.error = error.message || String(error);
@@ -1194,7 +1202,7 @@
     openMatch(encodedPath, encodedMatchId) { globalThis.HerdrMobileSearch.openContent(decodeURIComponent(encodedPath), decodeURIComponent(encodedMatchId)); },
     expandAll() { for (const file of mobileSearch.content.files || []) mobileSearch.content.expanded[file.path] = true; renderMobileSearch(); },
     collapseAll() { for (const file of mobileSearch.content.files || []) mobileSearch.content.expanded[file.path] = false; renderMobileSearch(); },
-    loadMore() { runMobileContentSearch(++mobileSearch.requestSeq, mobileSearch.query, currentWorkspaceCwd(), true).then(renderMobileSearch); },
+    loadMore() { runMobileContentSearch(++mobileSearch.requestSeq, mobileSearch.query, currentWorkspaceCwd(), true, { preserveScroll: true }).then(renderMobileSearchPreservingScroll); },
     loadFile(_path) {},
     expandSnippet(_path, _match, _direction) {
       const helper = globalThis.HerdrWorkspaceSearch;
@@ -1203,7 +1211,9 @@
       mobileSearch.content.contextLines = globalThis.HerdrLineContext && globalThis.HerdrLineContext.nextContextSize
         ? globalThis.HerdrLineContext.nextContextSize(current, { min: 3, max: 20 })
         : Math.min(20, current < 3 ? 3 : current * 2);
-      runMobileContentSearch(++mobileSearch.requestSeq, mobileSearch.query, currentWorkspaceCwd(), false).then(renderMobileSearch);
+      const path = decodeURIComponent(_path || "");
+      if (path) mobileSearch.content.expanded[path] = true;
+      runMobileContentSearch(++mobileSearch.requestSeq, mobileSearch.query, currentWorkspaceCwd(), false, { preserveExpanded: true, preserveScroll: true }).then(renderMobileSearchPreservingScroll);
     },
   };
 

--- a/src/assets/mobile/settings.js
+++ b/src/assets/mobile/settings.js
@@ -13,10 +13,6 @@
       const depth = fileBrowserDepthValue();
       const lineNumbers = fileBrowserLineNumbersEnabled();
       const headerSearch = headerSearchEnabled();
-      const searchWorkspaces = searchWorkspacesEnabled();
-      const searchFiles = searchFilesEnabled();
-      const searchFolders = searchFoldersEnabled();
-      const searchContent = searchContentEnabled();
       const searchOrder = searchSectionOrderValue();
       const pathSearch = fileBrowserPathSearchEnabled();
       const pathSearchPageSize = fileBrowserSearchPageSizeValue();
@@ -30,7 +26,7 @@
       const explorationDirectory = explorationDefaultDirectoryValue();
       const volume = notificationVolumeValue();
       const links = terminalLinksEnabled();
-      return `<section class="mobile-section mobile-form"><h2>Settings</h2>${appearanceSection(theme)}${layoutSection(layout)}${filesSection(depth, lineNumbers, headerSearch, searchWorkspaces, searchFiles, searchFolders, searchContent, searchOrder, pathSearch, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile)}${workspacesSection(worktreeDirectory, explorationDirectory)}${alertsSection(notifications, volume)}${terminalSection(font, links)}${dataSection()}${state.error ? `<div class="mobile-error">${escapeHtml(state.error)}</div>` : ""}</section>`;
+      return `<section class="mobile-section mobile-form"><h2>Settings</h2>${appearanceSection(theme)}${layoutSection(layout)}${filesSection(depth, lineNumbers, headerSearch, searchOrder, pathSearch, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile)}${workspacesSection(worktreeDirectory, explorationDirectory)}${alertsSection(notifications, volume)}${terminalSection(font, links)}${dataSection()}${state.error ? `<div class="mobile-error">${escapeHtml(state.error)}</div>` : ""}</section>`;
     }
 
     function appearanceSection(theme) {
@@ -41,14 +37,17 @@
       return `<div class="mobile-settings-group"><h3>Layout</h3><label><span>Layout mode</span><select onchange="HerdrMobile.setLayoutPreference(this.value)"><option value="auto" ${layout === "auto" ? "selected" : ""}>Auto</option><option value="mobile" ${layout === "mobile" ? "selected" : ""}>Mobile</option><option value="desktop" ${layout === "desktop" ? "selected" : ""}>Desktop</option></select><small>Auto uses viewport width, not user agent.</small></label></div>`;
     }
 
-    function filesSection(depth, lineNumbers, headerSearch, searchWorkspaces, searchFiles, searchFolders, searchContent, searchOrder, pathSearch, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile) {
-      return `<div class="mobile-settings-group"><h3>Files and search</h3><label><span>Browser depth</span><input type="number" min="0" max="8" step="1" value="${depth}" onchange="HerdrMobile.setFileBrowserDepth(this.value)"></label><small>0 shows current folder only. 3 expands three folder levels.</small><label><input type="checkbox" ${lineNumbers ? "checked" : ""} onchange="HerdrMobile.setFileBrowserLineNumbers(this.checked)"><span>Line numbers</span><small>Show line numbers when previewing text files.</small></label><label><input type="checkbox" ${headerSearch ? "checked" : ""} onchange="HerdrMobile.setHeaderSearchEnabled(this.checked)"><span>Header search button</span><small>Show the search action and allow the palette to open.</small></label><label><input type="checkbox" ${searchWorkspaces ? "checked" : ""} onchange="HerdrMobile.setSearchWorkspacesEnabled(this.checked)"><span>Header search workspaces</span><small>Show workspaces, worktrees, panels, and agents.</small></label><label><input type="checkbox" ${searchFiles ? "checked" : ""} onchange="HerdrMobile.setSearchFilesEnabled(this.checked)"><span>Header search files</span><small>Search file paths in the selected workspace.</small></label><label><input type="checkbox" ${searchFolders ? "checked" : ""} onchange="HerdrMobile.setSearchFoldersEnabled(this.checked)"><span>Header search folders</span><small>Search folder paths in the selected workspace.</small></label><label><input type="checkbox" ${searchContent ? "checked" : ""} onchange="HerdrMobile.setSearchContentEnabled(this.checked)"><span>Header search contents</span><small>Search text file contents in the selected workspace.</small></label><div><span>Search section order</span>${renderSearchSectionOrder(searchOrder)}</div><small>Use arrows to move workspaces, files, and content sections.</small><label><input type="checkbox" ${pathSearch ? "checked" : ""} onchange="HerdrMobile.setFileBrowserPathSearch(this.checked)"><span>File/folder backend search</span><small>Enable backend path search for the header file and folder sections.</small></label><label><span>File/folder search page size</span><input type="number" min="10" max="500" step="10" value="${pathSearchPageSize}" onchange="HerdrMobile.setFileBrowserSearchPageSize(this.value)"></label><small>Backend file/folder results loaded per lazy page.</small><label><span>Content search minimum characters</span><input type="number" min="1" max="20" step="1" value="${minChars}" onchange="HerdrMobile.setFileContentSearchMinChars(this.value)"></label><small>Minimum typed characters before content search runs.</small><label><span>Content search page size</span><input type="number" min="10" max="500" step="10" value="${contentPageSize}" onchange="HerdrMobile.setFileContentSearchPageSize(this.value)"></label><small>File groups loaded per content-search lazy page.</small><label><span>Content search context</span><input type="number" min="0" max="20" step="1" value="${contextLines}" onchange="HerdrMobile.setFileContentSearchContextLines(this.value)"></label><small>Default lines around each content match.</small><label><span>Content search auto-collapse</span><input type="number" min="0" max="200" step="1" value="${autoCollapse}" onchange="HerdrMobile.setFileContentSearchAutoCollapseFiles(this.value)"></label><small>Collapse file groups above this result count. 0 means never auto-collapse.</small><label><input type="checkbox" ${defaultExpanded ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchDefaultExpanded(this.checked)"><span>Content results expanded by default</span><small>Expand file groups when results load unless auto-collapse applies.</small></label><label><span>Content matches per file</span><input type="number" min="1" max="50" step="1" value="${matchesPerFile}" onchange="HerdrMobile.setFileContentSearchMatchesPerFile(this.value)"></label><small>Initial matches loaded per result file.</small></div>`;
+    function filesSection(depth, lineNumbers, headerSearch, searchOrder, pathSearch, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile) {
+      return `<div class="mobile-settings-group"><h3>Files and search</h3><label><span>Browser depth</span><input type="number" min="0" max="8" step="1" value="${depth}" onchange="HerdrMobile.setFileBrowserDepth(this.value)"></label><small>0 shows current folder only. 3 expands three folder levels.</small><label><input type="checkbox" ${lineNumbers ? "checked" : ""} onchange="HerdrMobile.setFileBrowserLineNumbers(this.checked)"><span>Line numbers</span><small>Show line numbers when previewing text files.</small></label><label><input type="checkbox" ${headerSearch ? "checked" : ""} onchange="HerdrMobile.setHeaderSearchEnabled(this.checked)"><span>Header search button</span><small>Show the search action and allow the palette to open.</small></label><div><span>Search section order</span>${renderSearchSectionOrder(searchOrder)}</div><small>Use arrows to move sections. Use Shown/Hidden to include or remove a section.</small><label><input type="checkbox" ${pathSearch ? "checked" : ""} onchange="HerdrMobile.setFileBrowserPathSearch(this.checked)"><span>File/folder backend search</span><small>Enable backend path search for the search file and folder sections.</small></label><label><span>File/folder page size</span><input type="number" min="10" max="500" step="10" value="${pathSearchPageSize}" onchange="HerdrMobile.setFileBrowserSearchPageSize(this.value)"></label><label><span>Content minimum characters</span><input type="number" min="1" max="20" step="1" value="${minChars}" onchange="HerdrMobile.setFileContentSearchMinChars(this.value)"></label><label><span>Content page size</span><input type="number" min="10" max="500" step="10" value="${contentPageSize}" onchange="HerdrMobile.setFileContentSearchPageSize(this.value)"></label><label><span>Content context lines</span><input type="number" min="0" max="20" step="1" value="${contextLines}" onchange="HerdrMobile.setFileContentSearchContextLines(this.value)"></label><label><span>Content auto-collapse files</span><input type="number" min="0" max="200" step="1" value="${autoCollapse}" onchange="HerdrMobile.setFileContentSearchAutoCollapseFiles(this.value)"></label><label><input type="checkbox" ${defaultExpanded ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchDefaultExpanded(this.checked)"><span>Content results expanded by default</span><small>Expand each file group when content results load.</small></label><label><span>Content matches per file</span><input type="number" min="1" max="50" step="1" value="${matchesPerFile}" onchange="HerdrMobile.setFileContentSearchMatchesPerFile(this.value)"></label></div>`;
     }
 
     function renderSearchSectionOrder(value) {
       const labels = { workspaces: "Workspaces", files: "Files", content: "Content" };
       const order = normalizeSearchSectionOrder(value);
-      return `<div class="mobile-actions mobile-search-order">${order.map((key, index) => `<span class="mobile-btn mobile-search-order-row"><strong>${escapeHtml(labels[key] || key)}</strong><button class="mobile-btn" ${index === 0 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',-1)">↑</button><button class="mobile-btn" ${index === order.length - 1 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',1)">↓</button></span>`).join("")}</div>`;
+      return `<div class="mobile-actions mobile-search-order">${order.map((key, index) => {
+        const enabled = searchSectionEnabled(key);
+        return `<span class="mobile-btn mobile-search-order-row"><strong>${escapeHtml(labels[key] || key)}</strong><button class="mobile-btn" ${index === 0 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',-1)">↑</button><button class="mobile-btn ${enabled ? "active" : ""}" onclick="HerdrMobile.toggleSearchSection('${key}')">${enabled ? "Shown" : "Hidden"}</button><button class="mobile-btn" ${index === order.length - 1 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',1)">↓</button></span>`;
+      }).join("")}</div>`;
     }
 
     function workspacesSection(worktreeDirectory, explorationDirectory) {
@@ -110,10 +109,13 @@
     }
 
     function headerSearchEnabled() { return readOptions().headerSearchEnabled !== false; }
-    function searchWorkspacesEnabled() { return readOptions().searchWorkspacesEnabled !== false; }
-    function searchFilesEnabled() { return readOptions().searchFilesEnabled !== false; }
-    function searchFoldersEnabled() { return readOptions().searchFoldersEnabled !== false; }
-    function searchContentEnabled() { return readOptions().searchContentEnabled !== false; }
+    function searchSectionOptionKey(key) {
+      return { workspaces: "searchWorkspacesEnabled", files: "searchFilesEnabled", content: "searchContentEnabled" }[key] || "";
+    }
+    function searchSectionEnabled(key) {
+      const optionKey = searchSectionOptionKey(key);
+      return !optionKey || readOptions()[optionKey] !== false;
+    }
     function normalizeSearchSectionOrder(value) {
       const allowed = ["workspaces", "files", "content"];
       const seen = new Set();
@@ -245,6 +247,15 @@
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
+    function toggleSearchSection(key) {
+      const parsed = readOptions();
+      const optionKey = searchSectionOptionKey(String(key || ""));
+      if (!optionKey) return;
+      parsed[optionKey] = parsed[optionKey] === false;
+      writeOptions(parsed);
+      if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
+    }
+
     function moveSearchSection(key, delta) {
       const parsed = readOptions();
       const order = normalizeSearchSectionOrder(parsed.searchSectionOrder);
@@ -357,6 +368,7 @@
       setSearchContentEnabled(value) { setBooleanOption("searchContentEnabled", value); },
       moveSearchSection,
       setSearchSectionOrder,
+      toggleSearchSection,
       setFileContentSearchMinChars,
       setFileContentSearchPageSize,
       setFileContentSearchAutoCollapseFiles,

--- a/src/assets/mobile/settings.js
+++ b/src/assets/mobile/settings.js
@@ -12,6 +12,7 @@
       const notifications = browserNotificationsEnabled();
       const depth = fileBrowserDepthValue();
       const lineNumbers = fileBrowserLineNumbersEnabled();
+      const headerSearch = headerSearchEnabled();
       const searchWorkspaces = searchWorkspacesEnabled();
       const searchFiles = searchFilesEnabled();
       const searchFolders = searchFoldersEnabled();
@@ -29,7 +30,7 @@
       const explorationDirectory = explorationDefaultDirectoryValue();
       const volume = notificationVolumeValue();
       const links = terminalLinksEnabled();
-      return `<section class="mobile-section mobile-form"><h2>Settings</h2>${appearanceSection(theme)}${layoutSection(layout)}${filesSection(depth, lineNumbers, searchWorkspaces, searchFiles, searchFolders, searchContent, searchOrder, pathSearch, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile)}${workspacesSection(worktreeDirectory, explorationDirectory)}${alertsSection(notifications, volume)}${terminalSection(font, links)}${dataSection()}${state.error ? `<div class="mobile-error">${escapeHtml(state.error)}</div>` : ""}</section>`;
+      return `<section class="mobile-section mobile-form"><h2>Settings</h2>${appearanceSection(theme)}${layoutSection(layout)}${filesSection(depth, lineNumbers, headerSearch, searchWorkspaces, searchFiles, searchFolders, searchContent, searchOrder, pathSearch, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile)}${workspacesSection(worktreeDirectory, explorationDirectory)}${alertsSection(notifications, volume)}${terminalSection(font, links)}${dataSection()}${state.error ? `<div class="mobile-error">${escapeHtml(state.error)}</div>` : ""}</section>`;
     }
 
     function appearanceSection(theme) {
@@ -40,8 +41,14 @@
       return `<div class="mobile-settings-group"><h3>Layout</h3><label><span>Layout mode</span><select onchange="HerdrMobile.setLayoutPreference(this.value)"><option value="auto" ${layout === "auto" ? "selected" : ""}>Auto</option><option value="mobile" ${layout === "mobile" ? "selected" : ""}>Mobile</option><option value="desktop" ${layout === "desktop" ? "selected" : ""}>Desktop</option></select><small>Auto uses viewport width, not user agent.</small></label></div>`;
     }
 
-    function filesSection(depth, lineNumbers, searchWorkspaces, searchFiles, searchFolders, searchContent, searchOrder, pathSearch, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile) {
-      return `<div class="mobile-settings-group"><h3>Files and search</h3><label><span>Browser depth</span><input type="number" min="0" max="8" step="1" value="${depth}" onchange="HerdrMobile.setFileBrowserDepth(this.value)"></label><small>0 shows current folder only. 3 expands three folder levels.</small><label><input type="checkbox" ${lineNumbers ? "checked" : ""} onchange="HerdrMobile.setFileBrowserLineNumbers(this.checked)"><span>Line numbers</span><small>Show line numbers when previewing text files.</small></label><label><input type="checkbox" ${searchWorkspaces ? "checked" : ""} onchange="HerdrMobile.setSearchWorkspacesEnabled(this.checked)"><span>Header search workspaces</span><small>Show workspaces, worktrees, panels, and agents.</small></label><label><input type="checkbox" ${searchFiles ? "checked" : ""} onchange="HerdrMobile.setSearchFilesEnabled(this.checked)"><span>Header search files</span><small>Search file paths in the selected workspace.</small></label><label><input type="checkbox" ${searchFolders ? "checked" : ""} onchange="HerdrMobile.setSearchFoldersEnabled(this.checked)"><span>Header search folders</span><small>Search folder paths in the selected workspace.</small></label><label><input type="checkbox" ${searchContent ? "checked" : ""} onchange="HerdrMobile.setSearchContentEnabled(this.checked)"><span>Header search contents</span><small>Search text file contents in the selected workspace.</small></label><label><span>Search section order</span><input value="${escapeHtml(searchOrder)}" onchange="HerdrMobile.setSearchSectionOrder(this.value)"></label><small>Comma list using workspaces, files, content.</small><label><input type="checkbox" ${pathSearch ? "checked" : ""} onchange="HerdrMobile.setFileBrowserPathSearch(this.checked)"><span>File/folder backend search</span><small>Enable backend path search for the header file and folder sections.</small></label><label><span>File/folder search page size</span><input type="number" min="10" max="500" step="10" value="${pathSearchPageSize}" onchange="HerdrMobile.setFileBrowserSearchPageSize(this.value)"></label><small>Backend file/folder results loaded per lazy page.</small><label><span>Content search minimum characters</span><input type="number" min="1" max="20" step="1" value="${minChars}" onchange="HerdrMobile.setFileContentSearchMinChars(this.value)"></label><small>Minimum typed characters before content search runs.</small><label><span>Content search page size</span><input type="number" min="10" max="500" step="10" value="${contentPageSize}" onchange="HerdrMobile.setFileContentSearchPageSize(this.value)"></label><small>File groups loaded per content-search lazy page.</small><label><span>Content search context</span><input type="number" min="0" max="20" step="1" value="${contextLines}" onchange="HerdrMobile.setFileContentSearchContextLines(this.value)"></label><small>Default lines around each content match.</small><label><span>Content search auto-collapse</span><input type="number" min="0" max="200" step="1" value="${autoCollapse}" onchange="HerdrMobile.setFileContentSearchAutoCollapseFiles(this.value)"></label><small>Collapse file groups above this result count. 0 means never auto-collapse.</small><label><input type="checkbox" ${defaultExpanded ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchDefaultExpanded(this.checked)"><span>Content results expanded by default</span><small>Expand file groups when results load unless auto-collapse applies.</small></label><label><span>Content matches per file</span><input type="number" min="1" max="50" step="1" value="${matchesPerFile}" onchange="HerdrMobile.setFileContentSearchMatchesPerFile(this.value)"></label><small>Initial matches loaded per result file.</small></div>`;
+    function filesSection(depth, lineNumbers, headerSearch, searchWorkspaces, searchFiles, searchFolders, searchContent, searchOrder, pathSearch, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile) {
+      return `<div class="mobile-settings-group"><h3>Files and search</h3><label><span>Browser depth</span><input type="number" min="0" max="8" step="1" value="${depth}" onchange="HerdrMobile.setFileBrowserDepth(this.value)"></label><small>0 shows current folder only. 3 expands three folder levels.</small><label><input type="checkbox" ${lineNumbers ? "checked" : ""} onchange="HerdrMobile.setFileBrowserLineNumbers(this.checked)"><span>Line numbers</span><small>Show line numbers when previewing text files.</small></label><label><input type="checkbox" ${headerSearch ? "checked" : ""} onchange="HerdrMobile.setHeaderSearchEnabled(this.checked)"><span>Header search button</span><small>Show the search action and allow the palette to open.</small></label><label><input type="checkbox" ${searchWorkspaces ? "checked" : ""} onchange="HerdrMobile.setSearchWorkspacesEnabled(this.checked)"><span>Header search workspaces</span><small>Show workspaces, worktrees, panels, and agents.</small></label><label><input type="checkbox" ${searchFiles ? "checked" : ""} onchange="HerdrMobile.setSearchFilesEnabled(this.checked)"><span>Header search files</span><small>Search file paths in the selected workspace.</small></label><label><input type="checkbox" ${searchFolders ? "checked" : ""} onchange="HerdrMobile.setSearchFoldersEnabled(this.checked)"><span>Header search folders</span><small>Search folder paths in the selected workspace.</small></label><label><input type="checkbox" ${searchContent ? "checked" : ""} onchange="HerdrMobile.setSearchContentEnabled(this.checked)"><span>Header search contents</span><small>Search text file contents in the selected workspace.</small></label><div><span>Search section order</span>${renderSearchSectionOrder(searchOrder)}</div><small>Use arrows to move workspaces, files, and content sections.</small><label><input type="checkbox" ${pathSearch ? "checked" : ""} onchange="HerdrMobile.setFileBrowserPathSearch(this.checked)"><span>File/folder backend search</span><small>Enable backend path search for the header file and folder sections.</small></label><label><span>File/folder search page size</span><input type="number" min="10" max="500" step="10" value="${pathSearchPageSize}" onchange="HerdrMobile.setFileBrowserSearchPageSize(this.value)"></label><small>Backend file/folder results loaded per lazy page.</small><label><span>Content search minimum characters</span><input type="number" min="1" max="20" step="1" value="${minChars}" onchange="HerdrMobile.setFileContentSearchMinChars(this.value)"></label><small>Minimum typed characters before content search runs.</small><label><span>Content search page size</span><input type="number" min="10" max="500" step="10" value="${contentPageSize}" onchange="HerdrMobile.setFileContentSearchPageSize(this.value)"></label><small>File groups loaded per content-search lazy page.</small><label><span>Content search context</span><input type="number" min="0" max="20" step="1" value="${contextLines}" onchange="HerdrMobile.setFileContentSearchContextLines(this.value)"></label><small>Default lines around each content match.</small><label><span>Content search auto-collapse</span><input type="number" min="0" max="200" step="1" value="${autoCollapse}" onchange="HerdrMobile.setFileContentSearchAutoCollapseFiles(this.value)"></label><small>Collapse file groups above this result count. 0 means never auto-collapse.</small><label><input type="checkbox" ${defaultExpanded ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchDefaultExpanded(this.checked)"><span>Content results expanded by default</span><small>Expand file groups when results load unless auto-collapse applies.</small></label><label><span>Content matches per file</span><input type="number" min="1" max="50" step="1" value="${matchesPerFile}" onchange="HerdrMobile.setFileContentSearchMatchesPerFile(this.value)"></label><small>Initial matches loaded per result file.</small></div>`;
+    }
+
+    function renderSearchSectionOrder(value) {
+      const labels = { workspaces: "Workspaces", files: "Files", content: "Content" };
+      const order = normalizeSearchSectionOrder(value);
+      return `<div class="mobile-actions mobile-search-order">${order.map((key, index) => `<span class="mobile-btn mobile-search-order-row"><strong>${escapeHtml(labels[key] || key)}</strong><button class="mobile-btn" ${index === 0 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',-1)">↑</button><button class="mobile-btn" ${index === order.length - 1 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',1)">↓</button></span>`).join("")}</div>`;
     }
 
     function workspacesSection(worktreeDirectory, explorationDirectory) {
@@ -102,11 +109,26 @@
       return readOptions().fileBrowserPathSearch !== false;
     }
 
+    function headerSearchEnabled() { return readOptions().headerSearchEnabled !== false; }
     function searchWorkspacesEnabled() { return readOptions().searchWorkspacesEnabled !== false; }
     function searchFilesEnabled() { return readOptions().searchFilesEnabled !== false; }
     function searchFoldersEnabled() { return readOptions().searchFoldersEnabled !== false; }
     function searchContentEnabled() { return readOptions().searchContentEnabled !== false; }
-    function searchSectionOrderValue() { return String(readOptions().searchSectionOrder || "workspaces,files,content"); }
+    function normalizeSearchSectionOrder(value) {
+      const allowed = ["workspaces", "files", "content"];
+      const seen = new Set();
+      const order = [];
+      for (const part of String(value || "").split(",")) {
+        const key = part.trim().toLowerCase();
+        if (allowed.includes(key) && !seen.has(key)) {
+          seen.add(key);
+          order.push(key);
+        }
+      }
+      for (const key of allowed) if (!seen.has(key)) order.push(key);
+      return order;
+    }
+    function searchSectionOrderValue() { return normalizeSearchSectionOrder(readOptions().searchSectionOrder || "workspaces,files,content").join(","); }
 
     function fileBrowserSearchPageSizeValue() {
       const value = Number(readOptions().fileBrowserSearchPageSize);
@@ -202,6 +224,13 @@
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
+    function setHeaderSearchEnabled(value) {
+      const parsed = readOptions();
+      parsed.headerSearchEnabled = !!value;
+      writeOptions(parsed);
+      if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
+    }
+
     function setBooleanOption(key, value) {
       const parsed = readOptions();
       parsed[key] = !!value;
@@ -211,7 +240,19 @@
 
     function setSearchSectionOrder(value) {
       const parsed = readOptions();
-      parsed.searchSectionOrder = String(value || "").trim();
+      parsed.searchSectionOrder = normalizeSearchSectionOrder(value).join(",");
+      writeOptions(parsed);
+      if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
+    }
+
+    function moveSearchSection(key, delta) {
+      const parsed = readOptions();
+      const order = normalizeSearchSectionOrder(parsed.searchSectionOrder);
+      const index = order.indexOf(String(key || ""));
+      const nextIndex = index + Number(delta || 0);
+      if (index < 0 || nextIndex < 0 || nextIndex >= order.length) return;
+      [order[index], order[nextIndex]] = [order[nextIndex], order[index]];
+      parsed.searchSectionOrder = order.join(",");
       writeOptions(parsed);
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
@@ -309,10 +350,12 @@
       setFileBrowserLineNumbers,
       setFileBrowserPathSearch,
       setFileBrowserSearchPageSize,
+      setHeaderSearchEnabled,
       setSearchWorkspacesEnabled(value) { setBooleanOption("searchWorkspacesEnabled", value); },
       setSearchFilesEnabled(value) { setBooleanOption("searchFilesEnabled", value); },
       setSearchFoldersEnabled(value) { setBooleanOption("searchFoldersEnabled", value); },
       setSearchContentEnabled(value) { setBooleanOption("searchContentEnabled", value); },
+      moveSearchSection,
       setSearchSectionOrder,
       setFileContentSearchMinChars,
       setFileContentSearchPageSize,

--- a/src/assets/shared/workspace_search.js
+++ b/src/assets/shared/workspace_search.js
@@ -128,8 +128,9 @@
     state.contextLines = settings().contextLines;
   }
 
-  function applyContentResults(state, data, append) {
+  function applyContentResults(state, data, append, options = {}) {
     const files = data.files || [];
+    const previousExpanded = state.expanded || {};
     state.files = append ? state.files.concat(files) : files;
     state.total_files = data.total_files || state.files.length;
     state.total_matches = data.total_matches || 0;
@@ -139,7 +140,11 @@
       const opts = settings();
       state.expanded = {};
       const expanded = defaultContentExpanded(opts, state.files.length);
-      for (const file of state.files) state.expanded[file.path] = expanded;
+      for (const file of state.files) {
+        state.expanded[file.path] = options.preserveExpanded && Object.prototype.hasOwnProperty.call(previousExpanded, file.path)
+          ? previousExpanded[file.path]
+          : expanded;
+      }
     } else {
       const expanded = defaultContentExpanded(settings(), state.files.length);
       for (const file of files) if (!Object.prototype.hasOwnProperty.call(state.expanded, file.path)) state.expanded[file.path] = expanded;


### PR DESCRIPTION
## Summary
- unify header search section ordering and visibility in one Settings control
- add per-section Shown/Hidden buttons between up/down arrows
- keep desktop and mobile controls aligned

## Validation
- node --test src/assets/*.test.mjs
- cargo fmt --check
- cargo test
- local release build and deploy verified