### PR TITLE
Extract panel switcher module

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -53,6 +53,7 @@ const DESKTOP_DIRECTORY_PICKER_JS: &str = include_str!("assets/desktop/directory
 const DESKTOP_JS: &str = concat!(
     include_str!("assets/desktop/app_js/core.js"),
     include_str!("assets/desktop/app_js/legacy_polling.js"),
+    include_str!("assets/desktop/app_js/panel_switcher.js"),
     include_str!("assets/desktop/app_js/render.js"),
     include_str!("assets/desktop/app_js/terminal.js"),
     include_str!("assets/desktop/app_js/worktrees.js"),

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -106,6 +106,7 @@ describe("app bundle load", () => {
   let source;
   let gitUiSource;
   let gitSettingsSource;
+  let desktopWorkspacesCss;
   let desktopTerminalSource;
   let appBootSource;
 
@@ -114,6 +115,7 @@ describe("app bundle load", () => {
     appBootSource = readFileSync(new URL("./app_boot.js", import.meta.url), "utf8");
     const desktopAppSource = [
       "./desktop/app_js/core.js",
+      "./desktop/app_js/panel_switcher.js",
       "./desktop/app_js/render.js",
       "./desktop/app_js/terminal.js",
       "./desktop/app_js/worktrees.js",
@@ -133,6 +135,7 @@ describe("app bundle load", () => {
       desktopAppSource;
     gitUiSource = readFileSync(new URL("./desktop/git_ui.js", import.meta.url), "utf8");
     gitSettingsSource = readFileSync(new URL("./desktop/git_ui/settings.js", import.meta.url), "utf8");
+    desktopWorkspacesCss = readFileSync(new URL("./desktop/app_css/workspaces.css", import.meta.url), "utf8");
   });
 
   it("loads without initialization-order ReferenceError", () => {
@@ -711,6 +714,25 @@ describe("app bundle load", () => {
     match(html, />custom<\/button>/);
     equal(html.includes(">shell</button>"), false);
     equal(ctx.panelRenameInitialLabel({ label: "shell", number: 1 }), "");
+
+    vm.runInContext(`
+      state.ws = "ws2";
+      state.tab = "ws2-tab1";
+      state.tabs = [
+        { workspace_id: "ws2", tab_id: "ws2-tab1", label: "shell", number: 1 },
+        { workspace_id: "ws2", tab_id: "ws2-tab2", label: "shell", number: 2 },
+      ];
+    `, ctx);
+    match(ctx.renderPanelField(), /<span>1<\/span>/);
+  });
+
+  it("keeps session manager buttons on one rounded style", () => {
+    match(source, /class="session-button primary" id="newBuiltinSessionTarget"/);
+    match(source, /class="session-button" id="newHerdrSessionTarget"/);
+    ok(!source.includes('class="tab add" id="newHerdrSessionTarget"'));
+    ok(!source.includes('class="mini danger" onclick="event.stopPropagation\(\);closeCurrentSession'));
+    match(desktopWorkspacesCss, /\.session-button \{/);
+    match(desktopWorkspacesCss, /border-radius: 10px;/);
   });
 
   it("renders backend-aware session manager and sends backend target headers", async () => {

--- a/src/assets/desktop/app_css/workspaces.css
+++ b/src/assets/desktop/app_css/workspaces.css
@@ -363,6 +363,39 @@ body.light .chip.label {
   flex-wrap: wrap;
   justify-content: flex-end;
 }
+.session-button {
+  align-items: center;
+  background: var(--panel2);
+  border: 1px solid var(--border2);
+  border-radius: 10px;
+  color: var(--fg);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
+  min-height: 30px;
+  padding: 8px 11px;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+  white-space: nowrap;
+}
+.session-button:hover,
+.session-button:focus {
+  background: var(--control-hover);
+  border-color: var(--accent-border);
+}
+.session-button.primary {
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+  color: var(--accent);
+}
+.session-button.danger {
+  color: #e64553;
+}
 .status-pill {
   display: inline-flex;
   align-items: center;

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -2121,7 +2121,7 @@ function setupSessionChrome() {
     m.className = "session-manager";
     m.id = "sessionManager";
     m.innerHTML =
-      '<div class="session-card"><div class="session-hero"><div><h1 id="sessionManagerTitle">Sessions</h1><p id="sessionManagerText">Choose a built-in or Herdr backend session to open.</p></div><div class="session-current"><span class="dot unknown"></span><span id="sessionCurrentLabel">default · built-in</span></div></div><div class="session-actions"><div class="session-list" id="sessionList"></div><div class="session-line session-new"><span><strong>Create or target session</strong><small>Choose where to create/open it. Built-in starts inside WebUI. Herdr starts external daemon.</small></span><span class="session-controls"><button class="btn" id="newBuiltinSessionTarget">New built-in</button><button class="tab add" id="newHerdrSessionTarget">New Herdr</button></span></div></div></div>';
+      '<div class="session-card"><div class="session-hero"><div><h1 id="sessionManagerTitle">Sessions</h1><p id="sessionManagerText">Choose a built-in or Herdr backend session to open.</p></div><div class="session-current"><span class="dot unknown"></span><span id="sessionCurrentLabel">default · built-in</span></div></div><div class="session-actions"><div class="session-list" id="sessionList"></div><div class="session-line session-new"><span><strong>Create or target session</strong><small>Choose where to create/open it. Built-in starts inside WebUI. Herdr starts external daemon.</small></span><span class="session-controls"><button class="session-button primary" id="newBuiltinSessionTarget">New built-in</button><button class="session-button" id="newHerdrSessionTarget">New Herdr</button></span></div></div></div>';
     document.querySelector(".main").prepend(m);
     el("newBuiltinSessionTarget").onclick = () => newSessionTarget("builtin");
     el("newHerdrSessionTarget").onclick = () => newSessionTarget("external-herdr");
@@ -2159,7 +2159,7 @@ function renderSessionRows() {
       const status = `<span class="status-pill ${s.running ? "running" : "offline"}">${s.running ? "running" : "offline"}</span>`;
       const backendPill = `<span class="status-pill">${escapeHtml(s.backend_label || sessionBackendLabel(backend))}</span>`;
       const controls = active
-        ? `<span class="session-controls">${backendPill}<button class="btn" onclick="event.stopPropagation();launchBackend('${escapeAttr(s.name)}','${escapeAttr(backend)}')">Launch</button><button class="tab add" onclick="event.stopPropagation();refresh()">Retry</button><button class="tab add" onclick="event.stopPropagation();resetSession()">Reset workspaces</button><button class="mini danger" onclick="event.stopPropagation();closeCurrentSession()">Close</button></span>`
+        ? `<span class="session-controls">${backendPill}<button class="session-button primary" onclick="event.stopPropagation();launchBackend('${escapeAttr(s.name)}','${escapeAttr(backend)}')">Launch</button><button class="session-button" onclick="event.stopPropagation();refresh()">Retry</button><button class="session-button" onclick="event.stopPropagation();resetSession()">Reset workspaces</button><button class="session-button danger" onclick="event.stopPropagation();closeCurrentSession()">Close</button></span>`
         : `<span class="session-controls">${backendPill}${status}</span>`;
       const hint = active
         ? "current browser target"

--- a/src/assets/desktop/app_js/panel_switcher.js
+++ b/src/assets/desktop/app_js/panel_switcher.js
@@ -1,0 +1,56 @@
+function isDefaultPanelTitle(label) {
+  const value = String(label || "").trim().toLowerCase();
+  return !value || value === "shell" || value === "terminal" || /^tab\s+\d+$/.test(value);
+}
+
+function panelNumberLabel(tab, index, tabs = state.tabs || []) {
+  const number = Number(tab && tab.number);
+  if (Number.isFinite(number) && number > 0) return String(number);
+  const fallbackIndex = Number.isFinite(index)
+    ? index
+    : tabs.findIndex((candidate) => candidate.tab_id === tab.tab_id);
+  return String((fallbackIndex >= 0 ? fallbackIndex : 0) + 1);
+}
+
+function panelVisibleLabel(tab, index, tabs = state.tabs || []) {
+  const label = String((tab && tab.label) || "").trim();
+  return isDefaultPanelTitle(label) ? panelNumberLabel(tab, index, tabs) : label;
+}
+
+function panelRenameInitialLabel(tab) {
+  const label = String((tab && tab.label) || "").trim();
+  return isDefaultPanelTitle(label) ? "" : label;
+}
+
+function panelTooltip(tab, index, tabs = state.tabs || []) {
+  const visible = panelVisibleLabel(tab, index, tabs);
+  const title = tabTitle(tab);
+  return visible === title
+    ? `Current panel: ${visible}. Double-click to rename.`
+    : `Current panel: ${visible} · ${title}. Double-click to rename.`;
+}
+
+function renderPanelField() {
+  if (!state.ws) return '<span class="panel-field-empty">No panel</span>';
+  const tabs = state.tabs || [];
+  const current = tabs.find((t) => t.tab_id === state.tab) || tabs[0] || null;
+  const currentIndex = current ? tabs.findIndex((t) => t.tab_id === current.tab_id) : -1;
+  const currentLabel = current ? panelVisibleLabel(current, currentIndex, tabs) : "No panel";
+  const hasSwitcher = tabs.length > 1;
+  if (current && state.editingTab === current.tab_id)
+    return `<div class="panel-field"><input class="panel-label panel-rename-input tab-rename-input" value="${escapeAttr(state.editingTabValue)}" onmousedown="event.stopPropagation()" onclick="event.stopPropagation()" onblur="commitTabRename('${current.tab_id}')" oninput="state.editingTabValue=this.value" onkeydown="tabRenameKey(event,'${current.tab_id}')"><button class="mini panel-add" title="New panel" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button><button class="mini warn panel-close" title="Close current panel" onclick="event.preventDefault();event.stopPropagation();closeTab('${current.tab_id}')">✕</button></div>`;
+  const menu = hasSwitcher && state.panelMenuOpen
+    ? `<div class="panel-menu">${tabs.map((tab, index) => `<button class="panel-menu-item${tab.tab_id === state.tab ? " active" : ""}" title="${escapeAttr(tabTitle(tab))}" onclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;go(state.ws,decodeURIComponent('${encodeURIComponent(tab.tab_id)}'))">${escapeHtml(panelVisibleLabel(tab, index, tabs))}</button>`).join("")}</div>`
+    : "";
+  const caret = hasSwitcher ? '<span class="panel-caret">▼</span>' : "";
+  const click = hasSwitcher ? "togglePanelMenu()" : "";
+  const close = current
+    ? `<button class="mini warn panel-close" title="Close current panel" onclick="event.preventDefault();event.stopPropagation();closeTab('${current.tab_id}')">✕</button>`
+    : "";
+  return `<div class="panel-field"><button class="panel-label" title="${escapeAttr(current ? panelTooltip(current, currentIndex, tabs) : "No panel")}" onclick="event.preventDefault();event.stopPropagation();${click}" ondblclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;${current ? `startTabRename('${current.tab_id}','${escapeAttr(panelRenameInitialLabel(current))}')` : ""}"><span>${escapeHtml(currentLabel)}</span>${caret}</button>${menu}<button class="mini panel-add" title="New panel" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button>${close}</div>`;
+}
+
+function togglePanelMenu() {
+  state.panelMenuOpen = !state.panelMenuOpen;
+  render();
+}

--- a/src/assets/desktop/app_js/render.js
+++ b/src/assets/desktop/app_js/render.js
@@ -242,49 +242,6 @@ function selectedWorkspaceActionButtons(w) {
     );
   return `<span class="space-actions selected-space-actions">${buttons.join("")}</span>`;
 }
-function isDefaultPanelTitle(label) {
-  const value = String(label || "").trim().toLowerCase();
-  return !value || value === "shell" || value === "terminal" || /^tab\s+\d+$/.test(value);
-}
-function panelNumberLabel(tab, index) {
-  const number = Number(tab && tab.number);
-  if (Number.isFinite(number) && number > 0) return String(number);
-  return String((Number.isFinite(index) ? index : state.tabs.findIndex((t) => t.tab_id === tab.tab_id)) + 1 || 1);
-}
-function panelVisibleLabel(tab, index) {
-  const label = String((tab && tab.label) || "").trim();
-  return isDefaultPanelTitle(label) ? panelNumberLabel(tab, index) : label;
-}
-function panelRenameInitialLabel(tab) {
-  const label = String((tab && tab.label) || "").trim();
-  return isDefaultPanelTitle(label) ? "" : label;
-}
-function panelTooltip(tab, index) {
-  const visible = panelVisibleLabel(tab, index);
-  const title = tabTitle(tab);
-  return visible === title ? `Current panel: ${visible}. Double-click to rename.` : `Current panel: ${visible} · ${title}. Double-click to rename.`;
-}
-function renderPanelField() {
-  if (!state.ws)
-    return '<span class="panel-field-empty">No panel</span>';
-  const tabs = state.tabs || [],
-    current = tabs.find((t) => t.tab_id === state.tab) || tabs[0] || null,
-    currentIndex = current ? tabs.findIndex((t) => t.tab_id === current.tab_id) : -1,
-    currentLabel = current ? panelVisibleLabel(current, currentIndex) : "No panel";
-  const hasSwitcher = tabs.length > 1;
-  if (current && state.editingTab === current.tab_id)
-    return `<div class="panel-field"><input class="panel-label panel-rename-input tab-rename-input" value="${escapeAttr(state.editingTabValue)}" onmousedown="event.stopPropagation()" onclick="event.stopPropagation()" onblur="commitTabRename('${current.tab_id}')" oninput="state.editingTabValue=this.value" onkeydown="tabRenameKey(event,'${current.tab_id}')"><button class="mini panel-add" title="New panel" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button><button class="mini warn panel-close" title="Close current panel" onclick="event.preventDefault();event.stopPropagation();closeTab('${current.tab_id}')">✕</button></div>`;
-  const menu = hasSwitcher && state.panelMenuOpen ? `<div class="panel-menu">${tabs.map((tab, index) => `<button class="panel-menu-item${tab.tab_id === state.tab ? " active" : ""}" title="${escapeAttr(tabTitle(tab))}" onclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;go(state.ws,decodeURIComponent('${encodeURIComponent(tab.tab_id)}'))">${escapeHtml(panelVisibleLabel(tab, index))}</button>`).join("")}</div>` : "";
-  const caret = hasSwitcher ? '<span class="panel-caret">▼</span>' : "";
-  const click = hasSwitcher ? "togglePanelMenu()" : "";
-  const close = current ? `<button class="mini warn panel-close" title="Close current panel" onclick="event.preventDefault();event.stopPropagation();closeTab('${current.tab_id}')">✕</button>` : "";
-  return `<div class="panel-field"><button class="panel-label" title="${escapeAttr(current ? panelTooltip(current, currentIndex) : "No panel")}" onclick="event.preventDefault();event.stopPropagation();${click}" ondblclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;${current ? `startTabRename('${current.tab_id}','${escapeAttr(panelRenameInitialLabel(current))}')` : ""}"><span>${escapeHtml(currentLabel)}</span>${caret}</button>${menu}<button class="mini panel-add" title="New panel" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button>${close}</div>`;
-}
-
-function togglePanelMenu() {
-  state.panelMenuOpen = !state.panelMenuOpen;
-  render();
-}
 function renderRepoHeader(group) {
   return `<div class="repo-header workspace-orphan-header"><span>${escapeHtml(group.label)}</span></div>`;
 }


### PR DESCRIPTION
## Summary
- extract panel switcher behavior into a small `panel_switcher.js` module
- keep default shell/panel numbering scoped to the selected workspace tabs, matching Herdr behavior
- unify session manager buttons under one rounded `session-button` style

## Validation
- `cargo fmt --check`
- `cargo test --all-targets`
- `node --test src/assets/*.test.mjs`
- `git diff --check`
- `cargo build --release --bins --target-dir target`
- `make update-mac`