### PR TITLE
Fix panel switcher numeric labels

### DIFF
--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -683,6 +683,30 @@ describe("app bundle load", () => {
     equal(ctx.stripTerminalQueryReplies("normal input"), "normal input");
   });
 
+  it("renders default shell panels as numeric panel labels", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+    vm.runInContext(`
+      state.ws = "ws1";
+      state.tab = "tab2";
+      state.panelMenuOpen = true;
+      state.tabs = [
+        { workspace_id: "ws1", tab_id: "tab1", label: "shell", number: 1 },
+        { workspace_id: "ws1", tab_id: "tab2", label: "shell", number: 2 },
+        { workspace_id: "ws1", tab_id: "tab3", label: "custom", number: 3 },
+      ];
+    `, ctx);
+
+    const html = ctx.renderPanelField();
+
+    match(html, /<span>2<\/span>/);
+    match(html, />1<\/button>/);
+    match(html, />2<\/button>/);
+    match(html, />custom<\/button>/);
+    equal(html.includes(">shell</button>"), false);
+    equal(ctx.panelRenameInitialLabel({ label: "shell", number: 1 }), "");
+  });
+
   it("renders backend-aware session manager and sends backend target headers", async () => {
     const ctx = context();
     const calls = [];

--- a/src/assets/desktop/app_js/render.js
+++ b/src/assets/desktop/app_js/render.js
@@ -242,20 +242,43 @@ function selectedWorkspaceActionButtons(w) {
     );
   return `<span class="space-actions selected-space-actions">${buttons.join("")}</span>`;
 }
+function isDefaultPanelTitle(label) {
+  const value = String(label || "").trim().toLowerCase();
+  return !value || value === "shell" || value === "terminal" || /^tab\s+\d+$/.test(value);
+}
+function panelNumberLabel(tab, index) {
+  const number = Number(tab && tab.number);
+  if (Number.isFinite(number) && number > 0) return String(number);
+  return String((Number.isFinite(index) ? index : state.tabs.findIndex((t) => t.tab_id === tab.tab_id)) + 1 || 1);
+}
+function panelVisibleLabel(tab, index) {
+  const label = String((tab && tab.label) || "").trim();
+  return isDefaultPanelTitle(label) ? panelNumberLabel(tab, index) : label;
+}
+function panelRenameInitialLabel(tab) {
+  const label = String((tab && tab.label) || "").trim();
+  return isDefaultPanelTitle(label) ? "" : label;
+}
+function panelTooltip(tab, index) {
+  const visible = panelVisibleLabel(tab, index);
+  const title = tabTitle(tab);
+  return visible === title ? `Current panel: ${visible}. Double-click to rename.` : `Current panel: ${visible} · ${title}. Double-click to rename.`;
+}
 function renderPanelField() {
   if (!state.ws)
     return '<span class="panel-field-empty">No panel</span>';
   const tabs = state.tabs || [],
     current = tabs.find((t) => t.tab_id === state.tab) || tabs[0] || null,
-    currentLabel = current ? tabTitle(current) : "No panel";
+    currentIndex = current ? tabs.findIndex((t) => t.tab_id === current.tab_id) : -1,
+    currentLabel = current ? panelVisibleLabel(current, currentIndex) : "No panel";
   const hasSwitcher = tabs.length > 1;
   if (current && state.editingTab === current.tab_id)
     return `<div class="panel-field"><input class="panel-label panel-rename-input tab-rename-input" value="${escapeAttr(state.editingTabValue)}" onmousedown="event.stopPropagation()" onclick="event.stopPropagation()" onblur="commitTabRename('${current.tab_id}')" oninput="state.editingTabValue=this.value" onkeydown="tabRenameKey(event,'${current.tab_id}')"><button class="mini panel-add" title="New panel" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button><button class="mini warn panel-close" title="Close current panel" onclick="event.preventDefault();event.stopPropagation();closeTab('${current.tab_id}')">✕</button></div>`;
-  const menu = hasSwitcher && state.panelMenuOpen ? `<div class="panel-menu">${tabs.map((tab) => `<button class="panel-menu-item${tab.tab_id === state.tab ? " active" : ""}" onclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;go(state.ws,decodeURIComponent('${encodeURIComponent(tab.tab_id)}'))">${escapeHtml(tabTitle(tab))}</button>`).join("")}</div>` : "";
+  const menu = hasSwitcher && state.panelMenuOpen ? `<div class="panel-menu">${tabs.map((tab, index) => `<button class="panel-menu-item${tab.tab_id === state.tab ? " active" : ""}" title="${escapeAttr(tabTitle(tab))}" onclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;go(state.ws,decodeURIComponent('${encodeURIComponent(tab.tab_id)}'))">${escapeHtml(panelVisibleLabel(tab, index))}</button>`).join("")}</div>` : "";
   const caret = hasSwitcher ? '<span class="panel-caret">▼</span>' : "";
   const click = hasSwitcher ? "togglePanelMenu()" : "";
   const close = current ? `<button class="mini warn panel-close" title="Close current panel" onclick="event.preventDefault();event.stopPropagation();closeTab('${current.tab_id}')">✕</button>` : "";
-  return `<div class="panel-field"><button class="panel-label" title="Current panel: ${escapeAttr(currentLabel)}. Double-click to rename." onclick="event.preventDefault();event.stopPropagation();${click}" ondblclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;${current ? `startTabRename('${current.tab_id}','${escapeAttr(currentLabel)}')` : ""}"><span>${escapeHtml(currentLabel)}</span>${caret}</button>${menu}<button class="mini panel-add" title="New panel" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button>${close}</div>`;
+  return `<div class="panel-field"><button class="panel-label" title="${escapeAttr(current ? panelTooltip(current, currentIndex) : "No panel")}" onclick="event.preventDefault();event.stopPropagation();${click}" ondblclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;${current ? `startTabRename('${current.tab_id}','${escapeAttr(panelRenameInitialLabel(current))}')` : ""}"><span>${escapeHtml(currentLabel)}</span>${caret}</button>${menu}<button class="mini panel-add" title="New panel" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button>${close}</div>`;
 }
 
 function togglePanelMenu() {


### PR DESCRIPTION
## Summary
- Render default shell/terminal panel labels as numeric panel positions in the header switcher.
- Preserve custom panel names and keep backend titles in tooltips.
- Start rename for default panels with an empty field instead of `shell`.
- Add JS regression coverage for numeric panel labels.

## Validation
- cargo fmt --check
- cargo test --all-targets
- node --test src/assets/*.test.mjs
- git diff --check
- cargo build --release --bins --target-dir target
- make update-mac