### PR TITLE
Add backend-aware session manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The README is the project summary and documentation index. Detailed functionalit
 ## Functionality summary
 
 - Multi-workspace terminal UI with desktop and mobile layouts, backed by the built-in backend by default.
+- Backend-aware session manager that detects built-in and external Herdr sessions, switches between them, and can create or launch sessions in either backend.
 - First-party `herdr-webui-tui` for terminal-native workspace/agent navigation, live attach/input/resize/detach, ANSI colors/styles, `--theme dark|light|system`, Ctrl-B help/menu, and smoke-friendly summary/once modes.
 - Workspace and linked worktree navigation with per-panel terminal state.
 - Git UI for status, diffs, staging, commits, stash, branches, cleanup, worktrees, conflicts, blame, and file history.
@@ -68,7 +69,7 @@ See [Technical details](docs/technical-details.md) for routes, limits, data flow
 
 - Git status uses one porcelain scan per refresh and propagates parent folder state server-side with priority red > yellow > green.
 - Content search skips dependency/build folders, caps traversal, skips large or binary files, paginates file groups, lazy-loads per-file match details, and validates regex patterns before traversal.
-- Terminal output is frame-batched before xterm writes, and large paste input uses bounded WebSocket chunks with backpressure.
+- Terminal output is frame-batched before xterm writes, large paste input uses bounded WebSocket chunks with backpressure, and browser terminal query replies such as OSC 10/11 colors are filtered before they can leak into PTY input.
 - Large Git diffs use lazy loading, placeholders, context expansion, and server-side Git commands rather than browser-side repository scanning.
 - Path inputs are cleaned before file-system operations. Mutating Git/file actions use backend validation, hash guards, and confirmation where destructive.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,6 +8,7 @@ Sidebar:
 
 - The sidebar can collapse via the divider; state is stored in browser `localStorage` and collapsed mode keeps compact blocked/working/idle/done counters.
 - The header exposes unified Search, Theme, No-sleep, Worktree, New workspace, Git, and Files controls. The footer exposes session info, shortcut help, Settings, and backend status. Built-in backend mode is shown as `built-in` instead of the internal built-in version string.
+- The footer session button opens the session manager. It lists detected external Herdr sessions and built-in sessions together, shows the backend kind for each row, and can target or launch a session in either backend.
 - Theme colors are browser-local and shared with shell controls and embedded Git UI.
 - No-sleep supports Off, Auto, 1 hour, 2 hours, 4 hours, and Infinite from a compact dropdown.
 - No-sleep status polling is adaptive: WebUI does not keep polling while no-sleep is Off and the server is healthy. Active modes and transient errors still retry so the control stays accurate without idle browser/network churn.
@@ -27,12 +28,15 @@ Settings:
 Built-in backend:
 
 - Fresh installs and fresh `webui-settings.json` files default to the built-in backend. External Herdr remains available as an explicit compatibility mode.
+- Session manager discovery scans external Herdr sockets under the Herdr config session directory and built-in socket namespaces under the WebUI config directory. The UI can create a new built-in session inside the WebUI process or launch an external Herdr session through `HERDR_WEB_HERDR_BIN`/`herdr`.
+- Selecting a session stores both the session name and backend target. HTTP requests send `x-herdr-session` plus `x-herdr-backend`, and terminal/event WebSockets include the same backend target as query data. This lets a single WebUI process talk to external Herdr and built-in sessions in parallel.
 - The footer shows `built-in` when `backend_mode` resolves to the built-in backend, rather than exposing the internal built-in version string as if it were an external Herdr daemon.
 - The built-in backend owns local workspace, tab, pane, agent, terminal, and worktree state inside the WebUI process. It uses local sockets for control and terminal attach so the browser UI and TUI client share one protocol path.
 - Control API coverage includes `ping`, `server.stop`, `session.snapshot`, `workspace.list/create/rename/close`, `tab.list/create/rename/close`, `pane.list/get/layout/close/read`, `agent.list/start`, `worktree.list/open/create`, and explicit unsupported errors for unsafe `worktree.remove`.
 - `ping` reports `builtin_backend: true`, `terminal_attach: true`, `terminal_server_scroll: false`, and `jcode_detection: true` so clients can choose safe feature paths.
 - `session.snapshot` returns focused workspace/tab/pane IDs plus workspace, tab, pane, and agent lists for fast WebUI and TUI bootstrap.
 - Terminals run through `portable-pty`, inherit a login-shell-like macOS/user `PATH`, set xterm-compatible terminal env, collect recent output, and expose attach/input/paste/resize/detach over the terminal socket.
+- Browser terminal input filters terminal-emulator query replies such as OSC 10/11 color responses before they reach the PTY. Native terminals consume those replies internally; xterm.js exposes them through `onData`, so WebUI drops them to avoid leaking `10;rgb:...`/`11;rgb:...` text into shells or agents.
 - Built-in terminal scroll is local xterm/TUI scroll only. Server-side scrollback, search, copy mode, and selection APIs are documented gaps.
 - Agent detection covers Herdr-style aliases for Jcode, Claude, OpenCode, Cursor, and Qoder CLI from direct argv, wrapped shells, and process trees. Jcode status detection follows the Herdr `jcode-support` manifest rules and also treats active Jcode background task cards as `working` so status does not jump to `idle` while a background task is still running.
 - Built-in events currently acknowledge subscription requests and rely on snapshot refresh fallback. A true event hub is still a parity gap.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ The README is the short project summary. This `docs/` directory holds detailed f
 | --- | --- | --- |
 | Run or install locally | [Installation](installation.md) | CLI flags, HTTPS modes, auth, service commands. |
 | What the app can do | [Features](features.md) | Sidebar, panels, worktrees, file browser, Git UI, terminal, settings. |
+| Session manager and backend choice | [Installation: Sessions](installation.md#sessions) | Detect/select/create built-in and external Herdr sessions, per-request backend target routing. |
 | File explorer behavior | [Features: File browser](features.md#webui-features) | [Technical details: File explorer](technical-details.md#file-explorer). |
 | Unified header search | [Features: File browser](features.md#webui-features) | [Technical details: Unified header search](technical-details.md#unified-header-search). |
 | Backend content search | [Features: File browser](features.md#webui-features) | [Technical details: Content search](technical-details.md#content-search). |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -212,7 +212,7 @@ Non-localhost binds require both username and password. WebUI rejects `0.0.0.0` 
 
 ## Sessions
 
-By default, WebUI targets Herdr's default session sockets.
+By default, fresh WebUI settings target the built-in backend default session. External Herdr sessions remain available from the session manager or by starting WebUI with `--backend-mode external-herdr`.
 
 Use a named session:
 
@@ -220,7 +220,14 @@ Use a named session:
 target/release/herdr-webui --session work --bind 127.0.0.1:8787
 ```
 
-When Herdr is offline, WebUI shows a session manager. It can launch Herdr using `HERDR_WEB_HERDR_BIN` or `herdr` from `PATH`, retry connection, reset workspaces, or close the current Herdr session.
+The footer session button opens the session manager. It detects:
+
+- built-in sessions under the WebUI config directory, for example `~/.config/herdr-webui/builtin/default`,
+- external Herdr sessions under the Herdr config directory, for example `~/.config/herdr/sessions/work`.
+
+Use **New built-in** to create or start a built-in session inside the WebUI process. Use **New Herdr** to target an external Herdr session and launch it using `HERDR_WEB_HERDR_BIN` or `herdr` from `PATH`. Selecting a row switches both the session name and backend target, so one browser WebUI process can work with built-in and external Herdr sessions in parallel.
+
+The session manager can also retry connection, reset workspaces, or close the current selected session. Closing a built-in session drops the in-process backend handle; closing an external Herdr session sends `server.stop` to that Herdr backend.
 
 If `--session NAME` is supplied, launched Herdr processes receive `HERDR_SESSION=NAME`.
 

--- a/docs/technical-details.md
+++ b/docs/technical-details.md
@@ -22,16 +22,20 @@ flowchart LR
 
 The built-in backend is the default runtime for new settings. External Herdr stays as a compatibility backend selected through settings or CLI flags. Both backends flow through the WebUI server adapter so browser code can keep one high-level API.
 
+The session manager adds a per-request backend target on top of the global default. Browser HTTP calls include `x-herdr-backend: builtin|external-herdr`; terminal and event WebSockets include `backend=builtin|external-herdr` query data because browsers cannot set custom WebSocket headers. The server still owns routing: external targets resolve to Herdr config sockets, built-in targets resolve to WebUI built-in socket namespaces and lazily start a built-in backend handle when launched.
+
 ### Built-in backend architecture
 
 - `src/builtin_backend.rs` owns built-in runtime state: workspaces, tabs, panes, terminals, agent metadata, worktree helpers, local socket listeners, request dispatch, and Jcode/OpenCode status detection.
 - Built-in control requests are newline-delimited JSON. Supported methods include `ping`, `session.snapshot`, workspace/tab/pane CRUD basics, `pane.read`, `agent.list/start`, and worktree list/open/create.
 - Built-in terminal attach uses `src/protocol.rs` frames over a separate local socket. The protocol supports attach, ANSI output, input, paste, resize, detach, and server shutdown frames.
-- The browser adapter in `src/main.rs` chooses built-in sockets when `backend_mode` resolves to `builtin`. Built-in mode must not accidentally route `/ws/events` or `/ws/terminal` to external Herdr session sockets.
+- The browser adapter in `src/main.rs` chooses sockets from the effective backend target. Without an explicit target it follows `backend_mode`; with `x-herdr-backend` or `backend=` query data it routes that request to the selected built-in or external Herdr session. Built-in mode must not accidentally route `/ws/events` or `/ws/terminal` to external Herdr session sockets, and external Herdr selections must still work from a WebUI process whose default is built-in.
+- Built-in sessions are stored in a small handle registry keyed by session name. The registry keeps each in-process built-in backend alive while it is running and allows the browser WebUI and TUI/smoke clients to attach in parallel. Closing a built-in session removes its handle; the handle drop unblocks socket listeners and cleans sockets.
 - `pane.read` returns terminal text after common TUI rewrites: carriage return, clear-line/display, cursor movement, OSC title skipping, and ANSI/control stripping. This keeps cleared Jcode toolbars/status cards from becoming stale plain text.
 - Agent detection first inspects known argv labels, then scans terminal child process trees with a short process-table cache, then falls back to terminal-screen markers. Jcode status follows the Herdr `jcode-support` manifest bottom-line rules plus active background-task markers so running tasks remain `working` even when an input prompt is visible.
 - Built-in `events.subscribe` is currently an acknowledgement plus snapshot-refresh fallback. A true event hub is the next architectural step for full Herdr parity.
 - Status detection must stay backend-core owned, not WebSocket-owned. The preferred evolution is: PTY/process/status detectors publish internal state-change events, then WebSocket, TUI, and smoke clients subscribe through an event hub. Coupling detection to the browser WebSocket would make TUI/headless clients second-class and would make status tests depend on a UI transport.
+- xterm.js terminal query replies are treated as frontend input sanitation, not backend color logic. Native terminals consume OSC 10/11 color query responses internally, but xterm.js can expose those responses through `onData`. WebUI filters those replies before they reach the terminal WebSocket so they cannot be written into the PTY as shell input.
 - Unsafe destructive operations stay explicit. `worktree.remove` returns unsupported until validation, preview, and rollback rules are implemented.
 
 ### TUI/client modularity

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -625,7 +625,7 @@ describe("app bundle load", () => {
       ctx.document.getElementById("versions").textContent,
       "webui 1.2.3 · backend built-in",
     );
-    equal(ctx.document.getElementById("footerSessionButton").textContent, "default");
+    equal(ctx.document.getElementById("footerSessionButton").textContent, "default · built-in");
 
     ctx.fetch = async (url) => {
       equal(url, "/api/versions");
@@ -670,6 +670,80 @@ describe("app bundle load", () => {
       ctx.document.getElementById("versions").textContent,
       "webui 1.2.3 · backend 0.7.3",
     );
+  });
+
+  it("filters OSC color query replies before terminal input reaches the backend", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    equal(
+      ctx.stripTerminalQueryReplies("\x1b]10;rgb:4c4c/4f4f/6969\x07hello\x1b]11;rgb:efef/f1f1/f5f5\x1b\\"),
+      "hello",
+    );
+    equal(ctx.stripTerminalQueryReplies("normal input"), "normal input");
+  });
+
+  it("renders backend-aware session manager and sends backend target headers", async () => {
+    const ctx = context();
+    const calls = [];
+    ctx.history = {
+      pushState(_state, _title, path) {
+        ctx.location.pathname = path;
+      },
+      replaceState(_state, _title, path) {
+        ctx.location.pathname = path;
+      },
+    };
+    ctx.fetch = async (url, opt = {}) => {
+      calls.push({ url, opt });
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            current_backend: "builtin",
+            sessions: [
+              { name: "default", backend: "builtin", backend_label: "built-in", running: true },
+              { name: "work", backend: "external-herdr", backend_label: "Herdr", running: true },
+            ],
+          }),
+        };
+      }
+      if (url === "/api/session/launch") {
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      }
+      if (url === "/api/versions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            backend_mode: "builtin",
+            current_backend: opt.headers && opt.headers["x-herdr-backend"],
+            session: "work",
+            compatibility: { status: "compatible" },
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    vm.runInContext(source, ctx);
+
+    await ctx.showSessionManager();
+
+    const html = ctx.document.getElementById("sessionList").innerHTML;
+    match(html, /built-in/);
+    match(html, /Herdr/);
+    ctx.goSession("work", "external-herdr");
+    await ctx.launchBackend("work", "external-herdr");
+
+    equal(vm.runInContext("state.sessionBackend", ctx), "external-herdr");
+    equal(ctx.apiOptions({}).headers["x-herdr-backend"], "external-herdr");
+    equal(ctx.apiOptions({}).headers["x-herdr-session"], "work");
+    const launchCall = calls.find((call) => call.url === "/api/session/launch");
+    deepEqual(JSON.parse(launchCall.opt.body), {
+      session: "work",
+      backend: "external-herdr",
+    });
   });
 
   it("defines grouped settings sections", () => {

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -36,6 +36,7 @@ let state = {
   // the first successful snapshot; falls back to legacy polling when false.
   supportsSessionSnapshot: false,
   backendMode: "builtin",
+  sessionBackend: localStorage.getItem("herdr-session-backend") || "builtin",
 };
 let term,
   termWs,
@@ -2120,34 +2121,52 @@ function setupSessionChrome() {
     m.className = "session-manager";
     m.id = "sessionManager";
     m.innerHTML =
-      '<div class="session-card"><div class="session-hero"><div><h1 id="sessionManagerTitle">Sessions</h1><p id="sessionManagerText">Choose a Herdr backend session to open.</p></div><div class="session-current"><span class="dot unknown"></span><span id="sessionCurrentLabel">default</span></div></div><div class="session-actions"><div class="session-list" id="sessionList"></div><div class="session-line session-new"><span><strong>Target another session</strong><small>Create or open a named target URL. Launch starts backend for current target.</small></span><span class="session-controls"><button class="btn" id="newSessionTarget">New target</button></span></div></div></div>';
+      '<div class="session-card"><div class="session-hero"><div><h1 id="sessionManagerTitle">Sessions</h1><p id="sessionManagerText">Choose a built-in or Herdr backend session to open.</p></div><div class="session-current"><span class="dot unknown"></span><span id="sessionCurrentLabel">default · built-in</span></div></div><div class="session-actions"><div class="session-list" id="sessionList"></div><div class="session-line session-new"><span><strong>Create or target session</strong><small>Choose where to create/open it. Built-in starts inside WebUI. Herdr starts external daemon.</small></span><span class="session-controls"><button class="btn" id="newBuiltinSessionTarget">New built-in</button><button class="tab add" id="newHerdrSessionTarget">New Herdr</button></span></div></div></div>';
     document.querySelector(".main").prepend(m);
-    el("newSessionTarget").onclick = () => {
-      const name = prompt("session name");
-      if (name) goSession(name);
-    };
+    el("newBuiltinSessionTarget").onclick = () => newSessionTarget("builtin");
+    el("newHerdrSessionTarget").onclick = () => newSessionTarget("external-herdr");
   }
+}
+function sessionBackendLabel(backend) {
+  return backend === "external-herdr" ? "Herdr" : "built-in";
+}
+function currentSessionBackend() {
+  return state.sessionBackend || state.backendMode || "builtin";
+}
+async function newSessionTarget(backend) {
+  const name = prompt(`${sessionBackendLabel(backend)} session name`);
+  if (!name) return;
+  await launchBackend(name, backend);
+  goSession(name, backend);
 }
 async function loadSessions() {
   try {
     const r = await api("/api/sessions");
     state.sessions = r.sessions || [];
+    state.sessionBackend = r.current_backend || currentSessionBackend();
   } catch (e) {
-    state.sessions = [{ name: state.session || "default", running: false }];
+    state.sessions = [{ name: state.session || "default", backend: currentSessionBackend(), running: false }];
   }
 }
 function renderSessionRows() {
   const list = state.sessions.length
     ? state.sessions
-    : [{ name: state.session || "default", running: state.backendOnline }];
+    : [{ name: state.session || "default", backend: currentSessionBackend(), running: state.backendOnline }];
   return list
     .map((s) => {
-      const active = s.name === state.session;
+      const backend = s.backend || "external-herdr";
+      const active = s.name === state.session && backend === currentSessionBackend();
       const status = `<span class="status-pill ${s.running ? "running" : "offline"}">${s.running ? "running" : "offline"}</span>`;
+      const backendPill = `<span class="status-pill">${escapeHtml(s.backend_label || sessionBackendLabel(backend))}</span>`;
       const controls = active
-        ? `<span class="session-controls"><button class="btn" onclick="event.stopPropagation();launchBackend()">Launch</button><button class="tab add" onclick="event.stopPropagation();refresh()">Retry</button><button class="tab add" onclick="event.stopPropagation();resetSession()">Reset workspaces</button><button class="mini danger" onclick="event.stopPropagation();closeCurrentSession()">Close</button></span>`
-        : `<span class="session-controls">${status}</span>`;
-      return `<div class="session-line ${active ? "active" : ""}" onclick="goSession('${escapeAttr(s.name)}')"><span><strong>${escapeHtml(s.name)}</strong><small>${active ? "current browser target" : s.running ? "click to switch to this running session" : "click to target this offline session"}</small></span>${controls}</div>`;
+        ? `<span class="session-controls">${backendPill}<button class="btn" onclick="event.stopPropagation();launchBackend('${escapeAttr(s.name)}','${escapeAttr(backend)}')">Launch</button><button class="tab add" onclick="event.stopPropagation();refresh()">Retry</button><button class="tab add" onclick="event.stopPropagation();resetSession()">Reset workspaces</button><button class="mini danger" onclick="event.stopPropagation();closeCurrentSession()">Close</button></span>`
+        : `<span class="session-controls">${backendPill}${status}</span>`;
+      const hint = active
+        ? "current browser target"
+        : s.running
+          ? `click to switch to this ${sessionBackendLabel(backend)} session`
+          : `click to target this offline ${sessionBackendLabel(backend)} session`;
+      return `<div class="session-line ${active ? "active" : ""}" onclick="goSession('${escapeAttr(s.name)}','${escapeAttr(backend)}')"><span><strong>${escapeHtml(s.name)}</strong><small>${escapeHtml(hint)}</small></span>${controls}</div>`;
     })
     .join("");
 }
@@ -2161,8 +2180,9 @@ async function showSessionManager(title, text) {
   if (titleEl) titleEl.textContent = title || "Session manager";
   if (textEl)
     textEl.textContent =
-      text || `Current target: ${state.session || "default"}`;
-  if (current) current.textContent = state.session || "default";
+      text || `Current target: ${state.session || "default"} · ${sessionBackendLabel(currentSessionBackend())}`;
+  if (current)
+    current.textContent = `${state.session || "default"} · ${sessionBackendLabel(currentSessionBackend())}`;
   if (list) list.innerHTML = renderSessionRows();
   if (manager) manager.style.display = "block";
 }
@@ -2170,14 +2190,20 @@ function hideSessionManager() {
   const manager = el("sessionManager");
   if (manager) manager.style.display = "none";
 }
-async function launchBackend() {
+async function launchBackend(session = state.session, backend = currentSessionBackend()) {
   const textEl = el("sessionManagerText");
-  if (textEl) textEl.textContent = "Launching Herdr session...";
+  if (textEl) textEl.textContent = `Launching ${sessionBackendLabel(backend)} session...`;
   try {
-    const r = await api("/api/session/launch", { method: "POST" });
+    const r = await api("/api/session/launch", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ session: session || "default", backend }),
+    });
     if (textEl)
       textEl.textContent = r.ok
-        ? `Launched pid ${r.pid}. Waiting for backend...`
+        ? r.pid
+          ? `Launched pid ${r.pid}. Waiting for backend...`
+          : `Launched ${sessionBackendLabel(backend)} session.`
         : r.error || "Launch failed";
     setTimeout(refresh, 1200);
   } catch (e) {
@@ -2185,11 +2211,15 @@ async function launchBackend() {
   }
 }
 async function closeCurrentSession() {
-  if (!confirm("Close current Herdr session?")) return;
+  if (!confirm(`Close current ${sessionBackendLabel(currentSessionBackend())} session?`)) return;
   try {
-    await api("/api/session/close", { method: "POST" });
+    await api("/api/session/close", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ session: state.session || "default", backend: currentSessionBackend() }),
+    });
     showSessionManager(
-      "Herdr session closed",
+      "Session closed",
       "Session stopped. You can launch it again.",
     );
     setTimeout(refresh, 800);
@@ -2235,6 +2265,9 @@ function apiOptions(opt) {
     next.headers || {},
     state.session && state.session !== "default"
       ? { "x-herdr-session": state.session }
+      : {},
+    currentSessionBackend()
+      ? { "x-herdr-backend": currentSessionBackend() }
       : {},
   );
   return next;
@@ -2337,6 +2370,13 @@ async function loadVersions() {
   try {
     const v = await api("/api/versions");
     state.backendMode = v.backend_mode || "builtin";
+    state.sessionBackend =
+      v.current_backend ||
+      (state.backendMode === "external" || state.backendMode === "external-herdr"
+        ? "external-herdr"
+        : state.backendMode === "builtin"
+          ? "builtin"
+          : state.sessionBackend || "builtin");
     const session = v.session || state.session || "default";
     const compat = v.compatibility || {},
       status =
@@ -2344,7 +2384,7 @@ async function loadVersions() {
           ? " · " + compat.status
           : "";
     const backendIsBuiltin =
-      state.backendMode === "builtin" ||
+      state.sessionBackend === "builtin" ||
       String(v.backend || "") === "builtin" ||
       String(v.backend || "").startsWith("builtin-");
     const backendLabel = backendIsBuiltin ? "built-in" : v.backend || "offline";
@@ -2353,11 +2393,11 @@ async function loadVersions() {
       versionsEl.title = `session ${session}${compat.message ? ` · ${compat.message}` : ""}`;
     }
     const button = el("footerSessionButton");
-    if (button) button.textContent = state.session || session;
+    if (button) button.textContent = `${state.session || session} · ${sessionBackendLabel(currentSessionBackend())}`;
   } catch (e) {
     if (versionsEl) versionsEl.textContent = "webui - · backend offline";
     const button = el("footerSessionButton");
-    if (button) button.textContent = state.session || "default";
+    if (button) button.textContent = `${state.session || "default"} · ${sessionBackendLabel(currentSessionBackend())}`;
   }
 }
 function sessionPrefix() {
@@ -2452,8 +2492,10 @@ function go(ws, tab, pane) {
   setTerminalLoading(true);
   refresh();
 }
-function goSession(name) {
+function goSession(name, backend = currentSessionBackend()) {
   state.session = name || "default";
+  state.sessionBackend = backend || "builtin";
+  localStorage.setItem("herdr-session-backend", state.sessionBackend);
   state.ws = null;
   state.tab = null;
   state.pane = null;

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -62,7 +62,7 @@ function connectTerminal() {
   const cols = state.termCols || 100,
     rows = state.termRows || 30,
     size = `${cols}x${rows}`;
-  const target = `${state.session}|${state.ws}|${state.tab}|${state.pane}|${state.terminalId}`;
+  const target = `${state.session}|${currentSessionBackend()}|${state.ws}|${state.tab}|${state.pane}|${state.terminalId}`;
   if (
     termWs &&
     termWs.readyState === 1 &&
@@ -589,6 +589,8 @@ async function pasteClipboard() {
 }
 function sendInputData(data, options = {}) {
   if (!termWs || termWs.readyState !== 1 || !data) return;
+  if (!options.allowTerminalReplies) data = stripTerminalQueryReplies(data);
+  if (!data) return;
   const bytes = inputEncoder.encode(data);
   const chunkSize = options.chunkSize || 16 * 1024;
   const maxBufferedAmount = options.maxBufferedAmount || 65536;
@@ -605,6 +607,14 @@ function sendInputData(data, options = {}) {
   inputQueueMaxBufferedAmount = Math.max(inputQueueMaxBufferedAmount, maxBufferedAmount);
   flushInputQueue();
 }
+
+function stripTerminalQueryReplies(data) {
+  return String(data || "").replace(
+    /\x1b\](?:10|11);rgb:[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}(?:\x07|\x1b\\)/g,
+    "",
+  );
+}
+
 function sendPasteToTerminal(text) {
   if (!termWs || termWs.readyState !== 1 || !text) return;
   pasteFrameUntil = Date.now() + 250;
@@ -777,16 +787,19 @@ window.addEventListener("focus", () =>
   requestAnimationFrame(fitFocusedTerminal),
 );
 function wsUrl(path) {
-  const sep = path.includes("?") ? "&" : "?";
-  const session =
-    state.session && state.session !== "default"
-      ? sep + "session=" + encodeURIComponent(state.session)
-      : "";
+  const params = [];
+  if (state.session && state.session !== "default")
+    params.push("session=" + encodeURIComponent(state.session));
+  if (typeof currentSessionBackend === "function" && currentSessionBackend())
+    params.push("backend=" + encodeURIComponent(currentSessionBackend()));
+  const suffix = params.length
+    ? (path.includes("?") ? "&" : "?") + params.join("&")
+    : "";
   return (
     (location.protocol === "https:" ? "wss://" : "ws://") +
     location.host +
     path +
-    session
+    suffix
   );
 }
 function escapeHtml(s) {

--- a/src/git_ui/mod.rs
+++ b/src/git_ui/mod.rs
@@ -513,6 +513,7 @@ mod tests {
             session_name: None,
             backend_mode: BackendMode::ExternalHerdr,
             _builtin_backend: None,
+            builtin_sessions: Arc::new(Mutex::new(HashMap::new())),
             herdr_bin: "herdr".to_string(),
             auth: Arc::new(Mutex::new(AuthConfig {
                 user: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ const MIN_BACKEND_VERSION: &str = "0.7.0";
 const MAX_TESTED_BACKEND_VERSION: &str = "0.7.3";
 
 type LocalStream = interprocess::local_socket::Stream;
+type BuiltinSessionRegistry =
+    Arc<Mutex<HashMap<String, Arc<builtin_backend::BuiltinBackendHandle>>>>;
 
 fn backend_compatibility_for_supported_range(
     backend: Option<&str>,
@@ -108,6 +110,29 @@ impl BackendMode {
 
     fn is_builtin(self) -> bool {
         matches!(self, Self::Builtin)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionBackendTarget {
+    ExternalHerdr,
+    Builtin,
+}
+
+impl SessionBackendTarget {
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "external-herdr" | "external" | "herdr" => Some(Self::ExternalHerdr),
+            "builtin" | "built-in" => Some(Self::Builtin),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ExternalHerdr => "external-herdr",
+            Self::Builtin => "builtin",
+        }
     }
 }
 
@@ -388,6 +413,7 @@ pub(crate) struct WebState {
     session_name: Option<String>,
     backend_mode: BackendMode,
     _builtin_backend: Option<Arc<builtin_backend::BuiltinBackendHandle>>,
+    builtin_sessions: BuiltinSessionRegistry,
     herdr_bin: String,
     auth: Arc<Mutex<AuthConfig>>,
     server_settings: Arc<Mutex<RuntimeServerSettings>>,
@@ -708,28 +734,28 @@ async fn main() -> io::Result<()> {
         config.session.as_deref(),
         config.api_socket.as_deref(),
     );
-    let (builtin_backend, api_socket, client_socket) = if backend_mode.is_builtin() {
+    let builtin_sessions: BuiltinSessionRegistry = Arc::new(Mutex::new(HashMap::new()));
+    let (api_socket, client_socket) = if backend_mode.is_builtin() {
         let (_api_socket, _client_socket) = builtin_socket_paths(config.session.as_deref());
-        let handle =
-            builtin_backend::BuiltinBackendHandle::start(builtin_backend::BuiltinBackendConfig {
+        let handle = Arc::new(builtin_backend::BuiltinBackendHandle::start(
+            builtin_backend::BuiltinBackendConfig {
                 api_socket: _api_socket,
                 client_socket: _client_socket,
                 cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                 shell: server_settings.builtin_shell.clone(),
-            })?;
+            },
+        )?);
         let api_socket = handle.api_socket().to_path_buf();
         let client_socket = handle.client_socket().to_path_buf();
-        (
-            Some(Arc::new(handle)),
-            Some(api_socket),
-            Some(client_socket),
-        )
+        if let Ok(mut sessions) = builtin_sessions.lock() {
+            sessions.insert(
+                canonical_session_name(config.session.as_deref()),
+                Arc::clone(&handle),
+            );
+        }
+        (Some(api_socket), Some(client_socket))
     } else {
-        (
-            None,
-            config.api_socket.clone(),
-            config.client_socket.clone(),
-        )
+        (config.api_socket.clone(), config.client_socket.clone())
     };
     let server_settings = Arc::new(Mutex::new(server_settings.clone()));
     let (rebind_tx, rebind_rx) = tokio::sync::watch::channel(server_settings.lock().unwrap().bind);
@@ -738,7 +764,8 @@ async fn main() -> io::Result<()> {
         client_socket,
         session_name: config.session.clone(),
         backend_mode,
-        _builtin_backend: builtin_backend,
+        _builtin_backend: None,
+        builtin_sessions,
         herdr_bin: std::env::var("HERDR_WEB_HERDR_BIN").unwrap_or_else(|_| "herdr".to_string()),
         auth,
         server_settings,
@@ -1153,10 +1180,17 @@ fn client_socket_path_for(name: Option<&str>) -> PathBuf {
     session_dir(name).join("herdr-client.sock")
 }
 
-fn session_from_headers(state: &WebState, headers: &HeaderMap) -> Option<String> {
-    headers
-        .get("x-herdr-session")
-        .and_then(|value| value.to_str().ok())
+fn canonical_session_name(session: Option<&str>) -> String {
+    session
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .filter(|value| *value != "default")
+        .unwrap_or("default")
+        .to_string()
+}
+
+fn request_session_name(state: &WebState, requested: Option<&str>) -> Option<String> {
+    requested
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .filter(|value| *value != "default")
@@ -1164,75 +1198,129 @@ fn session_from_headers(state: &WebState, headers: &HeaderMap) -> Option<String>
         .or_else(|| state.session_name.clone())
 }
 
-fn api_for_headers(state: &WebState, headers: &HeaderMap) -> ApiClient {
-    if state.backend_mode.is_builtin() {
-        if let Some(socket_path) = &state.api_socket {
-            return ApiClient {
-                socket_path: socket_path.clone(),
-            };
+fn backend_target_for_headers(state: &WebState, headers: &HeaderMap) -> SessionBackendTarget {
+    headers
+        .get("x-herdr-backend")
+        .and_then(|value| value.to_str().ok())
+        .and_then(SessionBackendTarget::parse)
+        .unwrap_or_else(|| {
+            if state.backend_mode.is_builtin() {
+                SessionBackendTarget::Builtin
+            } else {
+                SessionBackendTarget::ExternalHerdr
+            }
+        })
+}
+
+fn backend_target_for_query(
+    state: &WebState,
+    headers: &HeaderMap,
+    requested: Option<&str>,
+) -> SessionBackendTarget {
+    requested
+        .and_then(SessionBackendTarget::parse)
+        .unwrap_or_else(|| backend_target_for_headers(state, headers))
+}
+
+fn session_from_headers(state: &WebState, headers: &HeaderMap) -> Option<String> {
+    request_session_name(
+        state,
+        headers
+            .get("x-herdr-session")
+            .and_then(|value| value.to_str().ok()),
+    )
+}
+
+fn api_for_target_session(
+    state: &WebState,
+    backend: SessionBackendTarget,
+    session: Option<&str>,
+) -> ApiClient {
+    match backend {
+        SessionBackendTarget::Builtin => {
+            let session_name = canonical_session_name(session);
+            let (api_socket, _) = builtin_socket_paths(Some(&session_name));
+            ApiClient {
+                socket_path: api_socket,
+            }
         }
-    }
-    let session = session_from_headers(state, headers);
-    if session.is_none() {
-        if let Some(socket_path) = &state.api_socket {
-            return ApiClient {
-                socket_path: socket_path.clone(),
-            };
+        SessionBackendTarget::ExternalHerdr => {
+            if session.is_none() {
+                if let Some(socket_path) = &state.api_socket {
+                    return ApiClient {
+                        socket_path: socket_path.clone(),
+                    };
+                }
+            }
+            ApiClient {
+                socket_path: api_socket_path_for(session),
+            }
         }
-    }
-    ApiClient {
-        socket_path: api_socket_path_for(session.as_deref()),
     }
 }
 
-fn client_socket_for_headers(state: &WebState, headers: &HeaderMap) -> PathBuf {
-    if state.backend_mode.is_builtin() {
-        if let Some(socket_path) = &state.client_socket {
-            return socket_path.clone();
+fn client_socket_for_target_session(
+    state: &WebState,
+    backend: SessionBackendTarget,
+    session: Option<&str>,
+) -> PathBuf {
+    match backend {
+        SessionBackendTarget::Builtin => {
+            let session_name = canonical_session_name(session);
+            let (_, client_socket) = builtin_socket_paths(Some(&session_name));
+            client_socket
+        }
+        SessionBackendTarget::ExternalHerdr => {
+            if session.is_none() {
+                if let Some(socket_path) = &state.client_socket {
+                    return socket_path.clone();
+                }
+            }
+            client_socket_path_for(session)
         }
     }
+}
+
+fn api_for_headers(state: &WebState, headers: &HeaderMap) -> ApiClient {
+    let backend = backend_target_for_headers(state, headers);
     let session = session_from_headers(state, headers);
-    if session.is_none() {
-        if let Some(socket_path) = &state.client_socket {
-            return socket_path.clone();
-        }
-    }
-    client_socket_path_for(session.as_deref())
+    api_for_target_session(state, backend, session.as_deref())
+}
+
+#[cfg(test)]
+fn client_socket_for_headers(state: &WebState, headers: &HeaderMap) -> PathBuf {
+    let backend = backend_target_for_headers(state, headers);
+    let session = session_from_headers(state, headers);
+    client_socket_for_target_session(state, backend, session.as_deref())
 }
 
 fn api_for_query_session(
     state: &WebState,
     headers: &HeaderMap,
     session: Option<&str>,
+    backend: Option<&str>,
 ) -> ApiClient {
-    if state.backend_mode.is_builtin() {
-        return api_for_headers(state, headers);
-    }
-    session
-        .map(|session| ApiClient {
-            socket_path: api_socket_path_for(Some(session)),
-        })
-        .unwrap_or_else(|| api_for_headers(state, headers))
+    let backend = backend_target_for_query(state, headers, backend);
+    let session = request_session_name(state, session);
+    api_for_target_session(state, backend, session.as_deref())
 }
 
 fn client_socket_for_query_session(
     state: &WebState,
     headers: &HeaderMap,
     session: Option<&str>,
+    backend: Option<&str>,
 ) -> PathBuf {
-    if state.backend_mode.is_builtin() {
-        return client_socket_for_headers(state, headers);
-    }
-    session
-        .map(|session| client_socket_path_for(Some(session)))
-        .unwrap_or_else(|| client_socket_for_headers(state, headers))
+    let backend = backend_target_for_query(state, headers, backend);
+    let session = request_session_name(state, session);
+    client_socket_for_target_session(state, backend, session.as_deref())
 }
 
 fn session_display_name(session: Option<&str>) -> &str {
     session.unwrap_or("default")
 }
 
-fn known_sessions() -> Vec<serde_json::Value> {
+fn known_external_sessions() -> Vec<serde_json::Value> {
     let mut names = vec![None];
     let sessions_dir = config_dir().join("sessions");
     if let Ok(entries) = fs::read_dir(sessions_dir) {
@@ -1253,10 +1341,60 @@ fn known_sessions() -> Vec<serde_json::Value> {
             let running = connect_local_stream(&api_socket).is_ok();
             json!({
                 "name": session_display_name(name.as_deref()),
+                "backend": SessionBackendTarget::ExternalHerdr.as_str(),
+                "backend_label": "Herdr",
                 "running": running,
                 "api_socket": api_socket.display().to_string(),
             })
         })
+        .collect()
+}
+
+fn known_builtin_sessions(state: &WebState) -> Vec<serde_json::Value> {
+    let mut names = vec!["default".to_string()];
+    let sessions_dir = server_settings_path()
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("builtin");
+    if let Ok(entries) = fs::read_dir(sessions_dir) {
+        let mut found = entries
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().is_dir())
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|name| name != "default")
+            .collect::<Vec<_>>();
+        found.sort();
+        names.extend(found);
+    }
+    if let Ok(sessions) = state.builtin_sessions.lock() {
+        let mut live = sessions.keys().cloned().collect::<Vec<_>>();
+        live.sort();
+        for name in live {
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+    }
+    names
+        .into_iter()
+        .map(|name| {
+            let (api_socket, _) = builtin_socket_paths(Some(&name));
+            let running = connect_local_stream(&api_socket).is_ok();
+            json!({
+                "name": name,
+                "backend": SessionBackendTarget::Builtin.as_str(),
+                "backend_label": "built-in",
+                "running": running,
+                "api_socket": api_socket.display().to_string(),
+            })
+        })
+        .collect()
+}
+
+fn known_sessions(state: &WebState) -> Vec<serde_json::Value> {
+    known_external_sessions()
+        .into_iter()
+        .chain(known_builtin_sessions(state))
         .collect()
 }
 
@@ -1717,10 +1855,12 @@ async fn sessions(
     if let Err(response) = require_auth(&state, &headers, remote) {
         return response;
     }
-    if state.backend_mode.is_builtin() {
-        return Json(json!({ "sessions": ["default"] })).into_response();
-    }
-    Json(json!({ "sessions": known_sessions() })).into_response()
+    Json(json!({
+        "backend_mode": state.backend_mode.as_str(),
+        "current_backend": backend_target_for_headers(&state, &headers).as_str(),
+        "sessions": known_sessions(&state),
+    }))
+    .into_response()
 }
 
 async fn versions(
@@ -1732,14 +1872,15 @@ async fn versions(
         return response;
     }
     let session = session_from_headers(&state, &headers);
+    let current_backend = backend_target_for_headers(&state, &headers);
     let api = api_for_headers(&state, &headers);
     let backend = api.backend_info();
-    let compatibility = if state.backend_mode.is_builtin() {
+    let compatibility = if current_backend == SessionBackendTarget::Builtin {
         BackendCompatibility::Compatible
     } else {
         backend_compatibility_for_supported_range(backend.version.as_deref(), backend.protocol)
     };
-    let compatibility_message = if state.backend_mode.is_builtin() {
+    let compatibility_message = if current_backend == SessionBackendTarget::Builtin {
         "built-in backend is embedded in this WebUI process"
     } else {
         compatibility.message(backend.version.as_deref())
@@ -1748,6 +1889,7 @@ async fn versions(
         "webui": HERDR_WEBUI_VERSION,
         "backend": backend.version,
         "backend_mode": state.backend_mode.as_str(),
+        "current_backend": current_backend.as_str(),
         "session": session_display_name(session.as_deref()),
         "protocol_version": PROTOCOL_VERSION,
         "min_protocol_version": MIN_SUPPORTED_PROTOCOL_VERSION,
@@ -1763,16 +1905,103 @@ async fn versions(
     .into_response()
 }
 
+#[derive(Default, Deserialize)]
+struct SessionActionRequest {
+    session: Option<String>,
+    backend: Option<String>,
+}
+
+fn requested_session_from_headers<'a>(headers: &'a HeaderMap) -> Option<&'a str> {
+    headers
+        .get("x-herdr-session")
+        .and_then(|value| value.to_str().ok())
+}
+
+fn action_session(
+    state: &WebState,
+    headers: &HeaderMap,
+    body: &SessionActionRequest,
+) -> Option<String> {
+    request_session_name(
+        state,
+        body.session
+            .as_deref()
+            .or_else(|| requested_session_from_headers(headers)),
+    )
+}
+
+fn action_backend(
+    state: &WebState,
+    headers: &HeaderMap,
+    body: &SessionActionRequest,
+) -> SessionBackendTarget {
+    body.backend
+        .as_deref()
+        .and_then(SessionBackendTarget::parse)
+        .unwrap_or_else(|| backend_target_for_headers(state, headers))
+}
+
+fn ensure_builtin_session(state: &WebState, session: Option<&str>) -> Result<(), String> {
+    let session_name = canonical_session_name(session);
+    if state
+        .builtin_sessions
+        .lock()
+        .map(|sessions| sessions.contains_key(&session_name))
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+    let (api_socket, client_socket) = builtin_socket_paths(Some(&session_name));
+    if connect_local_stream(&api_socket).is_ok() {
+        return Ok(());
+    }
+    let shell = state
+        .server_settings
+        .lock()
+        .ok()
+        .and_then(|settings| settings.builtin_shell.clone());
+    let handle =
+        builtin_backend::BuiltinBackendHandle::start(builtin_backend::BuiltinBackendConfig {
+            api_socket,
+            client_socket,
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            shell,
+        })
+        .map_err(|err| err.to_string())?;
+    state
+        .builtin_sessions
+        .lock()
+        .map_err(|_| "built-in session registry unavailable".to_string())?
+        .insert(session_name, Arc::new(handle));
+    Ok(())
+}
+
 async fn launch_session(
     State(state): State<WebState>,
     headers: HeaderMap,
     ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    body: Option<Json<SessionActionRequest>>,
 ) -> Response {
     if let Err(response) = require_auth(&state, &headers, remote) {
         return response;
     }
-    if state.backend_mode.is_builtin() {
-        return Json(json!({ "ok": true, "builtin": true })).into_response();
+    let body = body.map(|Json(body)| body).unwrap_or_default();
+    let session = action_session(&state, &headers, &body);
+    let backend = action_backend(&state, &headers, &body);
+    if backend == SessionBackendTarget::Builtin {
+        return match ensure_builtin_session(&state, session.as_deref()) {
+            Ok(()) => Json(json!({
+                "ok": true,
+                "backend": backend.as_str(),
+                "session": session_display_name(session.as_deref()),
+            }))
+            .into_response(),
+            Err(err) => (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "ok": false, "error": err })),
+            )
+                .into_response(),
+        };
     }
     let mut command = std::process::Command::new(&state.herdr_bin);
     command
@@ -1782,7 +2011,6 @@ async fn launch_session(
         .stderr(Stdio::null())
         .env_remove("HERDR_SOCKET_PATH")
         .env_remove("HERDR_CLIENT_SOCKET_PATH");
-    let session = session_from_headers(&state, &headers);
     if let Some(session) = session.as_deref().filter(|value| *value != "default") {
         command.env("HERDR_SESSION", session);
     }
@@ -1792,7 +2020,13 @@ async fn launch_session(
         command.process_group(0);
     }
     match command.spawn() {
-        Ok(child) => Json(json!({ "ok": true, "pid": child.id() })).into_response(),
+        Ok(child) => Json(json!({
+            "ok": true,
+            "pid": child.id(),
+            "backend": backend.as_str(),
+            "session": session_display_name(session.as_deref()),
+        }))
+        .into_response(),
         Err(err) => (
             StatusCode::BAD_GATEWAY,
             Json(json!({ "ok": false, "error": err.to_string() })),
@@ -1805,12 +2039,27 @@ async fn close_session(
     State(state): State<WebState>,
     headers: HeaderMap,
     ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    body: Option<Json<SessionActionRequest>>,
 ) -> Response {
     if let Err(response) = require_auth(&state, &headers, remote) {
         return response;
     }
+    let body = body.map(|Json(body)| body).unwrap_or_default();
+    let session = action_session(&state, &headers, &body);
+    let backend = action_backend(&state, &headers, &body);
+    if backend == SessionBackendTarget::Builtin {
+        let session_name = canonical_session_name(session.as_deref());
+        let response = proxy_request(
+            &api_for_target_session(&state, backend, session.as_deref()),
+            json!({ "id": "web:server:stop", "method": "server.stop", "params": {} }),
+        );
+        if let Ok(mut sessions) = state.builtin_sessions.lock() {
+            sessions.remove(&session_name);
+        }
+        return response;
+    }
     proxy_request(
-        &api_for_headers(&state, &headers),
+        &api_for_target_session(&state, backend, session.as_deref()),
         json!({ "id": "web:server:stop", "method": "server.stop", "params": {} }),
     )
 }
@@ -2726,7 +2975,12 @@ async fn events_ws(
     if let Err(response) = require_auth(&state, &headers, remote) {
         return response;
     }
-    let api = api_for_query_session(&state, &headers, query.session.as_deref());
+    let api = api_for_query_session(
+        &state,
+        &headers,
+        query.session.as_deref(),
+        query.backend.as_deref(),
+    );
     ws.on_upgrade(move |socket| events_socket(state, api, socket))
 }
 
@@ -2817,12 +3071,14 @@ struct TerminalQuery {
     cols: Option<u16>,
     rows: Option<u16>,
     session: Option<String>,
+    backend: Option<String>,
     temporary_tab_id: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct SessionQuery {
     session: Option<String>,
+    backend: Option<String>,
 }
 
 async fn terminal_ws(
@@ -2835,9 +3091,18 @@ async fn terminal_ws(
     if let Err(response) = require_auth(&state, &headers, remote) {
         return response;
     }
-    let client_socket_path =
-        client_socket_for_query_session(&state, &headers, query.session.as_deref());
-    let api = api_for_query_session(&state, &headers, query.session.as_deref());
+    let client_socket_path = client_socket_for_query_session(
+        &state,
+        &headers,
+        query.session.as_deref(),
+        query.backend.as_deref(),
+    );
+    let api = api_for_query_session(
+        &state,
+        &headers,
+        query.session.as_deref(),
+        query.backend.as_deref(),
+    );
     ws.on_upgrade(move |socket| terminal_socket(client_socket_path, api, query, socket))
 }
 
@@ -3144,6 +3409,7 @@ mod tests {
             session_name: None,
             backend_mode: BackendMode::ExternalHerdr,
             _builtin_backend: None,
+            builtin_sessions: Arc::new(Mutex::new(HashMap::new())),
             herdr_bin: "herdr".to_string(),
             auth: Arc::new(Mutex::new(AuthConfig {
                 user: Some("user".to_string()),
@@ -3529,7 +3795,7 @@ mod tests {
     }
 
     #[test]
-    fn builtin_mode_uses_state_socket_paths_for_all_header_sessions() {
+    fn builtin_mode_routes_header_sessions_to_builtin_socket_namespace() {
         let mut state = test_state();
         state.backend_mode = BackendMode::Builtin;
         state.api_socket = Some(PathBuf::from("/tmp/builtin-api.sock"));
@@ -3537,22 +3803,69 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-herdr-session", HeaderValue::from_static("other"));
 
-        assert_eq!(
-            api_for_headers(&state, &headers).socket_path,
-            PathBuf::from("/tmp/builtin-api.sock")
+        assert!(api_for_headers(&state, &headers)
+            .socket_path
+            .ends_with("herdr-webui/builtin/other/herdr.sock"));
+        assert!(client_socket_for_headers(&state, &headers)
+            .ends_with("herdr-webui/builtin/other/herdr-client.sock"));
+        assert!(api_for_query_session(&state, &headers, Some("query"), None)
+            .socket_path
+            .ends_with("herdr-webui/builtin/query/herdr.sock"));
+        assert!(
+            client_socket_for_query_session(&state, &headers, Some("query"), None)
+                .ends_with("herdr-webui/builtin/query/herdr-client.sock")
         );
-        assert_eq!(
-            client_socket_for_headers(&state, &headers),
-            PathBuf::from("/tmp/builtin-client.sock")
+    }
+
+    #[test]
+    fn explicit_backend_header_can_route_external_while_default_is_builtin() {
+        let mut state = test_state();
+        state.backend_mode = BackendMode::Builtin;
+        let mut headers = HeaderMap::new();
+        headers.insert("x-herdr-session", HeaderValue::from_static("work"));
+        headers.insert(
+            "x-herdr-backend",
+            HeaderValue::from_static("external-herdr"),
         );
+
         assert_eq!(
-            api_for_query_session(&state, &headers, Some("other")).socket_path,
-            PathBuf::from("/tmp/builtin-api.sock")
+            backend_target_for_headers(&state, &headers),
+            SessionBackendTarget::ExternalHerdr
         );
-        assert_eq!(
-            client_socket_for_query_session(&state, &headers, Some("other")),
-            PathBuf::from("/tmp/builtin-client.sock")
-        );
+        assert!(api_for_headers(&state, &headers)
+            .socket_path
+            .ends_with("herdr/sessions/work/herdr.sock"));
+    }
+
+    #[test]
+    fn known_sessions_reports_external_and_builtin_entries() {
+        let _guard = env_lock().lock().unwrap();
+        let root =
+            std::env::temp_dir().join(format!("herdr-webui-sessions-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("herdr/sessions/work")).unwrap();
+        fs::create_dir_all(root.join("herdr-webui/builtin/inside")).unwrap();
+        std::env::set_var("XDG_CONFIG_HOME", &root);
+        let state = test_state();
+
+        let sessions = known_sessions(&state);
+        let pairs = sessions
+            .iter()
+            .map(|session| {
+                (
+                    session.get("backend").and_then(Value::as_str).unwrap_or(""),
+                    session.get("name").and_then(Value::as_str).unwrap_or(""),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert!(pairs.contains(&("external-herdr", "default")));
+        assert!(pairs.contains(&("external-herdr", "work")));
+        assert!(pairs.contains(&("builtin", "default")));
+        assert!(pairs.contains(&("builtin", "inside")));
+
+        std::env::remove_var("XDG_CONFIG_HOME");
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add backend-aware session manager entries for built-in and external Herdr sessions.
- Allow launching, closing, selecting, and WebSocket routing per backend/session.
- Filter xterm OSC 10/11 color query replies before they are sent to the PTY.
- Document session manager backend choice and built-in/external behavior.

## Validation
- cargo fmt --check
- cargo test --all-targets
- node --test src/assets/*.test.mjs
- git diff --check
- cargo build --release --bins --target-dir target
- make update-mac
- installed WebUI/TUI smoke for /api/versions, /api/sessions, and TUI --once