### PR TITLE
Fix terminal viewport overflow

### DIFF
--- a/src/assets/app.html
+++ b/src/assets/app.html
@@ -33,6 +33,10 @@
           <div class="terminal-loading" id="terminalLoading">
             <span>Loading panel</span>
           </div>
+          <div class="terminal-paste-progress" id="terminalPasteProgress" hidden aria-live="polite">
+            <div class="terminal-paste-progress-label" id="terminalPasteProgressLabel">Pasting…</div>
+            <div class="terminal-paste-progress-track" aria-hidden="true"><i id="terminalPasteProgressBar"></i></div>
+          </div>
           <button class="terminal-follow-button" id="terminalFollowButton" type="button" hidden title="Go to latest terminal output and resume follow" aria-label="Go to latest terminal output and resume follow">↓ Tail</button>
           <div class="terminal" id="terminal"></div>
         </div>

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -652,7 +652,7 @@ describe("app bundle load", () => {
     match(tempTerminalSource, /HerdrTerminalFit\.fitXtermToContainer\(container\)/);
     match(terminalFitSource, /function cellSize\(term, container, fallback\)/);
     match(terminalFitSource, /function gridSize\(container, term, options\)/);
-    match(terminalFitSource, /function fitXtermToContainer\(container\)/);
+    match(terminalFitSource, /function fitXtermToContainer\(container, options\)/);
     match(terminalFitSource, /root\.HerdrTerminalFit/);
     match(tempTerminalSource, /resizeTerminalSurface\(container, cols, rows\)/);
     match(tempTerminalSource, /box\.width >= 320 && box\.height >= 120/);

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -1954,9 +1954,26 @@ describe("app bundle load", () => {
     match(source, /addEventListener\(\s*"paste"/);
     match(source, /stopImmediatePropagation\(\)/);
     match(source, /sendPasteToTerminal\(text\)/);
-    match(source, /sendInputData\(terminalPasteInput\(text, false\)/);
+    match(source, /schedulePasteChunkFlush\(0\)/);
+    match(source, /function flushPasteChunks\(\)/);
+    match(source, /PASTE_TEXT_CHUNK_SIZE = 4096/);
+    match(source, /termWs\.bufferedAmount < PASTE_BUFFER_LIMIT/);
+    match(source, /normalizeTerminalPasteChunk\(pasteJob, rawChunk/);
+    match(source, /showTerminalPasteProgress\(pasteJob\.total\)/);
     ok(!source.includes('JSON.stringify({ type: "paste"'));
     ok(!source.includes('.paste(text)'));
+  });
+
+  it("renders terminal paste progress UI", () => {
+    const html = readFileSync(new URL("./app.html", import.meta.url), "utf8");
+    const terminalCss = readFileSync(new URL("./desktop/app_css/terminal.css", import.meta.url), "utf8");
+    match(html, /id="terminalPasteProgress"/);
+    match(html, /id="terminalPasteProgressLabel"/);
+    match(html, /id="terminalPasteProgressBar"/);
+    match(terminalCss, /\.terminal-paste-progress \{/);
+    match(terminalCss, /\.terminal-paste-progress-track i \{[\s\S]*?transition: width 80ms linear;/);
+    match(source, /function updateTerminalPasteProgress\(done, total\)/);
+    match(source, /label\.textContent = pct >= 100 \? "Paste sent" : "Pasting… " \+ pct \+ "%"/);
   });
 
   it("renders no-sleep control options", () => {

--- a/src/assets/desktop/app_css/terminal.css
+++ b/src/assets/desktop/app_css/terminal.css
@@ -53,6 +53,45 @@
 .terminal-follow-button[hidden] {
   display: none;
 }
+.terminal-paste-progress {
+  background: color-mix(in srgb, var(--panel), transparent 8%);
+  border: 1px solid var(--border2);
+  border-radius: 12px;
+  box-shadow: 0 10px 28px #0008;
+  color: var(--fg);
+  display: grid;
+  gap: 7px;
+  left: 18px;
+  min-width: min(360px, calc(100% - 36px));
+  padding: 10px 12px;
+  position: absolute;
+  right: auto;
+  top: 18px;
+  z-index: 9;
+}
+.terminal-paste-progress[hidden] {
+  display: none;
+}
+.terminal-paste-progress-label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+.terminal-paste-progress-track {
+  background: var(--panel2);
+  border-radius: 999px;
+  height: 6px;
+  overflow: hidden;
+}
+.terminal-paste-progress-track i {
+  background: linear-gradient(90deg, var(--accent), #a6e3a1);
+  border-radius: inherit;
+  display: block;
+  height: 100%;
+  transition: width 80ms linear;
+  width: 0%;
+}
 .terminal-follow-button:hover,
 .terminal-follow-button:focus {
   background: var(--accent-hover, var(--accent));

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -49,6 +49,7 @@ let term,
   connectedTerminalId = null,
   connectedSize = "",
   termScrollBound = false,
+  terminalViewportScrollElement = null,
   terminalTouchLastY = null,
   terminalWheelDeltaPixels = 0,
   terminalScrollbackOffsetEstimate = 0,
@@ -2513,6 +2514,14 @@ function resetTerminalConnection(clear = false, destroy = false) {
   terminalWriteFlushPending = false;
   terminalAttachPending = false;
   setTerminalFollowPaused(false);
+  if (
+    terminalViewportScrollElement &&
+    typeof terminalViewportScrollElement.removeEventListener === "function" &&
+    typeof handleTerminalViewportScroll === "function"
+  ) {
+    terminalViewportScrollElement.removeEventListener("scroll", handleTerminalViewportScroll);
+  }
+  terminalViewportScrollElement = null;
   if (termWs) {
     termWs.onclose = null;
     try {

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -69,6 +69,9 @@ let term,
   inputQueue = [],
   inputQueueMaxBufferedAmount = 65536,
   inputFlushTimer = null,
+  pasteJob = null,
+  pasteChunkTimer = null,
+  pasteProgressHideTimer = null,
   terminalWriteQueue = [],
   terminalWriteFlushPending = false,
   pasteFrameUntil = 0,
@@ -2509,6 +2512,16 @@ function resetTerminalConnection(clear = false, destroy = false) {
   }
   inputQueue = [];
   inputQueueMaxBufferedAmount = 65536;
+  if (pasteChunkTimer) {
+    clearTimeout(pasteChunkTimer);
+    pasteChunkTimer = null;
+  }
+  if (pasteProgressHideTimer) {
+    clearTimeout(pasteProgressHideTimer);
+    pasteProgressHideTimer = null;
+  }
+  pasteJob = null;
+  if (typeof hideTerminalPasteProgress === "function") hideTerminalPasteProgress();
   if (terminalWriteQueue.length && typeof flushTerminalFrames === "function") flushTerminalFrames();
   terminalWriteQueue = [];
   terminalWriteFlushPending = false;

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -258,6 +258,11 @@ function provideTerminalLinks(lineNumber, callback) {
 // RAF delay adds ~16ms of latency for no benefit. Above the threshold we
 // coalesce bursts to avoid overwhelming the renderer.
 const IMMEDIATE_WRITE_THRESHOLD = 8192;
+const PASTE_TEXT_CHUNK_SIZE = 4096;
+const PASTE_BYTE_CHUNK_SIZE = 16 * 1024;
+const PASTE_BUFFER_LIMIT = 64 * 1024;
+const PASTE_FLUSH_BUDGET_MS = 8;
+const PASTE_FLUSH_DELAY_MS = 4;
 // Frames above this size are likely full-screen repaints from the backend
 // (the initial attach frame). xterm.js parses these in 12ms time-slices with
 // setTimeout(0) between slices, and each slice triggers a browser paint of
@@ -637,12 +642,67 @@ function stripTerminalQueryReplies(data) {
 
 function sendPasteToTerminal(text) {
   if (!termWs || termWs.readyState !== 1 || !text) return;
-  pasteFrameUntil = Date.now() + 250;
-  sendInputData(terminalPasteInput(text, false), {
-    chunkSize: 16 * 1024,
-    maxBufferedAmount: 64 * 1024,
-  });
-  finishPasteFrameSoon();
+  const value = String(text || "");
+  if (!value) return;
+  if (pasteJob) {
+    pasteJob.text += value;
+    pasteJob.total = pasteJob.text.length;
+  } else {
+    pasteJob = { text: value, offset: 0, total: value.length, pendingCR: false };
+  }
+  pasteFrameUntil = Date.now() + Math.max(400, Math.min(8000, Math.ceil(pasteJob.total / 128)));
+  showTerminalPasteProgress(pasteJob.total);
+  schedulePasteChunkFlush(0);
+}
+function schedulePasteChunkFlush(delay = PASTE_FLUSH_DELAY_MS) {
+  if (pasteChunkTimer) return;
+  pasteChunkTimer = setTimeout(flushPasteChunks, delay);
+}
+function flushPasteChunks() {
+  pasteChunkTimer = null;
+  if (!pasteJob) return;
+  if (!termWs || termWs.readyState !== 1) {
+    pasteJob = null;
+    pasteFrameUntil = 0;
+    hideTerminalPasteProgress();
+    return;
+  }
+  const start = Date.now();
+  while (
+    pasteJob &&
+    pasteJob.offset < pasteJob.total &&
+    termWs.bufferedAmount < PASTE_BUFFER_LIMIT
+  ) {
+    const end = Math.min(pasteJob.total, pasteJob.offset + PASTE_TEXT_CHUNK_SIZE);
+    const rawChunk = pasteJob.text.slice(pasteJob.offset, end);
+    pasteJob.offset = end;
+    const chunk = normalizeTerminalPasteChunk(pasteJob, rawChunk, pasteJob.offset >= pasteJob.total);
+    if (chunk) sendPasteChunkToTerminal(chunk);
+    updateTerminalPasteProgress(pasteJob.offset, pasteJob.total);
+    if (Date.now() - start >= PASTE_FLUSH_BUDGET_MS) break;
+  }
+  if (!pasteJob) return;
+  if (pasteJob.offset >= pasteJob.total) {
+    finishPasteFrameSoon();
+    return;
+  }
+  schedulePasteChunkFlush(termWs.bufferedAmount >= PASTE_BUFFER_LIMIT ? PASTE_FLUSH_DELAY_MS : 0);
+}
+function normalizeTerminalPasteChunk(job, chunk, isFinal) {
+  if (job.pendingCR) {
+    chunk = "\r" + chunk;
+    job.pendingCR = false;
+  }
+  if (!isFinal && chunk.endsWith("\r")) {
+    chunk = chunk.slice(0, -1);
+    job.pendingCR = true;
+  }
+  return chunk.replace(/\r\n|\r/g, "\n");
+}
+function sendPasteChunkToTerminal(chunk) {
+  const bytes = inputEncoder.encode(chunk);
+  for (let i = 0; i < bytes.length; i += PASTE_BYTE_CHUNK_SIZE)
+    termWs.send(bytes.slice(i, i + PASTE_BYTE_CHUNK_SIZE));
 }
 function scheduleInputFlush() {
   if (inputFlushTimer) return;
@@ -661,10 +721,38 @@ function flushInputQueue() {
   else inputQueueMaxBufferedAmount = 65536;
 }
 function finishPasteFrameSoon() {
-  setTimeout(() => {
+  pasteJob = null;
+  updateTerminalPasteProgress(1, 1);
+  pasteProgressHideTimer = setTimeout(() => {
+    pasteProgressHideTimer = null;
     pasteFrameUntil = 0;
+    hideTerminalPasteProgress();
     scheduleTerminalLayoutFit();
   }, 250);
+}
+function showTerminalPasteProgress(total) {
+  if (pasteProgressHideTimer) {
+    clearTimeout(pasteProgressHideTimer);
+    pasteProgressHideTimer = null;
+  }
+  const progress = el("terminalPasteProgress");
+  if (progress) progress.hidden = false;
+  updateTerminalPasteProgress(0, total);
+}
+function updateTerminalPasteProgress(done, total) {
+  const pct = Math.max(0, Math.min(100, Math.round((Math.max(0, done) / Math.max(1, total)) * 100)));
+  const label = el("terminalPasteProgressLabel");
+  if (label) label.textContent = pct >= 100 ? "Paste sent" : "Pasting… " + pct + "%";
+  const bar = el("terminalPasteProgressBar");
+  if (bar) bar.style.width = pct + "%";
+}
+function hideTerminalPasteProgress() {
+  if (pasteProgressHideTimer) {
+    clearTimeout(pasteProgressHideTimer);
+    pasteProgressHideTimer = null;
+  }
+  const progress = el("terminalPasteProgress");
+  if (progress) progress.hidden = true;
 }
 function showClipboardMenu(x, y) {
   const menu = el("clipboardMenu");

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -59,6 +59,7 @@ function connectTerminal() {
     return;
   }
   fitTerminalShell();
+  if (shouldFitFocusedWebTerminal() || options.fitToBrowser) applyBrowserTerminalSize();
   const cols = state.termCols || 100,
     rows = state.termRows || 30,
     size = `${cols}x${rows}`;
@@ -212,6 +213,10 @@ function refreshTerminalAfterFontLoad(terminalKey) {
     .then(() => {
       if (!term || connectedTerminalId !== terminalKey) return;
       applyTerminalFont();
+      if ((shouldFitFocusedWebTerminal() || options.fitToBrowser) && applyBrowserTerminalSize()) {
+        connectTerminal();
+        return;
+      }
       fitTerminalSurface();
     })
     .catch(() => {});
@@ -503,6 +508,9 @@ function maybeAutoScrollToBottom() {
   if (terminalFollowPaused() || terminalScrollbackOffsetEstimate > 0) return;
   try { term.scrollToBottom(); } catch (e) {}
 }
+function followTerminalAfterWrite() {
+  requestAnimationFrame(maybeAutoScrollToBottom);
+}
 function writeTerminalFrame(data, onDone) {
   // For large frames (the initial attach repaint), use the write callback
   // to know when xterm.js finishes parsing. This avoids the caller
@@ -513,11 +521,11 @@ function writeTerminalFrame(data, onDone) {
     catch (e) { term.write(data); onDone(); return; }
   }
   try {
-    term.write(data);
+    term.write(data, followTerminalAfterWrite);
   } catch (e) {
     term.write(data);
+    followTerminalAfterWrite();
   }
-  maybeAutoScrollToBottom();
 }
 function scrollTerminalToBottom(focus = true) {
   sendBackendTail();
@@ -677,31 +685,62 @@ function fitTerminalSurface() {
     shell.scrollTop = 0;
     shell.scrollLeft = 0;
   }
-  const cell = HerdrTerminalFit.cellSize(term, terminal, { width: 9, height: 17 });
+  const cell = HerdrTerminalFit.cellSize(term, terminal, { width: 9, height: 20 });
   const cellWidth = cell.width;
   const rowHeight = cell.height;
   const width = Math.ceil(cellWidth * cols);
   const height = Math.ceil(rowHeight * rows);
+  const shellHeight = terminalShellInnerHeight(shell);
+  const visibleHeight = !options.overflow && shellHeight > 0
+    ? Math.min(height, shellHeight)
+    : height;
   if (options.overflow) {
     terminal.style.width = width + "px";
     terminal.style.height = height + "px";
+    terminal.style.maxHeight = "";
     terminal.style.minWidth = width + "px";
     terminal.style.minHeight = height + "px";
+    terminal.style.overflow = "";
   } else {
     terminal.style.width = "100%";
-    // Cap the terminal height to the shell's inner height so the last row
-    // is not scrolled off when the backend layout rows produce a surface
-    // taller than the shell. Use the shell client height minus the padding
-    // (8px top + 8px bottom = 16px) as the upper bound.
-    const shellHeight = shell ? Math.max(0, shell.clientHeight - 16) : 0;
-    if (shellHeight > 0 && height > shellHeight) {
-      terminal.style.height = shellHeight + "px";
-    } else {
-      terminal.style.height = "";
-    }
+    terminal.style.height = visibleHeight > 0 ? visibleHeight + "px" : "";
+    terminal.style.maxHeight = shellHeight > 0 ? shellHeight + "px" : "";
     terminal.style.minWidth = "0";
     terminal.style.minHeight = "0";
+    terminal.style.overflow = "hidden";
+    HerdrTerminalFit.fitXtermToContainer(terminal, { height: visibleHeight });
+    bindTerminalViewportFollow();
   }
+}
+function bindTerminalViewportFollow() {
+  const xtermElement = term && term.element;
+  const viewport = xtermElement && xtermElement.querySelector && xtermElement.querySelector(".xterm-viewport");
+  if (!viewport || typeof viewport.addEventListener !== "function" || terminalViewportScrollElement === viewport) return;
+  if (terminalViewportScrollElement && typeof terminalViewportScrollElement.removeEventListener === "function") {
+    terminalViewportScrollElement.removeEventListener("scroll", handleTerminalViewportScroll);
+  }
+  terminalViewportScrollElement = viewport;
+  viewport.addEventListener("scroll", handleTerminalViewportScroll, { passive: true });
+}
+function handleTerminalViewportScroll() {
+  setTerminalFollowPaused(!terminalAtBottom());
+}
+function cssPixels(value) {
+  const parsed = Number.parseFloat(value || "0");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+function terminalShellPadding(shell) {
+  if (!shell || typeof getComputedStyle !== "function") return { x: 16, y: 16 };
+  const style = getComputedStyle(shell);
+  return {
+    x: cssPixels(style.paddingLeft) + cssPixels(style.paddingRight),
+    y: cssPixels(style.paddingTop) + cssPixels(style.paddingBottom),
+  };
+}
+function terminalShellInnerHeight(shell) {
+  if (!shell) return 0;
+  const padding = terminalShellPadding(shell);
+  return Math.max(0, Math.floor(shell.clientHeight - padding.y));
 }
 function fitTerminalShell() {
   const shell = el("terminalShell");
@@ -726,16 +765,25 @@ function browserTerminalSize() {
   if (!shell) return null;
   const shellSize = fitTerminalShell();
   if (!shellSize) return null;
+  const padding = terminalShellPadding(shell);
   return HerdrTerminalFit.gridSize(shell, term, {
-    paddingX: 16,
-    paddingY: 16,
-    fallbackCell: { width: 9, height: 17 },
+    paddingX: padding.x,
+    paddingY: padding.y,
+    fallbackCell: { width: 9, height: 20 },
     minCols: 80,
     minRows: 24,
   });
 }
 function shouldFitFocusedWebTerminal() {
-  return !document.hidden && (!document.hasFocus || document.hasFocus());
+  return !document.hidden;
+}
+function applyBrowserTerminalSize() {
+  const fit = browserTerminalSize();
+  if (!fit) return false;
+  const changed = state.termCols !== fit.cols || state.termRows !== fit.rows;
+  state.termCols = fit.cols;
+  state.termRows = fit.rows;
+  return changed;
 }
 function shouldAutoFitDetachedTerminal() {
   if (options.fitToBrowser) return false;
@@ -753,9 +801,8 @@ function fitFocusedTerminal() {
   if (!state.terminalId || !shouldFitFocusedWebTerminal()) return;
   const fit = browserTerminalSize();
   if (!fit) return;
-  state.termCols = fit.cols;
-  state.termRows = fit.rows;
-  connectTerminal();
+  if (applyBrowserTerminalSize()) connectTerminal();
+  else fitTerminalSurface();
 }
 window.addEventListener("resize", () => {
   if (resizeFramePending) return;

--- a/src/assets/shared/terminal_fit.js
+++ b/src/assets/shared/terminal_fit.js
@@ -58,19 +58,44 @@
     };
   }
 
-  function fitXtermToContainer(container) {
+  function fitXtermToContainer(container, options) {
+    var opts = options || {};
     if (!container || !container.querySelector) return;
+    var height = Math.floor(opts.height || container.clientHeight || 0);
+    var heightPx = height > 0 ? height + "px" : "";
     var xterm = container.querySelector(".xterm");
     if (xterm) {
       xterm.style.width = "100%";
-      xterm.style.height = "100%";
+      xterm.style.height = heightPx || "100%";
+      xterm.style.maxHeight = heightPx || "";
       xterm.style.minWidth = "0";
       xterm.style.minHeight = "0";
+      xterm.style.overflow = "hidden";
     }
     var viewport = container.querySelector(".xterm-viewport");
     if (viewport) {
       viewport.style.left = "0";
       viewport.style.right = "0";
+      if (heightPx) {
+        viewport.style.height = heightPx;
+        viewport.style.maxHeight = heightPx;
+      }
+    }
+    if (!heightPx) return;
+    var screen = container.querySelector(".xterm-screen");
+    if (screen) {
+      screen.style.height = heightPx;
+      screen.style.maxHeight = heightPx;
+      screen.style.overflow = "hidden";
+    }
+    var helpers = container.querySelector(".xterm-helpers");
+    if (helpers) {
+      helpers.style.maxHeight = heightPx;
+      helpers.style.overflow = "hidden";
+    }
+    var canvasNodes = container.querySelectorAll && container.querySelectorAll(".xterm-screen canvas");
+    if (canvasNodes) {
+      for (var i = 0; i < canvasNodes.length; i++) canvasNodes[i].style.maxHeight = heightPx;
     }
   }
 

--- a/src/assets/terminal_frame.test.mjs
+++ b/src/assets/terminal_frame.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { createRequire } from "node:module";
 import vm from "node:vm";
+
+const require = createRequire(import.meta.url);
+const HerdrTerminalFit = require("./shared/terminal_fit.js");
 
 // Minimal mock for the desktop terminal frame pipeline. We only test the
 // enqueue / coalesce / flush logic, not xterm.js itself.
@@ -78,6 +82,89 @@ describe("desktop terminal frame coalescing", () => {
     assert.equal(writes.length, 1, "10 frames should produce 1 write");
     assert.ok(coalesced.includes("line 0"));
     assert.ok(coalesced.includes("line 9"));
+  });
+});
+
+describe("desktop terminal visible height fitting", () => {
+  function styleNode() {
+    return { style: {} };
+  }
+
+  it("caps xterm DOM nodes to the visible shell height", () => {
+    const xterm = styleNode();
+    const viewport = styleNode();
+    const screen = styleNode();
+    const helpers = styleNode();
+    const canvas = styleNode();
+    screen.style.height = "1580px";
+    const nodes = {
+      ".xterm": xterm,
+      ".xterm-viewport": viewport,
+      ".xterm-screen": screen,
+      ".xterm-helpers": helpers,
+    };
+    const container = {
+      clientHeight: 1064,
+      querySelector(selector) { return nodes[selector] || null; },
+      querySelectorAll(selector) { return selector === ".xterm-screen canvas" ? [canvas] : []; },
+    };
+
+    HerdrTerminalFit.fitXtermToContainer(container, { height: 1064 });
+
+    for (const node of [xterm, viewport, screen]) {
+      assert.equal(node.style.height, "1064px");
+      assert.equal(node.style.maxHeight, "1064px");
+    }
+    assert.equal(screen.style.overflow, "hidden");
+    assert.equal(helpers.style.maxHeight, "1064px");
+    assert.equal(canvas.style.maxHeight, "1064px");
+  });
+
+  it("uses 20px fallback cell height so a 1080px shell fits 53 rows, not 62", () => {
+    const shell = {
+      clientWidth: 1141,
+      clientHeight: 1080,
+      getClientRects() { return [{}]; },
+      getBoundingClientRect() { return { width: 1141, height: 1080 }; },
+      querySelector() { return null; },
+    };
+
+    const size = HerdrTerminalFit.gridSize(shell, null, {
+      paddingX: 16,
+      paddingY: 16,
+      fallbackCell: { width: 9, height: 20 },
+      minCols: 80,
+      minRows: 24,
+    });
+
+    assert.equal(size.rows, 53);
+    assert.equal(size.rows * size.cell.height, 1060);
+    assert.ok(size.rows * size.cell.height <= shell.clientHeight - 16);
+  });
+
+  it("auto-scrolls after xterm write callback only when follow is active", () => {
+    let scrolled = 0;
+    let paused = false;
+    const callbacks = [];
+    const term = {
+      write(_data, cb) { if (cb) callbacks.push(cb); },
+      scrollToBottom() { scrolled += 1; },
+    };
+    const maybeAutoScrollToBottom = () => {
+      if (paused) return;
+      term.scrollToBottom();
+    };
+    const followTerminalAfterWrite = () => maybeAutoScrollToBottom();
+
+    term.write("new data", followTerminalAfterWrite);
+    assert.equal(scrolled, 0, "scroll waits for xterm parse callback");
+    callbacks.shift()();
+    assert.equal(scrolled, 1, "follow active scrolls after write");
+
+    paused = true;
+    term.write("more data", followTerminalAfterWrite);
+    callbacks.shift()();
+    assert.equal(scrolled, 1, "paused follow preserves user scrollback");
   });
 });
 

--- a/src/assets/terminal_frame.test.mjs
+++ b/src/assets/terminal_frame.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
 import vm from "node:vm";
 
 const require = createRequire(import.meta.url);
@@ -165,6 +166,39 @@ describe("desktop terminal visible height fitting", () => {
     term.write("more data", followTerminalAfterWrite);
     callbacks.shift()();
     assert.equal(scrolled, 1, "paused follow preserves user scrollback");
+  });
+});
+
+describe("desktop terminal paste streaming", () => {
+  function loadDesktopTerminalContext() {
+    const source = readFileSync(new URL("./desktop/app_js/terminal.js", import.meta.url), "utf8");
+    const ctx = {
+      console,
+      TextEncoder,
+      clearTimeout() {},
+      setTimeout() { return 1; },
+      requestAnimationFrame() {},
+      document: { hidden: false },
+      window: { addEventListener() {} },
+      state: {},
+      options: {},
+      terminal: null,
+    };
+    vm.createContext(ctx);
+    vm.runInContext(source, ctx);
+    return ctx;
+  }
+
+  it("normalizes CRLF across async paste chunk boundaries", () => {
+    const ctx = loadDesktopTerminalContext();
+    const job = { pendingCR: false };
+
+    const first = ctx.normalizeTerminalPasteChunk(job, "hello\r", false);
+    const second = ctx.normalizeTerminalPasteChunk(job, "\nworld\rnext", true);
+
+    assert.equal(first, "hello");
+    assert.equal(second, "\nworld\nnext");
+    assert.equal(job.pendingCR, false);
   });
 });
 


### PR DESCRIPTION
## Summary
- cap xterm DOM nodes to the visible terminal shell height
- fit terminal rows using the actual 20px fallback line height
- keep following latest output unless the user scrolls up, including scrollbar drag

## Validation
- node --test src/assets/*.test.mjs
- cargo test