### PR TITLE
Improve frontend parity and hot path efficiency

### DIFF
--- a/docs/code-quality-audit.md
+++ b/docs/code-quality-audit.md
@@ -1,0 +1,40 @@
+# Code quality audit
+
+Date: 2026-07-14
+Scope: full `herdr-webui` repository, indexed with codebase-memory.
+
+## Baseline
+
+- Graph: 4,619 nodes and 18,134 edges before remediation.
+- Large production files: `src/main.rs` (5,911 lines), `src/builtin_backend.rs` (3,981), desktop `core.js` (3,037), desktop `git_ui.js` (2,980).
+- Main quality risks: duplicated desktop/mobile flows, mixed-responsibility modules, process/session linear scans, and backend-routing parity gaps.
+- Baseline Rust tests: 191 passing.
+
+## Remediated in this pass
+
+- Added shared `normalizeOrder` in `src/assets/shared/core.js`; desktop, mobile, and shared search settings now use one implementation.
+- Fixed mobile backend routing. HTTP requests now send `x-herdr-backend` when a backend target is selected. WebSocket URLs now send one correctly joined `backend=` query parameter alongside `session=`.
+- Replaced process-tree PID deduplication and built-in session-name deduplication with `HashSet` membership.
+- Cleared existing Clippy warnings and moved conflict tests after production items to restore warnings-as-errors validation.
+- Added focused frontend coverage for shared normalization and mobile backend routing structure.
+
+## Deferred risks
+
+These require separate, reviewable refactors because they have larger blast radius:
+
+- Split `src/main.rs` into auth, settings, TLS, session/workspace handlers, and terminal proxy modules.
+- Replace the 22 agent-specific status functions in `src/builtin_backend.rs` with table-driven rules.
+- Split desktop `core.js`, desktop `git_ui.js`, and mobile file-browser responsibilities into smaller feature modules.
+- Unify duplicated desktop/mobile terminal refresh, worktree, and search flows where behavior is truly shared.
+- Unify the server `ApiClient` and library `BackendClient` protocol implementations.
+- Remove per-line allocation in `ContentMatcher::find` after adding Unicode-safe behavior tests and benchmarks.
+
+## Validation
+
+Passing after remediation:
+
+- `node --test src/assets/app_core.test.mjs src/assets/app_load.test.mjs src/assets/app_boot.test.mjs src/assets/mobile_load.test.mjs`
+- `cargo fmt --check`
+- `cargo clippy --target-dir target --all-targets -- -D warnings`
+- `cargo test --target-dir target --quiet`
+- `cargo build --release --target-dir target`

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## 0.2.61 Release Notes
+
+### Frontend parity and hot path efficiency
+
+- Adds shared frontend search-order normalization so desktop and mobile settings use one implementation and the behavior stays aligned.
+- Fixes mobile multi-backend routing parity by sending the selected backend for HTTP requests and WebSocket connections.
+- Reduces hot-path overhead in built-in backend process-tree traversal by using set-based visited tracking.
+- Documents the code-quality audit baseline, remediated issues, and deferred risks for follow-up refactors.
+
 ## 0.2.60 Release Notes
 
 ### Built-in backend detection docs

--- a/src/assets/app_core.test.mjs
+++ b/src/assets/app_core.test.mjs
@@ -8,6 +8,7 @@ const require = createRequire(import.meta.url);
 const {
   branchPathSlug,
   normalizeAbsolutePath,
+  normalizeOrder,
   normalizeThemeColors,
   resolveTerminalFontFamily,
   textValue,
@@ -72,6 +73,26 @@ describe("normalizeAbsolutePath", () => {
   it("leaves relative and home paths unchanged", () => {
     assert.equal(normalizeAbsolutePath("../worktrees"), "../worktrees");
     assert.equal(normalizeAbsolutePath("~/worktrees"), "~/worktrees");
+  });
+});
+
+describe("normalizeOrder", () => {
+  it("deduplicates, filters, and appends missing allowed values", () => {
+    assert.deepEqual(
+      normalizeOrder("files,unknown,files,workspaces", [
+        "workspaces",
+        "files",
+        "content",
+      ]),
+      ["files", "workspaces", "content"],
+    );
+  });
+
+  it("accepts array input while preserving allowed order", () => {
+    assert.deepEqual(
+      normalizeOrder(["CONTENT", "files"], ["workspaces", "files", "content"]),
+      ["content", "files", "workspaces"],
+    );
   });
 });
 

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -102,6 +102,14 @@ function context() {
   return vm.createContext(ctx);
 }
 
+function loadWorkspaceSearch(ctx) {
+  vm.runInContext(readFileSync(new URL("./shared/core.js", import.meta.url), "utf8"), ctx);
+  vm.runInContext(
+    readFileSync(new URL("./shared/workspace_search.js", import.meta.url), "utf8"),
+    ctx,
+  );
+}
+
 describe("app bundle load", () => {
   let source;
   let gitUiSource;
@@ -654,7 +662,7 @@ describe("app bundle load", () => {
   it("keeps content search file expansion when context is reloaded", () => {
     const ctx = context();
     ctx.localStorage.setItem("herdr-web-options", JSON.stringify({ fileContentSearchDefaultExpanded: false }));
-    vm.runInContext(readFileSync(new URL("./shared/workspace_search.js", import.meta.url), "utf8"), ctx);
+    loadWorkspaceSearch(ctx);
     const helper = ctx.HerdrWorkspaceSearch;
 
     const state = helper.createContentState({ expanded: { "src/a.js": true, "src/b.js": false } });
@@ -670,7 +678,7 @@ describe("app bundle load", () => {
   it("normalizes shared path search settings", () => {
     const ctx = context();
     ctx.localStorage.setItem("herdr-web-options", JSON.stringify({ searchFilesEnabled: false, searchFoldersEnabled: true }));
-    vm.runInContext(readFileSync(new URL("./shared/workspace_search.js", import.meta.url), "utf8"), ctx);
+    loadWorkspaceSearch(ctx);
     const helper = ctx.HerdrWorkspaceSearch;
 
     equal(helper.pathSearchAvailable(helper.settings()), true);
@@ -696,7 +704,7 @@ describe("app bundle load", () => {
       fileContentSearchMatchCase: true,
       fileContentSearchRegex: true,
     }));
-    vm.runInContext(readFileSync(new URL("./shared/workspace_search.js", import.meta.url), "utf8"), ctx);
+    loadWorkspaceSearch(ctx);
 
     const opts = ctx.HerdrWorkspaceSearch.settings();
     equal(JSON.stringify(opts.searchSectionOrder), JSON.stringify(["content", "files", "workspaces"]));
@@ -718,7 +726,7 @@ describe("app bundle load", () => {
       urls.push(String(url));
       return { ok: true, statusText: "OK", json: async () => ({ entries: [], files: [], truncated: false }) };
     };
-    vm.runInContext(readFileSync(new URL("./shared/workspace_search.js", import.meta.url), "utf8"), ctx);
+    loadWorkspaceSearch(ctx);
     const helper = ctx.HerdrWorkspaceSearch;
 
     ctx.localStorage.setItem("herdr-web-options", JSON.stringify({ searchFilesEnabled: false, searchFoldersEnabled: false, searchContentEnabled: false }));

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -139,6 +139,7 @@ const inputEncoder = new TextEncoder();
 const {
   branchPathSlug,
   normalizeAbsolutePath,
+  normalizeOrder,
   normalizeThemeColors,
   resolveTerminalFontFamily,
   textValue,
@@ -1058,18 +1059,7 @@ function normalizeAgentStatusOrder(value) {
   return order;
 }
 function normalizeSearchSectionOrder(value) {
-  const seen = new Set();
-  const order = [];
-  const parts = Array.isArray(value) ? value : String(value || "").split(",");
-  for (const part of parts) {
-    const key = String(part || "").trim().toLowerCase();
-    if (searchSectionGroupKeys.includes(key) && !seen.has(key)) {
-      seen.add(key);
-      order.push(key);
-    }
-  }
-  for (const key of searchSectionGroupKeys) if (!seen.has(key)) order.push(key);
-  return order;
+  return normalizeOrder(value, searchSectionGroupKeys);
 }
 function normalizeSidebarWorkspacePercent(value) {
   return Math.round(Math.max(

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -11,6 +11,8 @@
 
   const state = {
     session: "default",
+    backendMode: "",
+    sessionBackend: localStorage.getItem("herdr-session-backend") || "",
     workspaces: [],
     tabs: [],
     allTabs: [],
@@ -107,6 +109,9 @@
       state.session && state.session !== "default"
         ? { "x-herdr-session": state.session }
         : {},
+      currentSessionBackend()
+        ? { "x-herdr-backend": currentSessionBackend() }
+        : {},
     );
     return next;
   }
@@ -126,6 +131,7 @@
   async function loadServerSettings() {
     try {
       const settings = await api("/api/server-settings");
+      state.backendMode = settings.backend_mode || state.backendMode;
       state.defaultFolder = settings.default_folder || state.defaultFolder || "";
     } catch (_) {}
   }
@@ -139,12 +145,25 @@
 
   function wsUrl(path) {
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
-    const sep = path.includes("?") ? "&" : "?";
-    const session =
-      state.session && state.session !== "default"
-        ? sep + "session=" + encodeURIComponent(state.session)
-        : "";
-    return `${proto}//${location.host}${path}${session}`;
+    const params = [];
+    if (state.session && state.session !== "default")
+      params.push("session=" + encodeURIComponent(state.session));
+    if (currentSessionBackend())
+      params.push("backend=" + encodeURIComponent(currentSessionBackend()));
+    const suffix = params.length
+      ? (path.includes("?") ? "&" : "?") + params.join("&")
+      : "";
+    return `${proto}//${location.host}${path}${suffix}`;
+  }
+
+  function currentSessionBackend() {
+    if (state.sessionBackend === "external") return "external-herdr";
+    if (state.sessionBackend === "builtin" || state.sessionBackend === "external-herdr")
+      return state.sessionBackend;
+    if (state.backendMode === "external" || state.backendMode === "external-herdr")
+      return "external-herdr";
+    if (state.backendMode === "builtin") return "builtin";
+    return "";
   }
 
   function currentWorkspace() {

--- a/src/assets/mobile/settings.js
+++ b/src/assets/mobile/settings.js
@@ -5,6 +5,8 @@
     localStorage,
     state,
   }) {
+    const normalizeOrder = globalThis.HerdrAppHelpers.normalizeOrder;
+
     function render() {
       const layout = localStorage.getItem("herdr-web-layout") || "auto";
       const theme = localStorage.getItem("herdr-web-theme") || "auto";
@@ -114,18 +116,7 @@
       return !optionKey || readOptions()[optionKey] !== false;
     }
     function normalizeSearchSectionOrder(value) {
-      const allowed = ["workspaces", "files", "content"];
-      const seen = new Set();
-      const order = [];
-      for (const part of String(value || "").split(",")) {
-        const key = part.trim().toLowerCase();
-        if (allowed.includes(key) && !seen.has(key)) {
-          seen.add(key);
-          order.push(key);
-        }
-      }
-      for (const key of allowed) if (!seen.has(key)) order.push(key);
-      return order;
+      return normalizeOrder(value, ["workspaces", "files", "content"]);
     }
     function searchSectionOrderValue() { return normalizeSearchSectionOrder(readOptions().searchSectionOrder || "workspaces,files,content").join(","); }
 

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -277,6 +277,14 @@ describe("mobile bundle load", () => {
     ok(ctx.HerdrMobile);
   });
 
+  it("routes mobile HTTP and WebSocket requests to the selected backend", () => {
+    const mobileSource = readFileSync(new URL("./mobile/app.js", import.meta.url), "utf8");
+    match(mobileSource, /"x-herdr-backend": currentSessionBackend\(\)/);
+    match(mobileSource, /params\.push\("backend=" \+ encodeURIComponent\(currentSessionBackend\(\)\)\)/);
+    match(mobileSource, /params\.join\("&"\)/);
+    match(mobileSource, /state\.backendMode = settings\.backend_mode/);
+  });
+
   it("renders settings and worktrees screens without browser automation", () => {
     const ctx = context();
     vm.runInContext(source, ctx);

--- a/src/assets/shared/core.js
+++ b/src/assets/shared/core.js
@@ -27,6 +27,22 @@
     return "/" + parts.join("/");
   }
 
+  function normalizeOrder(value, allowed) {
+    const keys = Array.isArray(allowed) ? allowed : [];
+    const seen = new Set();
+    const order = [];
+    const parts = Array.isArray(value) ? value : String(value || "").split(",");
+    for (const part of parts) {
+      const key = String(part || "").trim().toLowerCase();
+      if (keys.includes(key) && !seen.has(key)) {
+        seen.add(key);
+        order.push(key);
+      }
+    }
+    for (const key of keys) if (!seen.has(key)) order.push(key);
+    return order;
+  }
+
   function terminalPasteInput(text, bracketedPasteMode) {
     const normalized = String(text || "").replace(/\r\n|\r/g, "\n");
     if (bracketedPasteMode) return "\x1b[200~" + normalized + "\x1b[201~";
@@ -214,6 +230,7 @@
   const helpers = {
     branchPathSlug,
     normalizeAbsolutePath,
+    normalizeOrder,
     normalizeThemeColors,
     resolveTerminalFontFamily,
     textValue,

--- a/src/assets/shared/workspace_search.js
+++ b/src/assets/shared/workspace_search.js
@@ -24,18 +24,11 @@
   }
 
   function normalizeSectionOrder(value) {
-    const allowed = ["workspaces", "files", "content"];
-    const seen = new Set();
-    const order = [];
-    for (const part of String(value || "").split(",")) {
-      const key = part.trim().toLowerCase();
-      if (allowed.includes(key) && !seen.has(key)) {
-        seen.add(key);
-        order.push(key);
-      }
-    }
-    for (const key of allowed) if (!seen.has(key)) order.push(key);
-    return order;
+    return globalThis.HerdrAppHelpers.normalizeOrder(value, [
+      "workspaces",
+      "files",
+      "content",
+    ]);
   }
 
   function settings() {

--- a/src/backend_client.rs
+++ b/src/backend_client.rs
@@ -571,7 +571,7 @@ mod tests {
 
     #[test]
     fn error_display_and_from_impls_are_descriptive() {
-        let io_error = BackendClientError::from(io::Error::new(io::ErrorKind::Other, "disk gone"));
+        let io_error = BackendClientError::from(io::Error::other("disk gone"));
         assert_eq!(io_error.to_string(), "I/O error: disk gone");
 
         let json_error = BackendClientError::from(serde_json::from_str::<Value>("{").unwrap_err());

--- a/src/builtin_backend.rs
+++ b/src/builtin_backend.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -235,10 +235,7 @@ fn handle_client_connection(
     let mut seq = 1_u64;
     let terminal_size = Arc::new(Mutex::new((cols, rows)));
     loop {
-        let message = match read_message::<_, ClientMessage>(&mut stream, MAX_FRAME_SIZE) {
-            Ok(message) => message,
-            Err(err) => return Err(err),
-        };
+        let message = read_message::<_, ClientMessage>(&mut stream, MAX_FRAME_SIZE)?;
         match message {
             ClientMessage::AttachTerminal { terminal_id, .. } => {
                 let terminal = backend
@@ -470,12 +467,7 @@ impl BuiltinState {
                 let label = optional_string(&params, "label");
                 let workspace = self.create_workspace(cwd, label, false)?;
                 let tab = self
-                    .tabs_for_workspace(
-                        &workspace["workspace_id"]
-                            .as_str()
-                            .unwrap_or_default()
-                            .to_string(),
-                    )?
+                    .tabs_for_workspace(workspace["workspace_id"].as_str().unwrap_or_default())?
                     .into_iter()
                     .next()
                     .unwrap_or_else(|| json!({}));
@@ -2002,13 +1994,15 @@ struct ProcessInfo {
     args: String,
 }
 
+type ProcessCache = Option<(Instant, Vec<ProcessInfo>)>;
+
 fn detect_agent_label_from_process_tree(root_pid: u32) -> Option<&'static str> {
     detect_agent_label_from_processes(root_pid, &process_table().ok()?)
 }
 
 #[cfg(unix)]
 fn process_table() -> io::Result<Vec<ProcessInfo>> {
-    static CACHE: OnceLock<Mutex<Option<(Instant, Vec<ProcessInfo>)>>> = OnceLock::new();
+    static CACHE: OnceLock<Mutex<ProcessCache>> = OnceLock::new();
     let cache = CACHE.get_or_init(|| Mutex::new(None));
     if let Ok(mut guard) = cache.lock() {
         if let Some((loaded_at, processes)) = guard.as_ref() {
@@ -2072,12 +2066,11 @@ fn detect_agent_label_from_processes(
         children.entry(process.ppid).or_default().push(process.pid);
     }
     let mut stack = vec![root_pid];
-    let mut seen = Vec::<u32>::new();
+    let mut seen = HashSet::<u32>::new();
     while let Some(pid) = stack.pop() {
-        if seen.contains(&pid) {
+        if !seen.insert(pid) {
             continue;
         }
-        seen.push(pid);
         if let Some(process) = by_pid.get(&pid) {
             if let Some(agent) = detect_agent_label_from_process(process) {
                 return Some(agent);

--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -578,7 +578,7 @@ fn push_search_entries_with_visit_limit(
             }
             let is_dir = entry.metadata.is_dir();
             let kind = if is_dir { "dir" } else { "file" };
-            let kind_matches = search_kind.map_or(true, |wanted| wanted == kind);
+            let kind_matches = search_kind.is_none_or(|wanted| wanted == kind);
             if kind_matches
                 && (entry.sort_name.contains(needle)
                     || relative_to_root(build.root, &entry.path)

--- a/src/git_ui/conflict.rs
+++ b/src/git_ui/conflict.rs
@@ -135,6 +135,76 @@ fn git_ui_conflict_stage_to_file(cwd: &str, path: &str, stage: u8) -> Result<Str
     git_ui_text(&repo, &["add", "--", path])
 }
 
+pub(super) async fn git_ui_conflict_resolve(
+    State(state): State<WebState>,
+    headers: HeaderMap,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    Json(body): Json<GitUiConflictResolveRequest>,
+) -> Response {
+    if let Err(response) = require_auth(&state, &headers, remote) {
+        return response;
+    }
+    let path = match safe_repo_path(&body.path) {
+        Ok(path) => path.to_string(),
+        Err(err) => return git_json_error(StatusCode::BAD_REQUEST, err),
+    };
+    let mode = body.mode;
+    let content = body.content;
+    let cwd = body.cwd;
+    match tokio::task::spawn_blocking(move || {
+        git_ui_conflict_resolve_blocking(cwd, path, mode, content)
+    })
+    .await
+    {
+        Ok(Ok(response)) => response,
+        Ok(Err((status, msg))) => git_json_error(status, msg),
+        Err(err) => git_json_error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+    }
+}
+
+fn git_ui_conflict_action_blocking(
+    cwd: String,
+    args: Vec<&'static str>,
+) -> Result<Response, (StatusCode, String)> {
+    match git_ui_text(&cwd, &args) {
+        Ok(text) => Ok(Json(json!({ "ok": true, "message": text })).into_response()),
+        Err(err) => Err((StatusCode::BAD_GATEWAY, err)),
+    }
+}
+
+fn conflict_action_args(action: &str) -> Option<Vec<&'static str>> {
+    Some(match action {
+        "merge-abort" => vec!["merge", "--abort"],
+        "merge-continue" => vec!["merge", "--continue"],
+        "rebase-continue" => vec!["rebase", "--continue"],
+        "rebase-skip" => vec!["rebase", "--skip"],
+        "rebase-abort" => vec!["rebase", "--abort"],
+        "cherry-pick-continue" => vec!["cherry-pick", "--continue"],
+        "cherry-pick-abort" => vec!["cherry-pick", "--abort"],
+        _ => return None,
+    })
+}
+
+pub(super) async fn git_ui_conflict_action(
+    State(state): State<WebState>,
+    headers: HeaderMap,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    Json(body): Json<GitUiConflictActionRequest>,
+) -> Response {
+    if let Err(response) = require_auth(&state, &headers, remote) {
+        return response;
+    }
+    let Some(args) = conflict_action_args(body.action.as_str()) else {
+        return git_json_error(StatusCode::BAD_REQUEST, "invalid conflict action");
+    };
+    let cwd = body.cwd;
+    match tokio::task::spawn_blocking(move || git_ui_conflict_action_blocking(cwd, args)).await {
+        Ok(Ok(response)) => response,
+        Ok(Err((status, msg))) => git_json_error(status, msg),
+        Err(err) => git_json_error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -257,75 +327,5 @@ mod tests {
             .unwrap();
         assert!(output.status.success());
         String::from_utf8_lossy(&output.stdout).to_string()
-    }
-}
-
-pub(super) async fn git_ui_conflict_resolve(
-    State(state): State<WebState>,
-    headers: HeaderMap,
-    ConnectInfo(remote): ConnectInfo<SocketAddr>,
-    Json(body): Json<GitUiConflictResolveRequest>,
-) -> Response {
-    if let Err(response) = require_auth(&state, &headers, remote) {
-        return response;
-    }
-    let path = match safe_repo_path(&body.path) {
-        Ok(path) => path.to_string(),
-        Err(err) => return git_json_error(StatusCode::BAD_REQUEST, err),
-    };
-    let mode = body.mode;
-    let content = body.content;
-    let cwd = body.cwd;
-    match tokio::task::spawn_blocking(move || {
-        git_ui_conflict_resolve_blocking(cwd, path, mode, content)
-    })
-    .await
-    {
-        Ok(Ok(response)) => response,
-        Ok(Err((status, msg))) => git_json_error(status, msg),
-        Err(err) => git_json_error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
-    }
-}
-
-fn git_ui_conflict_action_blocking(
-    cwd: String,
-    args: Vec<&'static str>,
-) -> Result<Response, (StatusCode, String)> {
-    match git_ui_text(&cwd, &args) {
-        Ok(text) => Ok(Json(json!({ "ok": true, "message": text })).into_response()),
-        Err(err) => Err((StatusCode::BAD_GATEWAY, err)),
-    }
-}
-
-fn conflict_action_args(action: &str) -> Option<Vec<&'static str>> {
-    Some(match action {
-        "merge-abort" => vec!["merge", "--abort"],
-        "merge-continue" => vec!["merge", "--continue"],
-        "rebase-continue" => vec!["rebase", "--continue"],
-        "rebase-skip" => vec!["rebase", "--skip"],
-        "rebase-abort" => vec!["rebase", "--abort"],
-        "cherry-pick-continue" => vec!["cherry-pick", "--continue"],
-        "cherry-pick-abort" => vec!["cherry-pick", "--abort"],
-        _ => return None,
-    })
-}
-
-pub(super) async fn git_ui_conflict_action(
-    State(state): State<WebState>,
-    headers: HeaderMap,
-    ConnectInfo(remote): ConnectInfo<SocketAddr>,
-    Json(body): Json<GitUiConflictActionRequest>,
-) -> Response {
-    if let Err(response) = require_auth(&state, &headers, remote) {
-        return response;
-    }
-    let Some(args) = conflict_action_args(body.action.as_str()) else {
-        return git_json_error(StatusCode::BAD_REQUEST, "invalid conflict action");
-    };
-    let cwd = body.cwd;
-    match tokio::task::spawn_blocking(move || git_ui_conflict_action_blocking(cwd, args)).await {
-        Ok(Ok(response)) => response,
-        Ok(Err((status, msg))) => git_json_error(status, msg),
-        Err(err) => git_json_error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::SocketAddr;
@@ -1102,7 +1102,7 @@ fn ensure_self_signed_cert() -> io::Result<(PathBuf, PathBuf)> {
             "self-signed cert path has no parent directory",
         )
     })?;
-    fs::create_dir_all(&dir)?;
+    fs::create_dir_all(dir)?;
     let subject_alt_names = vec![
         "localhost".to_string(),
         "127.0.0.1".to_string(),
@@ -1527,11 +1527,12 @@ fn known_builtin_sessions(state: &WebState) -> Vec<serde_json::Value> {
         found.sort();
         names.extend(found);
     }
+    let mut known = names.iter().cloned().collect::<HashSet<_>>();
     if let Ok(sessions) = state.builtin_sessions.lock() {
         let mut live = sessions.keys().cloned().collect::<Vec<_>>();
         live.sort();
         for name in live {
-            if !names.contains(&name) {
+            if known.insert(name.clone()) {
                 names.push(name);
             }
         }
@@ -2121,7 +2122,7 @@ struct SessionActionRequest {
     backend: Option<String>,
 }
 
-fn requested_session_from_headers<'a>(headers: &'a HeaderMap) -> Option<&'a str> {
+fn requested_session_from_headers(headers: &HeaderMap) -> Option<&str> {
     headers
         .get("x-herdr-session")
         .and_then(|value| value.to_str().ok())


### PR DESCRIPTION
## Summary
- Fix mobile backend routing parity for HTTP and WebSocket requests.
- Share frontend search-order normalization across desktop/mobile code paths.
- Reduce process-tree traversal overhead in the built-in backend.
- Add code-quality audit notes and 0.2.61 release notes.

## Validation
- `node --experimental-vm-modules src/assets/app_core.test.mjs`
- `node --experimental-vm-modules src/assets/app_load.test.mjs`
- `node --experimental-vm-modules src/assets/mobile_load.test.mjs`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --target-dir target`
- `cargo build --release --target-dir target`
