### PR TITLE
Fix temporary terminal focus and minimize

### DIFF
--- a/src/assets/app.html
+++ b/src/assets/app.html
@@ -122,6 +122,7 @@
           <h2 id="tempTerminalTitle">Temporary terminal</h2>
           <div class="temp-terminal-head-actions">
             <span class="temp-terminal-hint">Input captured · Ctrl+G detaches</span>
+            <button class="temp-terminal-minimize" id="tempTerminalMinimize" title="Minimize temporary terminal" aria-label="Minimize temporary terminal">−</button>
             <button class="temp-terminal-close" id="tempTerminalClose" title="Detach temporary terminal" aria-label="Detach temporary terminal">✕</button>
           </div>
         </div>

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -636,7 +636,10 @@ describe("app bundle load", () => {
     const modalCss = readFileSync(new URL("./desktop/app_css/modals.css", import.meta.url), "utf8");
 
     match(tempTerminalSource, /document\.addEventListener\("keydown", tempTerminalKeydown, true\)/);
-    match(tempTerminalSource, /if \(tempTerminalOwnsEventTarget\(event\.target\)\) return;/);
+    match(tempTerminalSource, /if \(tempTerminalOwnsEventTarget\(event\.target\)\) \{/);
+    match(tempTerminalSource, /terminalFocusRetainingInputForKey\(event\)/);
+    match(tempTerminalSource, /if \(event\.key === "Backspace"\) return "\\x7f";/);
+    match(tempTerminalSource, /if \(event\.key === "Tab"\) return event\.shiftKey \? "\\x1b\[Z" : "\\t";/);
     match(tempTerminalSource, /term\.element \|\| \(el\(containerId\) && el\(containerId\)\.querySelector/);
     match(tempTerminalSource, /case "Backspace": return "\\x7f";/);
     match(tempTerminalSource, /case "Tab": return event\.shiftKey \? "\\x1b\[Z" : "\\t";/);
@@ -666,8 +669,10 @@ describe("app bundle load", () => {
     match(modalCss, /\.temp-terminal-body \{[\s\S]*?min-height: 0;[\s\S]*?overflow: hidden;/);
     match(modalCss, /\.temp-terminal-body \.xterm \{[\s\S]*?height: 100%;[\s\S]*?width: 100%;/);
     match(html, /Input captured · Ctrl\+G detaches/);
+    match(html, /aria-label="Minimize temporary terminal"/);
     match(html, /aria-label="Detach temporary terminal"/);
     match(modalCss, /\.temp-terminal-hint/);
+    match(modalCss, /\.temp-terminal-restore \{[\s\S]*?position: fixed;[\s\S]*?right: calc\(env\(safe-area-inset-right, 0px\) \+ 18px\);/);
     match(source, /Ctrl\+G<\/kbd><span>Detach temporary terminal/);
     match(source, /Temporary terminal captures Tab\/Backspace and normal input while open/);
   });

--- a/src/assets/desktop/app_css/modals.css
+++ b/src/assets/desktop/app_css/modals.css
@@ -190,6 +190,7 @@
   color: var(--muted);
   font-size: 12px;
 }
+.temp-terminal-minimize,
 .temp-terminal-close {
   background: transparent;
   border: 0;
@@ -199,9 +200,37 @@
   padding: 4px 8px;
   border-radius: 6px;
 }
+.temp-terminal-minimize:hover,
 .temp-terminal-close:hover {
   background: var(--border);
   color: var(--fg);
+}
+.temp-terminal-restore {
+  align-items: center;
+  background: var(--panel);
+  border: 1px solid var(--border2);
+  border-radius: 999px;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 18px);
+  box-shadow: 0 10px 28px #0008;
+  color: var(--fg);
+  cursor: pointer;
+  display: none;
+  gap: 8px;
+  padding: 8px 12px;
+  position: fixed;
+  right: calc(env(safe-area-inset-right, 0px) + 18px);
+  z-index: 1199;
+}
+.temp-terminal-restore:hover {
+  background: var(--border);
+}
+.temp-terminal-restore-icon {
+  font-size: 15px;
+  line-height: 1;
+}
+.temp-terminal-restore-label {
+  font-size: 12px;
+  font-weight: 600;
 }
 .temp-terminal-body {
   flex: 1;

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -948,6 +948,7 @@ body.mobile-keyboard-open .mobile-screen.terminal-active .mobile-tabs {
   color: var(--muted, #a6adc8);
   font-size: 12px;
 }
+.temp-terminal-minimize,
 .temp-terminal-close {
   background: transparent;
   border: 0;
@@ -957,9 +958,37 @@ body.mobile-keyboard-open .mobile-screen.terminal-active .mobile-tabs {
   padding: 4px 8px;
   border-radius: 6px;
 }
+.temp-terminal-minimize:hover,
 .temp-terminal-close:hover {
   background: var(--border, #313244);
   color: var(--fg, #cdd6f4);
+}
+.temp-terminal-restore {
+  align-items: center;
+  background: var(--panel, #1e1e2e);
+  border: 1px solid var(--border2, #45475a);
+  border-radius: 999px;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 18px);
+  box-shadow: 0 10px 28px #0008;
+  color: var(--fg, #cdd6f4);
+  cursor: pointer;
+  display: none;
+  gap: 8px;
+  padding: 8px 12px;
+  position: fixed;
+  right: calc(env(safe-area-inset-right, 0px) + 18px);
+  z-index: 1199;
+}
+.temp-terminal-restore:hover {
+  background: var(--border, #313244);
+}
+.temp-terminal-restore-icon {
+  font-size: 15px;
+  line-height: 1;
+}
+.temp-terminal-restore-label {
+  font-size: 12px;
+  font-weight: 600;
 }
 .temp-terminal-body {
   flex: 1;

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -322,6 +322,7 @@
             <h2 id="tempTerminalTitle">Temporary terminal</h2>
             <div class="temp-terminal-head-actions">
               <span class="temp-terminal-hint">Input captured · Ctrl+G detaches</span>
+              <button class="temp-terminal-minimize" id="tempTerminalMinimize" title="Minimize temporary terminal" aria-label="Minimize temporary terminal">−</button>
               <button class="temp-terminal-close" id="tempTerminalClose" title="Detach temporary terminal" aria-label="Detach temporary terminal">✕</button>
             </div>
           </div>

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -316,8 +316,10 @@ describe("mobile bundle load", () => {
     const mobileCss = readFileSync(new URL("./mobile/app.css", import.meta.url), "utf8");
 
     match(mobileSource, /Input captured · Ctrl\+G detaches/);
+    match(mobileSource, /aria-label="Minimize temporary terminal"/);
     match(mobileSource, /aria-label="Detach temporary terminal"/);
     match(mobileCss, /\.temp-terminal-hint/);
+    match(mobileCss, /\.temp-terminal-restore \{[\s\S]*?position: fixed;[\s\S]*?right: calc\(env\(safe-area-inset-right, 0px\) \+ 18px\);/);
     match(mobileCss, /height: min\(80vh, calc\(var\(--herdr-mobile-viewport-height\) - 24px\)\)/);
     match(mobileCss, /\.temp-terminal-body \{[\s\S]*?min-height: 0;[\s\S]*?overflow: hidden;/);
   });

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -37,16 +37,27 @@
     var linkProvider = null;
     var confirmVisible = false;
     var keyTrapBound = false;
+    var isMinimized = false;
+    var restoreButton = null;
 
     function open() {
-      if (isOpen) return;
+      if (isOpen) {
+        if (isMinimized) restore();
+        return;
+      }
       if (!state.ws && !defaultFolderFn()) return;
       isOpen = true;
       closing = false;
+      isMinimized = false;
+      hideRestoreControl();
       var modal = el(modalId);
-      if (modal) modal.style.display = "grid";
+      if (modal) {
+        modal.style.display = "grid";
+        modal.removeAttribute && modal.removeAttribute("aria-hidden");
+      }
       var container = el(containerId);
       if (container) container.innerHTML = "";
+      installMinimizeControl();
       installInputTrap();
       createTerminalSession();
     }
@@ -60,12 +71,17 @@
       if (!isOpen) return;
       hideCloseConfirm();
       isOpen = false;
+      isMinimized = false;
       closing = true;
       removeInputTrap();
+      hideRestoreControl();
       disconnectWs();
       disposeTerm();
       var modal = el(modalId);
-      if (modal) modal.style.display = "none";
+      if (modal) {
+        modal.style.display = "none";
+        modal.setAttribute && modal.setAttribute("aria-hidden", "true");
+      }
       closeTab();
       createdTabId = null;
       createdPaneId = null;
@@ -148,7 +164,7 @@
     }
 
     function tempTerminalKeydown(event) {
-      if (!isOpen || confirmVisible) return;
+      if (!isOpen || isMinimized || confirmVisible) return;
       if (event.ctrlKey && !event.altKey && !event.metaKey && String(event.key || "").toLowerCase() === "g") {
         event.preventDefault();
         event.stopImmediatePropagation();
@@ -156,7 +172,15 @@
         return;
       }
       if (isCloseControl(event.target)) return;
-      if (tempTerminalOwnsEventTarget(event.target)) return;
+      if (tempTerminalOwnsEventTarget(event.target)) {
+        var ownedInput = terminalFocusRetainingInputForKey(event);
+        if (ownedInput == null) return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        focusTerminalSoon();
+        sendInput(ownedInput);
+        return;
+      }
       var input = terminalInputForKey(event);
       if (input == null) return;
       event.preventDefault();
@@ -166,7 +190,7 @@
     }
 
     function isCloseControl(target) {
-      return !!(target && target.closest && target.closest(".temp-terminal-close, .temp-terminal-confirm"));
+      return !!(target && target.closest && target.closest(".temp-terminal-close, .temp-terminal-minimize, .temp-terminal-restore, .temp-terminal-confirm"));
     }
 
     function tempTerminalOwnsEventTarget(target) {
@@ -182,9 +206,16 @@
 
     function focusTerminalSoon() {
       setTimeout(function () {
-        if (!isOpen || confirmVisible || !term) return;
+        if (!isOpen || isMinimized || confirmVisible || !term) return;
         try { term.focus(); } catch (e) {}
       }, 0);
+    }
+
+    function terminalFocusRetainingInputForKey(event) {
+      if (event.metaKey || event.altKey || event.ctrlKey) return null;
+      if (event.key === "Backspace") return "\x7f";
+      if (event.key === "Tab") return event.shiftKey ? "\x1b[Z" : "\t";
+      return null;
     }
 
     function terminalInputForKey(event) {
@@ -369,9 +400,80 @@
       var fonts = globalThis.document && globalThis.document.fonts;
       if (!fonts || !fonts.ready) return;
       fonts.ready.then(function () {
-        if (!isOpen || !term) return;
+        if (!isOpen || isMinimized || !term) return;
         handleResize();
       }).catch(function () {});
+    }
+
+    function installMinimizeControl() {
+      var modal = el(modalId);
+      var button = modal && modal.querySelector && modal.querySelector(".temp-terminal-minimize");
+      if (button && !button.__herdrTempTerminalMinimizeBound) {
+        button.__herdrTempTerminalMinimizeBound = true;
+        button.onclick = minimize;
+      }
+      ensureRestoreControl();
+    }
+
+    function ensureRestoreControl() {
+      if (restoreButton) return restoreButton;
+      var doc = globalThis.document;
+      if (!doc || !doc.createElement || !doc.body) return null;
+      restoreButton = doc.createElement("button");
+      restoreButton.type = "button";
+      restoreButton.className = "temp-terminal-restore";
+      restoreButton.title = "Show temporary terminal";
+      restoreButton.setAttribute("aria-label", "Show temporary terminal");
+      restoreButton.innerHTML = '<span class="temp-terminal-restore-icon" aria-hidden="true">▣</span><span class="temp-terminal-restore-label">Terminal</span>';
+      restoreButton.onclick = restore;
+      restoreButton.style.display = "none";
+      doc.body.appendChild(restoreButton);
+      return restoreButton;
+    }
+
+    function showRestoreControl() {
+      var button = ensureRestoreControl();
+      if (button) button.style.display = "inline-flex";
+    }
+
+    function hideRestoreControl() {
+      if (restoreButton) restoreButton.style.display = "none";
+    }
+
+    function blurTerminalFocus() {
+      var doc = globalThis.document;
+      var active = doc && doc.activeElement;
+      if (!active || !tempTerminalOwnsEventTarget(active) || !active.blur) return;
+      try { active.blur(); } catch (e) {}
+    }
+
+    function minimize() {
+      if (!isOpen || isMinimized || confirmVisible) return;
+      isMinimized = true;
+      removeInputTrap();
+      blurTerminalFocus();
+      var modal = el(modalId);
+      if (modal) {
+        modal.style.display = "none";
+        modal.setAttribute && modal.setAttribute("aria-hidden", "true");
+      }
+      showRestoreControl();
+    }
+
+    function restore() {
+      if (!isOpen) return;
+      isMinimized = false;
+      hideRestoreControl();
+      var modal = el(modalId);
+      if (modal) {
+        modal.style.display = "grid";
+        modal.removeAttribute && modal.removeAttribute("aria-hidden");
+      }
+      installInputTrap();
+      HerdrTerminalFit.afterLayout(function () {
+        handleResize();
+        focusTerminalSoon();
+      });
     }
 
     function disconnectWs() {
@@ -470,18 +572,18 @@
       try { term.write(data); } catch (e) { try { term.write(data); } catch (e2) {} }
     }
 
-    function isVisible() { return isOpen; }
+    function isVisible() { return isOpen && !isMinimized; }
 
     function handlePaneExited(paneId) {
       if (isOpen && paneId && createdPaneId === paneId) close();
     }
 
     function handleResize() {
-      if (!isOpen || !term) return;
+      if (!isOpen || isMinimized || !term) return;
       if (resizeTimer) clearTimeout(resizeTimer);
       resizeTimer = setTimeout(function () {
         resizeTimer = null;
-        if (!isOpen || !term) return;
+        if (!isOpen || isMinimized || !term) return;
         var container = el(containerId);
         if (!container) return;
         var size = terminalGridSize(container);
@@ -504,7 +606,7 @@
       HerdrTerminalFit.fitXtermToContainer(container);
     }
 
-    return { open: open, requestClose: requestClose, close: close, isVisible: isVisible, handleResize: handleResize, handlePaneExited: handlePaneExited };
+    return { open: open, requestClose: requestClose, close: close, minimize: minimize, restore: restore, isVisible: isVisible, handleResize: handleResize, handlePaneExited: handlePaneExited };
   }
 
   globalThis.HerdrTempTerminal = { create: createTempTerminal };

--- a/src/assets/temp_terminal.test.mjs
+++ b/src/assets/temp_terminal.test.mjs
@@ -50,6 +50,7 @@ function context() {
   const listeners = new Map();
   const createdButtons = [];
   const timeouts = [];
+  const apiCalls = [];
 
   const getElement = (id) => {
     if (!elements.has(id)) elements.set(id, makeElement(id));
@@ -145,6 +146,7 @@ function context() {
       },
     },
     api(url) {
+      apiCalls.push(url);
       if (url === "/api/tabs") return Promise.resolve({ result: { tab: { tab_id: "tab-1" } } });
       if (url.startsWith("/api/panes")) return Promise.resolve({ result: { panes: [{ tab_id: "tab-1", pane_id: "pane-1", terminal_id: "term-1" }] } });
       return Promise.resolve({ result: {} });
@@ -152,6 +154,7 @@ function context() {
     sentFrames,
     listeners,
     createdButtons,
+    apiCalls,
     elements,
     console,
   };
@@ -196,6 +199,12 @@ function keyEvent(key, target, extra = {}) {
   };
 }
 
+function terminalInputFrames(ctx) {
+  return ctx.sentFrames
+    .filter((frame) => frame instanceof Uint8Array)
+    .map((frame) => Buffer.from(frame).toString("utf8"));
+}
+
 describe("temporary terminal", () => {
   it("captures Tab and Backspace inside xterm before the browser moves focus", async () => {
     const ctx = context();
@@ -208,15 +217,30 @@ describe("temporary terminal", () => {
     listener(tab);
     equal(tab.defaultPrevented, true);
     equal(tab.immediateStopped, true);
-    let inputFrames = ctx.sentFrames.filter((frame) => frame instanceof Uint8Array);
-    equal(Buffer.from(inputFrames[0]).toString("utf8"), "\t");
+    let inputFrames = terminalInputFrames(ctx);
+    equal(inputFrames[0], "\t");
 
     const backspace = keyEvent("Backspace", target);
     listener(backspace);
     equal(backspace.defaultPrevented, true);
     equal(backspace.immediateStopped, true);
-    inputFrames = ctx.sentFrames.filter((frame) => frame instanceof Uint8Array);
-    equal(Buffer.from(inputFrames[1]).toString("utf8"), "\x7f");
+    inputFrames = terminalInputFrames(ctx);
+    equal(inputFrames[1], "\x7f");
+  });
+
+  it("lets xterm handle ordinary keys from inside the terminal without duplicate input", async () => {
+    const ctx = context();
+    await openTempTerminal(ctx);
+    const listener = ctx.listeners.get("keydown");
+    ok(listener);
+    const before = terminalInputFrames(ctx).length;
+
+    const enter = keyEvent("Enter", { insideTerm: true });
+    listener(enter);
+
+    equal(enter.defaultPrevented, false);
+    equal(enter.immediateStopped, false);
+    equal(terminalInputFrames(ctx).length, before);
   });
 
   it("minimizes to a corner restore control and restores the same live terminal", async () => {
@@ -239,6 +263,27 @@ describe("temporary terminal", () => {
     equal(modal.style.display, "grid");
     equal(modal.attributes["aria-hidden"], undefined);
     equal(restoreButton.style.display, "none");
+    ok(ctx.listeners.get("keydown"));
+  });
+
+  it("open restores a minimized terminal without creating another tab session", async () => {
+    const ctx = context();
+    const tempTerminal = await openTempTerminal(ctx);
+    const tabCreatesBefore = ctx.apiCalls.filter((url) => url === "/api/tabs").length;
+    const firstTerminal = ctx.lastTerminal;
+    const listener = ctx.listeners.get("keydown");
+    ok(listener);
+
+    tempTerminal.minimize();
+    const beforeInput = terminalInputFrames(ctx).length;
+    listener(keyEvent("a", ctx.document.body));
+    equal(terminalInputFrames(ctx).length, beforeInput);
+
+    tempTerminal.open();
+
+    equal(tempTerminal.isVisible(), true);
+    equal(ctx.lastTerminal, firstTerminal);
+    equal(ctx.apiCalls.filter((url) => url === "/api/tabs").length, tabCreatesBefore);
     ok(ctx.listeners.get("keydown"));
   });
 });

--- a/src/assets/temp_terminal.test.mjs
+++ b/src/assets/temp_terminal.test.mjs
@@ -1,0 +1,244 @@
+import { describe, it } from "node:test";
+import { equal, ok } from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+function makeElement(id = "") {
+  return {
+    id,
+    children: [],
+    containsTarget: null,
+    innerHTML: "",
+    onclick: null,
+    style: {},
+    attributes: {},
+    className: "",
+    title: "",
+    type: "",
+    __herdrTempTerminalMinimizeBound: false,
+    addEventListener() {},
+    removeEventListener() {},
+    appendChild(child) {
+      this.children.push(child);
+    },
+    blur() {
+      this.blurred = true;
+    },
+    contains(target) {
+      return target === this || target === this.containsTarget || !!(target && target.insideTerm);
+    },
+    getBoundingClientRect() {
+      return { width: 800, height: 420 };
+    },
+    querySelector(selector) {
+      if (selector === ".temp-terminal-minimize") return this.minimizeButton || null;
+      if (selector === ".xterm") return this.xtermElement || null;
+      return null;
+    },
+    removeAttribute(name) {
+      delete this.attributes[name];
+    },
+    setAttribute(name, value) {
+      this.attributes[name] = String(value);
+    },
+  };
+}
+
+function context() {
+  const elements = new Map();
+  const sentFrames = [];
+  const listeners = new Map();
+  const createdButtons = [];
+  const timeouts = [];
+
+  const getElement = (id) => {
+    if (!elements.has(id)) elements.set(id, makeElement(id));
+    return elements.get(id);
+  };
+
+  const modal = getElement("tempTerminalModal");
+  modal.minimizeButton = makeElement("tempTerminalMinimize");
+  const container = getElement("tempTerminal");
+
+  class FakeTerminal {
+    constructor() {
+      this.element = makeElement("xterm");
+      this.element.containsTarget = { insideTerm: true };
+      this.focusCount = 0;
+      this.resizeCalls = [];
+      context.lastTerminal = this;
+    }
+    focus() {
+      this.focusCount += 1;
+    }
+    onData(fn) {
+      this.onDataHandler = fn;
+    }
+    open(target) {
+      target.xtermElement = this.element;
+    }
+    resize(cols, rows) {
+      this.resizeCalls.push([cols, rows]);
+    }
+    write() {}
+    dispose() {
+      this.disposed = true;
+    }
+  }
+
+  class FakeWebSocket {
+    constructor() {
+      this.readyState = 1;
+      this.bufferedAmount = 0;
+      context.lastWebSocket = this;
+    }
+    send(data) {
+      sentFrames.push(data);
+    }
+    close() {
+      this.readyState = 3;
+    }
+  }
+
+  const ctx = {
+    TextEncoder,
+    Terminal: FakeTerminal,
+    WebSocket: FakeWebSocket,
+    clearTimeout() {},
+    setTimeout(fn) {
+      timeouts.push(fn);
+      fn();
+      return timeouts.length;
+    },
+    requestAnimationFrame(fn) {
+      fn();
+    },
+    document: {
+      activeElement: null,
+      body: makeElement("body"),
+      createElement(tag) {
+        const child = makeElement(tag);
+        createdButtons.push(child);
+        return child;
+      },
+      addEventListener(type, fn) {
+        listeners.set(type, fn);
+      },
+      removeEventListener(type, fn) {
+        if (listeners.get(type) === fn) listeners.delete(type);
+      },
+      getElementById: getElement,
+    },
+    HerdrTerminalFit: {
+      afterLayout(fn) {
+        fn();
+      },
+      cellSize() {
+        return { width: 9, height: 20 };
+      },
+      fitXtermToContainer() {},
+      gridSize() {
+        return { cols: 88, rows: 22 };
+      },
+      visibleBox() {
+        return { width: 800, height: 420 };
+      },
+    },
+    api(url) {
+      if (url === "/api/tabs") return Promise.resolve({ result: { tab: { tab_id: "tab-1" } } });
+      if (url.startsWith("/api/panes")) return Promise.resolve({ result: { panes: [{ tab_id: "tab-1", pane_id: "pane-1", terminal_id: "term-1" }] } });
+      return Promise.resolve({ result: {} });
+    },
+    sentFrames,
+    listeners,
+    createdButtons,
+    elements,
+    console,
+  };
+  ctx.globalThis = ctx;
+  ctx.window = ctx;
+  return vm.createContext(ctx);
+}
+
+async function openTempTerminal(ctx) {
+  vm.runInContext(readFileSync(new URL("./shared/temp_terminal.js", import.meta.url), "utf8"), ctx);
+  const tempTerminal = ctx.HerdrTempTerminal.create({
+    el: ctx.document.getElementById,
+    state: { ws: "ws-1" },
+    wsUrl: (path) => path,
+    api: ctx.api,
+    modalId: "tempTerminalModal",
+    containerId: "tempTerminal",
+    defaultFolderFn: () => "",
+  });
+  tempTerminal.open();
+  for (let i = 0; i < 8; i += 1) await Promise.resolve();
+  return tempTerminal;
+}
+
+function keyEvent(key, target, extra = {}) {
+  return {
+    key,
+    target,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    defaultPrevented: false,
+    immediateStopped: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    stopImmediatePropagation() {
+      this.immediateStopped = true;
+    },
+    ...extra,
+  };
+}
+
+describe("temporary terminal", () => {
+  it("captures Tab and Backspace inside xterm before the browser moves focus", async () => {
+    const ctx = context();
+    await openTempTerminal(ctx);
+    const listener = ctx.listeners.get("keydown");
+    ok(listener);
+    const target = { insideTerm: true };
+
+    const tab = keyEvent("Tab", target);
+    listener(tab);
+    equal(tab.defaultPrevented, true);
+    equal(tab.immediateStopped, true);
+    let inputFrames = ctx.sentFrames.filter((frame) => frame instanceof Uint8Array);
+    equal(Buffer.from(inputFrames[0]).toString("utf8"), "\t");
+
+    const backspace = keyEvent("Backspace", target);
+    listener(backspace);
+    equal(backspace.defaultPrevented, true);
+    equal(backspace.immediateStopped, true);
+    inputFrames = ctx.sentFrames.filter((frame) => frame instanceof Uint8Array);
+    equal(Buffer.from(inputFrames[1]).toString("utf8"), "\x7f");
+  });
+
+  it("minimizes to a corner restore control and restores the same live terminal", async () => {
+    const ctx = context();
+    const tempTerminal = await openTempTerminal(ctx);
+    const modal = ctx.elements.get("tempTerminalModal");
+    const restoreButton = ctx.createdButtons.find((button) => button.className === "temp-terminal-restore");
+    ok(restoreButton);
+    equal(tempTerminal.isVisible(), true);
+
+    tempTerminal.minimize();
+    equal(tempTerminal.isVisible(), false);
+    equal(modal.style.display, "none");
+    equal(modal.attributes["aria-hidden"], "true");
+    equal(restoreButton.style.display, "inline-flex");
+    equal(ctx.listeners.has("keydown"), false);
+
+    restoreButton.onclick();
+    equal(tempTerminal.isVisible(), true);
+    equal(modal.style.display, "grid");
+    equal(modal.attributes["aria-hidden"], undefined);
+    equal(restoreButton.style.display, "none");
+    ok(ctx.listeners.get("keydown"));
+  });
+});


### PR DESCRIPTION
## Summary
- keep temporary terminal focus stable for Tab/Backspace by intercepting those xterm-owned keys
- add minimize-to-corner and restore behavior without dropping the live terminal session
- extend regression coverage for key handling, duplicate-input prevention, and restore without a new tab

## Validation
- node --test src/assets/temp_terminal.test.mjs src/assets/app_load.test.mjs src/assets/mobile_load.test.mjs
- node --test src/assets/*.test.mjs
- cargo test