### PR TITLE
Fix Git log load-more render

### DIFF
--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -2041,6 +2041,8 @@ describe("app bundle load", () => {
     match(gitLogSource, /const LANE_COLORS = \[/);
     match(gitLogSource, /exact_date/);
     match(gitLogSource, /function renderLoadMore/);
+    ok(!gitLogSource.includes("const footer = renderLoadMore(data,"));
+    match(gitLogSource, /renderLoadMore\(options\.data \|\| \{\}, rows, options, esc\)/);
     match(gitLogSource, /Load more changes/);
     match(gitLogSource, /HerdrGitUi.loadMoreLog\(\)/);
     match(gitLogSource, /data\.has_more/);

--- a/src/assets/desktop/git_ui/log.js
+++ b/src/assets/desktop/git_ui/log.js
@@ -28,7 +28,7 @@
     const body = rows.length
       ? rows.map((row) => renderRow(row, selected, filters, options, baseBranch)).join("")
       : `<div class="git-ui-empty-row">No commits found.</div>`;
-    const footer = renderLoadMore(data, rows, options, esc);
+    const footer = renderLoadMore(options.data || {}, rows, options, esc);
     return `${scope}<div class="git-ui-log git-ui-log-table">${header}${body}${footer}</div>`;
   }
 


### PR DESCRIPTION
## Summary
- Fixes Git log runtime ReferenceError from the load-more footer render path
- Adds regression coverage to prevent calling renderLoadMore with an out-of-scope data variable

## Validation
- cargo fmt --check
- cargo test --all-targets
- node --test src/assets/*.test.mjs
- git diff --check
- cargo build --release --bins --target-dir target
- local deploy smoke: snapshot-92fded07f8bf builtin compatible