### PR TITLE
Fix terminal extending below view area

### DIFF
--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -275,7 +275,12 @@ function showTerminalShellMode() {
   syncShellModeButtons();
   if (state.terminalId && !term && typeof Terminal !== "undefined") connectTerminal();
   fitTerminalShell();
-  if (typeof requestAnimationFrame === "function") requestAnimationFrame(fitTerminalShell);
+  if (typeof fitTerminalSurface === "function") fitTerminalSurface();
+  if (typeof requestAnimationFrame === "function")
+    requestAnimationFrame(() => {
+      fitTerminalShell();
+      if (typeof fitTerminalSurface === "function") fitTerminalSurface();
+    });
 }
 const headTitle = document.querySelector(".head strong");
 if (headTitle) {

--- a/src/assets/desktop/app_js/render.js
+++ b/src/assets/desktop/app_js/render.js
@@ -71,6 +71,7 @@ function render() {
     }
   }
   fitTerminalShell();
+  if (typeof fitTerminalSurface === "function") fitTerminalSurface();
 }
 window.HerdrDesktopRender = render;
 function updateTitle(wsById, tabById, tabCountsByWorkspace, pane) {

--- a/src/assets/desktop/file_browser.js
+++ b/src/assets/desktop/file_browser.js
@@ -493,6 +493,14 @@
     const gitOpen = !!(git && git.style.display !== "none");
     shell.style.display = state.open || gitOpen ? "none" : "";
     if (window.syncShellModeButtons) window.syncShellModeButtons();
+    // Refit the terminal surface when the shell reappears so the
+    // terminal does not extend below the visible area.
+    if (!state.open && !gitOpen && shell.style.display !== "none") {
+      if (window.HerdrTerminalFit) window.HerdrTerminalFit.afterLayout(function () {
+        if (typeof fitTerminalShell === "function") fitTerminalShell();
+        if (typeof fitTerminalSurface === "function") fitTerminalSurface();
+      });
+    }
   }
 
   function treeEntries() {

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -610,6 +610,14 @@
     const fileVisible = !!(fileBrowser && fileBrowser.isVisible && fileBrowser.isVisible());
     shell.style.display = show || fileVisible ? "none" : "";
     if (window.syncShellModeButtons) window.syncShellModeButtons();
+    // Refit the terminal surface when the shell reappears so the
+    // terminal does not extend below the visible area.
+    if (!show && !fileVisible && shell.style.display !== "none") {
+      if (window.HerdrTerminalFit) window.HerdrTerminalFit.afterLayout(function () {
+        if (typeof fitTerminalShell === "function") fitTerminalShell();
+        if (typeof fitTerminalSurface === "function") fitTerminalSurface();
+      });
+    }
   }
 
   async function open(workspace, options) {


### PR DESCRIPTION
## Problem

Sometimes the terminal surface extends below the visible area, so the last rows are cut off and the user cannot see the prompt or recent output.

## Root cause

`fitTerminalSurface()` was only called during `connectTerminal()` (initial connection) or layout updates. When the terminal shell was hidden (Git UI or File Browser open) then shown again, `connectTerminal()` short-circuited because `term` already existed, so the terminal surface kept its old height and extended below the visible area.

## Fix

Call `fitTerminalSurface()` in the paths where the shell reappears:

1. **`render.js`** — added `fitTerminalSurface()` at the end of `render()` alongside the existing `fitTerminalShell()`.
2. **`core.js`** — `showTerminalShellMode()` now calls `fitTerminalSurface()` both synchronously and via `requestAnimationFrame`.
3. **`git_ui.js`** — `syncTerminalVisibility()` now calls `fitTerminalShell()` + `fitTerminalSurface()` via `afterLayout()` when the shell reappears.
4. **`file_browser.js`** — same refit when file browser closes and shell reappears.

## Testing

All 165 JS tests pass. Built and deployed locally via `make update-mac`.