### PR TITLE
Keep terminal at latest output while following

### DIFF
--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -492,6 +492,17 @@ function setTerminalFollowPaused(paused) {
   button.setAttribute("aria-hidden", paused ? "false" : "true");
 }
 
+// Auto-scroll to bottom after writing new data when the user is
+// following (not paused). This keeps the latest output visible while
+// preserving manual scrollback positions.
+function terminalFollowPaused() {
+  const button = el("terminalFollowButton");
+  return !!(button && !button.hidden);
+}
+function maybeAutoScrollToBottom() {
+  if (terminalFollowPaused() || terminalScrollbackOffsetEstimate > 0) return;
+  try { term.scrollToBottom(); } catch (e) {}
+}
 function writeTerminalFrame(data, onDone) {
   // For large frames (the initial attach repaint), use the write callback
   // to know when xterm.js finishes parsing. This avoids the caller
@@ -506,6 +517,7 @@ function writeTerminalFrame(data, onDone) {
   } catch (e) {
     term.write(data);
   }
+  maybeAutoScrollToBottom();
 }
 function scrollTerminalToBottom(focus = true) {
   sendBackendTail();


### PR DESCRIPTION
## Problem

When terminal output keeps updating, the latest lines can move below the visible area. Users cannot read the end of the output even though follow mode is active.

## Root cause

Normal terminal frames were written to xterm without forcing the viewport back to the bottom. The existing tail behavior only ran on initial attach or explicit Tail clicks.

## Fix

Add `maybeAutoScrollToBottom()` after normal terminal writes. It:

- Scrolls xterm to the bottom after new output when follow mode is active
- Preserves manual scrollback positions when the Tail button is visible
- Respects remote backend scrollback estimate when the user has scrolled up

## Validation

- `node --test src/assets/*.test.mjs` passes, 165 tests
- `cargo build --release --bins` succeeds
- Deployed locally with `make update-mac`