### PR TITLE
Filter terminal palette query replies

### DIFF
--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -680,6 +680,12 @@ describe("app bundle load", () => {
       ctx.stripTerminalQueryReplies("\x1b]10;rgb:4c4c/4f4f/6969\x07hello\x1b]11;rgb:efef/f1f1/f5f5\x1b\\"),
       "hello",
     );
+    equal(
+      ctx.stripTerminalQueryReplies("\x1b]4;10;rgb:d7d7/ffff/d6d6\x1b\\prompt"),
+      "prompt",
+    );
+    equal(ctx.stripTerminalQueryReplies("4;10;rgb:d7d7/ffff/d6d6\\prompt"), "prompt");
+    equal(ctx.stripTerminalQueryReplies("\x1b]12;rgb:d7d7/ffff/d6d6\x07prompt"), "prompt");
     equal(ctx.stripTerminalQueryReplies("normal input"), "normal input");
   });
 

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -610,7 +610,7 @@ function sendInputData(data, options = {}) {
 
 function stripTerminalQueryReplies(data) {
   return String(data || "").replace(
-    /\x1b\](?:10|11);rgb:[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}(?:\x07|\x1b\\)/g,
+    /(?:\x1b\])?(?:(?:10|11|12)|4;\d{1,3});rgb:[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}\/[0-9a-fA-F]{1,4}(?:\x07|\x1b\\|\\)?/g,
     "",
   );
 }


### PR DESCRIPTION
## Summary
- Filter xterm.js OSC palette/cursor color query replies before sending terminal input to the PTY.
- Covers leaked palette reply forms and OSC 12 cursor color replies.
- Keeps normal user input untouched.

## Why
Some shells/themes query terminal colors. Native terminals consume those replies internally, but xterm.js can surface them through input callbacks. If forwarded to the PTY, fragments like d7ffd6 can appear in the prompt/input.

## Validation
- node --test src/assets/app_load.test.mjs --test-name-pattern 'filters OSC color query replies before terminal input reaches the backend'
- node --test src/assets/*.test.mjs
- git diff --check
- make update-mac
