### PR TITLE
Increase backend client and TUI parser coverage

### DIFF
--- a/src/backend_client.rs
+++ b/src/backend_client.rs
@@ -570,6 +570,24 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn error_display_and_from_impls_are_descriptive() {
+        let io_error = BackendClientError::from(io::Error::new(io::ErrorKind::Other, "disk gone"));
+        assert_eq!(io_error.to_string(), "I/O error: disk gone");
+
+        let json_error = BackendClientError::from(serde_json::from_str::<Value>("{").unwrap_err());
+        assert!(json_error.to_string().starts_with("JSON error:"));
+
+        assert_eq!(
+            BackendClientError::Protocol("bad frame".to_string()).to_string(),
+            "terminal protocol error: bad frame"
+        );
+        assert_eq!(
+            BackendClientError::UnexpectedResponse("wrong frame".to_string()).to_string(),
+            "unexpected response: wrong frame"
+        );
+    }
+
+    #[test]
     fn builtin_session_uses_webui_socket_convention() {
         let _guard = env_lock().lock().unwrap();
         let base = PathBuf::from("/tmp").join(unique_name("tui-client-config"));
@@ -613,6 +631,30 @@ mod tests {
         let result = client.snapshot().unwrap();
 
         assert_eq!(result["type"], "session_snapshot");
+        handle.join().unwrap();
+        let _ = fs::remove_file(socket);
+    }
+
+    #[test]
+    fn request_raw_reports_closed_control_socket() {
+        let socket = temp_socket("tui-api-closed");
+        let listener = bind_local_listener(&socket).unwrap();
+        let handle = thread::spawn(move || {
+            let stream = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            assert!(line.contains("session.snapshot"));
+            drop(stream);
+        });
+
+        let client = BackendClient::new(&socket, temp_socket("unused-terminal"));
+        let err = client
+            .request_raw(json!({ "id": "x", "method": "session.snapshot", "params": {} }))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("closed the control socket without a response"));
         handle.join().unwrap();
         let _ = fs::remove_file(socket);
     }
@@ -787,6 +829,37 @@ mod tests {
     }
 
     #[test]
+    fn runtime_settings_path_uses_xdg_home_and_temp_fallbacks() {
+        let _guard = env_lock().lock().unwrap();
+        let original_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let original_home = std::env::var_os("HOME");
+        let xdg = PathBuf::from("/tmp").join(unique_name("xdg-config"));
+        let home = PathBuf::from("/tmp").join(unique_name("home-config"));
+
+        std::env::set_var("XDG_CONFIG_HOME", &xdg);
+        std::env::set_var("HOME", &home);
+        assert_eq!(
+            runtime_settings_path(),
+            xdg.join("herdr-webui/webui-settings.json")
+        );
+
+        std::env::remove_var("XDG_CONFIG_HOME");
+        assert_eq!(
+            runtime_settings_path(),
+            home.join(".config/herdr-webui/webui-settings.json")
+        );
+
+        std::env::remove_var("HOME");
+        assert_eq!(
+            runtime_settings_path(),
+            std::env::temp_dir().join("herdr-webui/webui-settings.json")
+        );
+
+        restore_env_var("XDG_CONFIG_HOME", original_xdg);
+        restore_env_var("HOME", original_home);
+    }
+
+    #[test]
     fn create_worktree_from_base_sends_builtin_cwd_base_shape() {
         let socket = temp_socket("tui-worktree-create");
         let listener = bind_local_listener(&socket).unwrap();
@@ -818,6 +891,150 @@ mod tests {
             .unwrap();
 
         assert_eq!(result["type"], "worktree_created");
+        handle.join().unwrap();
+        let _ = fs::remove_file(socket);
+    }
+
+    #[test]
+    fn terminal_attach_reports_welcome_errors_and_wrong_first_frame() {
+        let socket = temp_socket("tui-term-err");
+        let listener = bind_local_listener(&socket).unwrap();
+        let handle = thread::spawn(move || {
+            for response in [
+                ServerMessage::Welcome {
+                    version: BUILTIN_TUI_PROTOCOL_VERSION,
+                    encoding: RenderEncoding::TerminalAnsi,
+                    error: Some("terminal rejected".to_string()),
+                },
+                ServerMessage::ServerShutdown {
+                    reason: Some("not welcome".to_string()),
+                },
+            ] {
+                let mut stream = listener.accept().unwrap();
+                match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                    .unwrap()
+                {
+                    ClientMessage::Hello { .. } => {}
+                    other => panic!("expected hello, got {other:?}"),
+                }
+                write_message(&mut stream, &response).unwrap();
+            }
+        });
+
+        let client = BackendClient::new(temp_socket("unused-api"), &socket);
+        let protocol_err = match client.attach_terminal("term_1", 80, 24) {
+            Err(err) => err,
+            Ok(_) => panic!("expected terminal protocol error"),
+        };
+        assert_eq!(
+            protocol_err.to_string(),
+            "terminal protocol error: terminal rejected"
+        );
+        let unexpected = match client.attach_terminal("term_1", 80, 24) {
+            Err(err) => err,
+            Ok(_) => panic!("expected unexpected terminal response"),
+        };
+        assert!(unexpected
+            .to_string()
+            .contains("expected terminal Welcome, got ServerShutdown"));
+
+        handle.join().unwrap();
+        let _ = fs::remove_file(socket);
+    }
+
+    #[test]
+    fn terminal_client_maps_non_output_events_and_ignores_control_frames() {
+        let socket = temp_socket("tui-terminal-events");
+        let listener = bind_local_listener(&socket).unwrap();
+        let handle = thread::spawn(move || {
+            let mut stream = listener.accept().unwrap();
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
+                ClientMessage::Hello { cols, rows, .. } => assert_eq!((cols, rows), (1, 1)),
+                other => panic!("expected hello, got {other:?}"),
+            }
+            write_message(
+                &mut stream,
+                &ServerMessage::Welcome {
+                    version: BUILTIN_TUI_PROTOCOL_VERSION,
+                    encoding: RenderEncoding::TerminalAnsi,
+                    error: None,
+                },
+            )
+            .unwrap();
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
+                ClientMessage::AttachTerminal { terminal_id, .. } => {
+                    assert_eq!(terminal_id, "term_events")
+                }
+                other => panic!("expected attach, got {other:?}"),
+            }
+
+            let events = [
+                ServerMessage::Graphics {
+                    bytes: b"image".to_vec(),
+                },
+                ServerMessage::WindowTitle {
+                    title: Some("title".to_string()),
+                },
+                ServerMessage::Clipboard {
+                    data: "copied".to_string(),
+                },
+                ServerMessage::Notify {
+                    kind: crate::protocol::NotifyKind::Toast,
+                    message: "message".to_string(),
+                    body: Some("body".to_string()),
+                },
+                ServerMessage::MouseCapture { enabled: true },
+                ServerMessage::ServerShutdown {
+                    reason: Some("done".to_string()),
+                },
+                ServerMessage::ReloadSoundConfig,
+                ServerMessage::PrefixInputSource { active: true },
+            ];
+            for event in events {
+                write_message(&mut stream, &event).unwrap();
+            }
+        });
+
+        let client = BackendClient::new(temp_socket("unused-api"), &socket);
+        let mut terminal = client.attach_terminal("term_events", 0, 0).unwrap();
+
+        assert_eq!(terminal.size(), (1, 1));
+        assert_eq!(
+            terminal.read_event().unwrap(),
+            TerminalEvent::Graphics(b"image".to_vec())
+        );
+        assert_eq!(
+            terminal.read_event().unwrap(),
+            TerminalEvent::WindowTitle(Some("title".to_string()))
+        );
+        assert_eq!(
+            terminal.read_event().unwrap(),
+            TerminalEvent::Clipboard("copied".to_string())
+        );
+        assert_eq!(
+            terminal.read_event().unwrap(),
+            TerminalEvent::Notify {
+                message: "message".to_string(),
+                body: Some("body".to_string())
+            }
+        );
+        assert_eq!(
+            terminal.read_event().unwrap(),
+            TerminalEvent::MouseCapture { enabled: true }
+        );
+        assert_eq!(
+            terminal.read_event().unwrap(),
+            TerminalEvent::ServerShutdown {
+                reason: Some("done".to_string())
+            }
+        );
+        assert_eq!(terminal.read_event().unwrap(), TerminalEvent::Ignored);
+        assert_eq!(terminal.read_event().unwrap(), TerminalEvent::Ignored);
+
         handle.join().unwrap();
         let _ = fs::remove_file(socket);
     }
@@ -939,6 +1156,67 @@ mod tests {
         assert_eq!(seen_rx.recv().unwrap(), b"abc");
         handle.join().unwrap();
         let _ = fs::remove_file(socket);
+    }
+
+    #[test]
+    fn terminal_client_direct_input_and_detach_use_protocol_frames() {
+        let socket = temp_socket("tui-term-io");
+        let listener = bind_local_listener(&socket).unwrap();
+        let (seen_tx, seen_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let mut stream = listener.accept().unwrap();
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
+                ClientMessage::Hello { .. } => {}
+                other => panic!("expected hello, got {other:?}"),
+            }
+            write_message(
+                &mut stream,
+                &ServerMessage::Welcome {
+                    version: BUILTIN_TUI_PROTOCOL_VERSION,
+                    encoding: RenderEncoding::TerminalAnsi,
+                    error: None,
+                },
+            )
+            .unwrap();
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
+                ClientMessage::AttachTerminal { terminal_id, .. } => {
+                    assert_eq!(terminal_id, "term_io")
+                }
+                other => panic!("expected attach, got {other:?}"),
+            }
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
+                ClientMessage::Input { data } => seen_tx.send(data).unwrap(),
+                other => panic!("expected input, got {other:?}"),
+            }
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
+                ClientMessage::Detach => {}
+                other => panic!("expected detach, got {other:?}"),
+            }
+        });
+
+        let client = BackendClient::new(temp_socket("unused-api"), &socket);
+        let mut terminal = client.attach_terminal("term_io", 100, 30).unwrap();
+        terminal.send_input(b"direct").unwrap();
+        terminal.detach().unwrap();
+
+        assert_eq!(seen_rx.recv().unwrap(), b"direct");
+        handle.join().unwrap();
+        let _ = fs::remove_file(socket);
+    }
+
+    fn restore_env_var(key: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
     }
 
     fn env_lock() -> &'static Mutex<()> {

--- a/src/backend_client.rs
+++ b/src/backend_client.rs
@@ -618,6 +618,175 @@ mod tests {
     }
 
     #[test]
+    fn request_reports_backend_errors_and_missing_results() {
+        let socket = temp_socket("tui-api-error");
+        let listener = bind_local_listener(&socket).unwrap();
+        let handle = thread::spawn(move || {
+            for response in [
+                json!({ "id": "tui:ping", "error": { "message": "boom" } }),
+                json!({ "id": "tui:ping" }),
+            ] {
+                let mut stream = listener.accept().unwrap();
+                let mut line = String::new();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                reader.read_line(&mut line).unwrap();
+                stream.write_all(response.to_string().as_bytes()).unwrap();
+                stream.write_all(b"\n").unwrap();
+                stream.flush().unwrap();
+            }
+        });
+
+        let client = BackendClient::new(&socket, temp_socket("unused-terminal"));
+        let backend_error = client.ping().unwrap_err().to_string();
+        assert!(backend_error.contains("backend error: boom"));
+        let missing_result = client.ping().unwrap_err().to_string();
+        assert!(missing_result.contains("missing result in backend response"));
+
+        handle.join().unwrap();
+        let _ = fs::remove_file(socket);
+    }
+
+    #[test]
+    fn api_helpers_send_expected_methods_and_params() {
+        let socket = temp_socket("tui-api-methods");
+        let listener = bind_local_listener(&socket).unwrap();
+        let expected = vec![
+            ("ping", json!({})),
+            ("workspace.list", json!({})),
+            (
+                "workspace.create",
+                json!({ "cwd": "/repo", "label": "Repo", "focus": false, "env": {} }),
+            ),
+            ("tab.list", json!({ "workspace_id": "ws_1" })),
+            (
+                "tab.create",
+                json!({ "workspace_id": "ws_1", "label": "Build" }),
+            ),
+            ("pane.list", json!({ "workspace_id": "ws_1" })),
+            ("pane.read", json!({ "pane_id": "pane_1" })),
+            ("agent.list", json!({})),
+            (
+                "agent.start",
+                json!({ "name": "jcode", "argv": ["jcode", "--help"], "cwd": "/repo" }),
+            ),
+            ("worktree.list", json!({ "cwd": "/repo" })),
+            (
+                "worktree.open",
+                json!({ "path": "/repo", "branch": "main", "label": "Main" }),
+            ),
+            (
+                "worktree.create",
+                json!({ "cwd": "/repo", "branch": "feature", "base": "HEAD", "path": "/wt/feature", "label": "Feature" }),
+            ),
+        ];
+        let expected_for_thread = expected.clone();
+        let handle = thread::spawn(move || {
+            for (method, params) in expected_for_thread {
+                let mut stream = listener.accept().unwrap();
+                let mut line = String::new();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                reader.read_line(&mut line).unwrap();
+                let request: Value = serde_json::from_str(&line).unwrap();
+                assert_eq!(request["method"], method);
+                assert_eq!(request["params"], params);
+                stream
+                    .write_all(
+                        json!({ "id": request["id"], "result": { "type": "ok", "method": method } })
+                            .to_string()
+                            .as_bytes(),
+                    )
+                    .unwrap();
+                stream.write_all(b"\n").unwrap();
+                stream.flush().unwrap();
+            }
+        });
+
+        let client = BackendClient::new(&socket, temp_socket("unused-terminal"));
+        assert_eq!(client.ping().unwrap()["method"], "ping");
+        assert_eq!(
+            client.list_workspaces().unwrap()["method"],
+            "workspace.list"
+        );
+        assert_eq!(
+            client
+                .create_workspace(Some("/repo"), Some("Repo"))
+                .unwrap()["method"],
+            "workspace.create"
+        );
+        assert_eq!(
+            client.list_tabs(Some("ws_1")).unwrap()["method"],
+            "tab.list"
+        );
+        assert_eq!(
+            client.create_tab(Some("ws_1"), Some("Build")).unwrap()["method"],
+            "tab.create"
+        );
+        assert_eq!(
+            client.list_panes(Some("ws_1")).unwrap()["method"],
+            "pane.list"
+        );
+        assert_eq!(client.read_pane("pane_1").unwrap()["method"], "pane.read");
+        assert_eq!(client.list_agents().unwrap()["method"], "agent.list");
+        assert_eq!(
+            client
+                .start_agent(
+                    "jcode",
+                    &["jcode".to_string(), "--help".to_string()],
+                    Some("/repo")
+                )
+                .unwrap()["method"],
+            "agent.start"
+        );
+        assert_eq!(
+            client.list_worktrees(Some("/repo")).unwrap()["method"],
+            "worktree.list"
+        );
+        assert_eq!(
+            client
+                .open_worktree("/repo", Some("main"), Some("Main"))
+                .unwrap()["method"],
+            "worktree.open"
+        );
+        assert_eq!(
+            client
+                .create_worktree("/repo", "feature", "/wt/feature", Some("Feature"))
+                .unwrap()["method"],
+            "worktree.create"
+        );
+
+        handle.join().unwrap();
+        let _ = fs::remove_file(socket);
+    }
+
+    #[test]
+    fn socket_helpers_sanitize_and_shorten_paths() {
+        let _guard = env_lock().lock().unwrap();
+        let base = PathBuf::from("/tmp").join(unique_name("tui-client-long-config"));
+        std::env::set_var("XDG_CONFIG_HOME", &base);
+
+        assert_eq!(safe_socket_component("work/session:?"), "work_session__");
+        assert_eq!(safe_socket_component(""), "default");
+        assert_eq!(short_socket_hash("abc").len(), 16);
+        assert!(socket_path_pair_fits(&(
+            PathBuf::from("/tmp/a.sock"),
+            PathBuf::from("/tmp/b.sock"),
+        )));
+
+        let long_session = "s".repeat(140);
+        let client = BackendClient::builtin_session(Some(&long_session));
+        assert!(client.api_socket().starts_with(
+            short_builtin_socket_dir("")
+                .parent()
+                .unwrap_or(Path::new("/tmp"))
+        ));
+        assert!(client.api_socket().ends_with("herdr.sock"));
+        assert!(client.terminal_socket().ends_with("herdr-client.sock"));
+
+        let _ = fs::remove_dir_all(base);
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
+    #[test]
     fn create_worktree_from_base_sends_builtin_cwd_base_shape() {
         let socket = temp_socket("tui-worktree-create");
         let listener = bind_local_listener(&socket).unwrap();
@@ -700,6 +869,44 @@ mod tests {
             match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
                 .unwrap()
             {
+                ClientMessage::Resize { cols, rows, .. } => {
+                    assert_eq!((cols, rows), (1, 1));
+                }
+                other => panic!("expected resize, got {other:?}"),
+            }
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
+                ClientMessage::InputEvents { events } => match &events[..] {
+                    [crate::protocol::ClientInputEvent::Paste { text }] => {
+                        assert_eq!(text, "terminal paste")
+                    }
+                    other => panic!("expected paste event, got {other:?}"),
+                },
+                other => panic!("expected input events, got {other:?}"),
+            }
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
+                ClientMessage::Resize { cols, rows, .. } => {
+                    assert_eq!((cols, rows), (120, 40));
+                }
+                other => panic!("expected writer resize, got {other:?}"),
+            }
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
+                ClientMessage::InputEvents { events } => match &events[..] {
+                    [crate::protocol::ClientInputEvent::Paste { text }] => {
+                        assert_eq!(text, "writer paste")
+                    }
+                    other => panic!("expected writer paste event, got {other:?}"),
+                },
+                other => panic!("expected writer input events, got {other:?}"),
+            }
+            match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
+                .unwrap()
+            {
                 ClientMessage::Input { data } => seen_tx.send(data).unwrap(),
                 other => panic!("expected input, got {other:?}"),
             }
@@ -713,9 +920,16 @@ mod tests {
 
         let client = BackendClient::new(temp_socket("unused-api"), &socket);
         let mut terminal = client.attach_terminal("term_1", 80, 24).unwrap();
+        assert_eq!(terminal.size(), (80, 24));
         let output = terminal.read_output().unwrap();
+        terminal.resize(0, 0).unwrap();
+        assert_eq!(terminal.size(), (1, 1));
+        terminal.paste_text("terminal paste").unwrap();
         let mut writer = terminal.writer().unwrap();
-        assert_eq!(writer.size(), (80, 24));
+        assert_eq!(writer.size(), (1, 1));
+        writer.resize(120, 40).unwrap();
+        assert_eq!(writer.size(), (120, 40));
+        writer.paste_text("writer paste").unwrap();
         writer.send_input(b"abc").unwrap();
         writer.detach().unwrap();
 

--- a/src/bin/herdr-webui-tui.rs
+++ b/src/bin/herdr-webui-tui.rs
@@ -377,12 +377,40 @@ mod tests {
     fn parses_cli_defaults_and_modes() {
         let cli = Cli::parse([
             "--summary".to_string(),
+            "--once".to_string(),
+            "--session".to_string(),
+            "work".to_string(),
             "--refresh-ms".to_string(),
             "250".to_string(),
         ])
         .unwrap();
         assert!(cli.summary);
+        assert!(cli.once);
+        assert_eq!(cli.options.session.as_deref(), Some("work"));
         assert_eq!(cli.options.refresh_interval, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn parses_socket_overrides_and_clamps_refresh() {
+        let cli = Cli::parse([
+            "--api-socket".to_string(),
+            "/tmp/herdr.sock".to_string(),
+            "--terminal-socket".to_string(),
+            "/tmp/herdr-client.sock".to_string(),
+            "--refresh-ms".to_string(),
+            "1".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            cli.options.api_socket,
+            Some(PathBuf::from("/tmp/herdr.sock"))
+        );
+        assert_eq!(
+            cli.options.terminal_socket,
+            Some(PathBuf::from("/tmp/herdr-client.sock"))
+        );
+        assert_eq!(cli.options.refresh_interval, Duration::from_millis(50));
     }
 
     #[test]
@@ -396,5 +424,24 @@ mod tests {
         let err =
             Cli::parse(["--api-socket".to_string(), "/tmp/herdr.sock".to_string()]).unwrap_err();
         assert!(err.contains("must be provided together"));
+    }
+
+    #[test]
+    fn rejects_cli_help_missing_invalid_and_unknown_values() {
+        let help = Cli::parse(["--help".to_string()]).unwrap_err();
+        assert!(help.contains("Usage: herdr-webui-tui"));
+
+        let missing = Cli::parse(["--session".to_string()]).unwrap_err();
+        assert!(missing.contains("missing value for --session"));
+
+        let invalid_refresh =
+            Cli::parse(["--refresh-ms".to_string(), "fast".to_string()]).unwrap_err();
+        assert!(invalid_refresh.contains("invalid --refresh-ms value"));
+
+        let invalid_theme = Cli::parse(["--theme".to_string(), "blue".to_string()]).unwrap_err();
+        assert!(invalid_theme.contains("invalid theme 'blue'"));
+
+        let unknown = Cli::parse(["--webui-url".to_string()]).unwrap_err();
+        assert!(unknown.contains("unknown argument: --webui-url"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3504,6 +3504,47 @@ mod tests {
     }
 
     #[test]
+    fn parses_backend_modes_and_session_targets() {
+        assert_eq!(
+            BackendMode::parse("external-herdr").unwrap(),
+            BackendMode::ExternalHerdr
+        );
+        assert_eq!(
+            BackendMode::parse("external").unwrap(),
+            BackendMode::ExternalHerdr
+        );
+        assert_eq!(
+            BackendMode::parse("herdr").unwrap(),
+            BackendMode::ExternalHerdr
+        );
+        assert_eq!(BackendMode::parse("builtin").unwrap(), BackendMode::Builtin);
+        assert_eq!(
+            BackendMode::parse("built-in").unwrap(),
+            BackendMode::Builtin
+        );
+        assert_eq!(BackendMode::parse("auto").unwrap(), BackendMode::Auto);
+        assert_eq!(BackendMode::Builtin.as_str(), "builtin");
+        assert_eq!(BackendMode::Auto.as_str(), "auto");
+        assert!(BackendMode::Builtin.is_builtin());
+        assert!(!BackendMode::ExternalHerdr.is_builtin());
+        assert!(BackendMode::parse("bad")
+            .unwrap_err()
+            .to_string()
+            .contains("invalid --backend-mode"));
+
+        assert_eq!(
+            SessionBackendTarget::parse("external"),
+            Some(SessionBackendTarget::ExternalHerdr)
+        );
+        assert_eq!(
+            SessionBackendTarget::parse("built-in"),
+            Some(SessionBackendTarget::Builtin)
+        );
+        assert_eq!(SessionBackendTarget::Builtin.as_str(), "builtin");
+        assert_eq!(SessionBackendTarget::parse("unknown"), None);
+    }
+
+    #[test]
     fn parses_https_off_opt_out() {
         let args = ["--https", "off"].map(String::from);
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -523,6 +523,18 @@ unsafe fn libc_geteuid() -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn test_config(tls: crate::TlsConfig) -> WebConfig {
+        WebConfig {
+            bind: "127.0.0.1:8787".parse().unwrap(),
+            session: Some("work".to_string()),
+            api_socket: None,
+            client_socket: None,
+            backend_mode: None,
+            tls,
+        }
+    }
 
     #[test]
     fn linux_service_unit_contains_binary_and_flags() {
@@ -607,5 +619,67 @@ mod tests {
             xml_escape("<&>\"'"),
             "&lt;&amp;&gt;&quot;&apos;".to_string()
         );
+    }
+
+    #[test]
+    fn service_files_include_env_and_all_tls_modes() {
+        let _guard = env_lock().lock().unwrap();
+        std::env::set_var("HERDR_WEB_HERDR_BIN", "herdr & helper");
+
+        let tls = crate::TlsConfig {
+            mode: TlsMode::Auto,
+            cert_path: Some(PathBuf::from("/tmp/cert path.pem")),
+            key_path: Some(PathBuf::from("/tmp/key path.pem")),
+        };
+        let mut config = test_config(tls);
+        config.session = Some("work <session>".to_string());
+
+        let plist = mac_plist_xml(&config, Path::new("/tmp/herdr-webui")).unwrap();
+        assert!(plist.contains("<key>HERDR_WEB_HERDR_BIN</key>"));
+        assert!(plist.contains("<string>herdr &amp; helper</string>"));
+        assert!(plist.contains("<string>work &lt;session&gt;</string>"));
+        assert!(plist.contains("<string>auto</string>"));
+        assert!(plist.contains("<string>/tmp/cert path.pem</string>"));
+        assert!(plist.contains("<string>/tmp/key path.pem</string>"));
+
+        let unit = linux_service_unit(&config, Path::new("/tmp/herdr webui"));
+        assert!(unit.contains("Environment=HERDR_WEB_HERDR_BIN='herdr & helper'"));
+        assert!(unit.contains("--https auto"));
+        assert!(unit.contains("--tls-cert '/tmp/cert path.pem'"));
+        assert!(unit.contains("--tls-key '/tmp/key path.pem'"));
+
+        config.tls.mode = TlsMode::Files;
+        let files_unit = linux_service_unit(&config, Path::new("/tmp/herdr-webui"));
+        assert!(files_unit.contains("--https files"));
+
+        std::env::remove_var("HERDR_WEB_HERDR_BIN");
+    }
+
+    #[test]
+    fn linux_service_exists_checks_config_home_path() {
+        let _guard = env_lock().lock().unwrap();
+        let base =
+            std::env::temp_dir().join(format!("herdr-webui-service-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        std::env::set_var("XDG_CONFIG_HOME", &base);
+
+        let missing = ensure_linux_service_exists().unwrap_err();
+        assert_eq!(missing.kind(), io::ErrorKind::NotFound);
+        assert!(missing
+            .to_string()
+            .contains("systemd user service not found"));
+
+        let service = linux_service_path().unwrap();
+        fs::create_dir_all(service.parent().unwrap()).unwrap();
+        fs::write(&service, "unit").unwrap();
+        ensure_linux_service_exists().unwrap();
+
+        std::env::remove_var("XDG_CONFIG_HOME");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
     }
 }

--- a/src/tui_terminal.rs
+++ b/src/tui_terminal.rs
@@ -421,4 +421,92 @@ mod tests {
         assert_eq!(lines[0][3].style.bg, Some(Color::Rgb(1, 2, 3)));
         assert!(lines[0][3].style.underlined);
     }
+
+    #[test]
+    fn terminal_output_styled_lines_apply_cursor_and_erase_sequences() {
+        let lines = terminal_output_styled_lines_lossy(
+            "alpha\nbeta\x1b[1A\x1b[3GZZ\x1b[1B\x1b[1G!\x1b[K\ntrim\x1b[2K\n\x1b[2Jafter",
+        );
+
+        assert_eq!(plain_lines(&lines), vec!["after"]);
+
+        let lines = terminal_output_styled_lines_lossy("abcdef\x1b[3DXY\x1b[1K\x1b[2Gz");
+        assert_eq!(plain_lines(&lines), vec![" z"]);
+    }
+
+    #[test]
+    fn terminal_output_styled_lines_handle_tabs_backspace_osc_and_empty_edges() {
+        let lines =
+            terminal_output_styled_lines_lossy("\n\tX\u{8}Y\x1b]10;rgb:aaaa/bbbb/cccc\x1b\\\n\n");
+
+        assert_eq!(plain_lines(&lines), vec!["        Y"]);
+    }
+
+    #[test]
+    fn terminal_output_styled_lines_support_style_resets_and_bright_colors() {
+        let lines =
+            terminal_output_styled_lines_lossy("\x1b[2;3;4;94;104mbright\x1b[22;23;24;39;49mplain");
+
+        let bright = &lines[0][0];
+        assert_eq!(bright.text, "bright");
+        assert!(bright.style.dim);
+        assert!(bright.style.italic);
+        assert!(bright.style.underlined);
+        assert_eq!(bright.style.fg, Some(Color::Indexed(12)));
+        assert_eq!(bright.style.bg, Some(Color::Indexed(12)));
+
+        let plain = &lines[0][1];
+        assert_eq!(plain.text, "plain");
+        assert!(!plain.style.bold);
+        assert!(!plain.style.dim);
+        assert!(!plain.style.italic);
+        assert!(!plain.style.underlined);
+        assert_eq!(plain.style.fg, None);
+        assert_eq!(plain.style.bg, None);
+    }
+
+    #[test]
+    fn styled_terminal_line_truncates_and_applies_ratatui_styles() {
+        let spans = vec![
+            TuiTextSpan {
+                text: "abc".to_string(),
+                style: TuiTextStyle {
+                    fg: Some(Color::Red),
+                    bg: Some(Color::Blue),
+                    bold: true,
+                    dim: true,
+                    italic: true,
+                    underlined: true,
+                },
+            },
+            TuiTextSpan {
+                text: "def".to_string(),
+                style: TuiTextStyle::default(),
+            },
+        ];
+
+        let empty = styled_terminal_line(&spans, 0, Color::White);
+        assert_eq!(empty.spans[0].content.as_ref(), "");
+
+        let line = styled_terminal_line(&spans, 5, Color::White);
+        assert_eq!(line.spans[0].content.as_ref(), "abc");
+        assert_eq!(line.spans[0].style.fg, Some(Color::Red));
+        assert_eq!(line.spans[0].style.bg, Some(Color::Blue));
+        assert!(line.spans[0].style.add_modifier.contains(Modifier::BOLD));
+        assert!(line.spans[0].style.add_modifier.contains(Modifier::DIM));
+        assert!(line.spans[0].style.add_modifier.contains(Modifier::ITALIC));
+        assert!(line.spans[0]
+            .style
+            .add_modifier
+            .contains(Modifier::UNDERLINED));
+        assert_eq!(line.spans[1].content.as_ref(), "de…");
+        assert_eq!(line.spans[1].style.fg, Some(Color::White));
+    }
+
+    fn plain_lines(lines: &[Vec<TuiTextSpan>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|line| line.iter().map(|span| span.text.as_str()).collect())
+            .collect()
+    }
 }

--- a/src/tui_theme.rs
+++ b/src/tui_theme.rs
@@ -134,9 +134,13 @@ impl Palette {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
 
     #[test]
     fn parses_theme_names_and_aliases() {
+        assert_eq!("".parse::<TuiTheme>().unwrap(), TuiTheme::System);
+        assert_eq!(" auto ".parse::<TuiTheme>().unwrap(), TuiTheme::System);
+        assert_eq!("DARK".parse::<TuiTheme>().unwrap(), TuiTheme::Dark);
         assert_eq!("dark".parse::<TuiTheme>().unwrap(), TuiTheme::Dark);
         assert_eq!("light".parse::<TuiTheme>().unwrap(), TuiTheme::Light);
         assert_eq!("system".parse::<TuiTheme>().unwrap(), TuiTheme::System);
@@ -159,5 +163,54 @@ mod tests {
         let palette = Palette::system(TerminalTheme::Light);
         assert_eq!(palette.bg, Color::Reset);
         assert_eq!(palette.text, Color::Rgb(30, 41, 59));
+
+        let dark = Palette::system(TerminalTheme::Dark);
+        assert_eq!(dark.bg, Color::Reset);
+        assert_eq!(dark.text, Color::Rgb(205, 214, 244));
+    }
+
+    #[test]
+    fn theme_env_prefers_webui_setting_then_jcode_then_system() {
+        let _guard = env_lock().lock().unwrap();
+        let original_webui = std::env::var_os("HERDR_WEBUI_TUI_THEME");
+        let original_jcode = std::env::var_os("JCODE_THEME");
+
+        std::env::set_var("HERDR_WEBUI_TUI_THEME", "light");
+        std::env::set_var("JCODE_THEME", "dark");
+        assert_eq!(TuiTheme::from_env(), TuiTheme::Light);
+
+        std::env::remove_var("HERDR_WEBUI_TUI_THEME");
+        assert_eq!(TuiTheme::from_env(), TuiTheme::Dark);
+
+        std::env::set_var("JCODE_THEME", "invalid");
+        assert_eq!(TuiTheme::from_env(), TuiTheme::System);
+
+        restore_env_var("HERDR_WEBUI_TUI_THEME", original_webui);
+        restore_env_var("JCODE_THEME", original_jcode);
+    }
+
+    #[test]
+    fn palette_default_and_for_theme_use_dark_fallback() {
+        let default = Palette::default();
+        let dark = Palette::for_theme(TuiTheme::Dark);
+
+        assert_eq!(default.bg, dark.bg);
+        assert_eq!(default.accent, Color::Rgb(137, 180, 250));
+        assert_eq!(default.green, Color::Rgb(166, 227, 161));
+        assert_eq!(default.yellow, Color::Rgb(249, 226, 175));
+        assert_eq!(default.red, Color::Rgb(243, 139, 168));
+        assert_eq!(default.teal, Color::Rgb(148, 226, 213));
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env_var(key: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add backend client error/protocol/event coverage
- add TUI parser/style/theme coverage
- raise Rust line coverage over 70%

## Validation
- cargo fmt --check
- cargo test --all-targets
- cargo llvm-cov --summary-only --all-targets => 70.68% lines
- node --test src/assets/*.test.mjs
- git diff --check
- cargo build --release --bins --target-dir target