### PR TITLE
Show temporary terminal shortcuts in tooltips

### DIFF
--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -244,6 +244,7 @@ describe("app bundle load", () => {
     equal(ctx.document.getElementById("settingsToggle").title, "Settings (Ctrl+Q then S)");
     equal(ctx.document.getElementById("headerActionsButton").title, "Search and actions (Ctrl+Q then /)");
     equal(ctx.document.getElementById("sidebarToggle").title, "Hide sidebar (Ctrl+Q then B)");
+    equal(ctx.document.getElementById("tempTerminalMinimize").title, "Minimize temporary terminal (Ctrl+Q then Shift+M)");
 
     vm.runInContext(`
       state.ws = "w1";
@@ -701,6 +702,11 @@ describe("app bundle load", () => {
     match(tempTerminalSource, /document\.addEventListener\("keydown", tempTerminalKeydown, true\)/);
     match(tempTerminalSource, /if \(tempTerminalOwnsEventTarget\(event\.target\)\) \{/);
     match(tempTerminalSource, /terminalFocusRetainingInputForKey\(event\)/);
+    match(tempTerminalSource, /shortcutLabelFn/);
+    match(tempTerminalSource, /setShortcutTitle\(button, "Minimize temporary terminal"\)/);
+    match(tempTerminalSource, /setShortcutTitle\(button, "Show temporary terminal"\)/);
+    match(shortcutsSource, /tempTerminalToggle/);
+    match(readFileSync(new URL("./desktop/app_js/bindings.js", import.meta.url), "utf8"), /shortcutLabelFn: \(\) => shortcutLabel\("webuiShortcuts", "tempTerminalToggle"\)/);
     match(tempTerminalSource, /if \(event\.key === "Backspace"\) return "\\x7f";/);
     match(tempTerminalSource, /if \(event\.key === "Tab"\) return event\.shiftKey \? "\\x1b\[Z" : "\\t";/);
     match(tempTerminalSource, /term\.element \|\| \(el\(containerId\) && el\(containerId\)\.querySelector/);

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -639,6 +639,7 @@ if (globalThis.HerdrTempTerminal && el("tempTerminalModal")) {
     fontFamilyFn: terminalFontFamily,
     themeFn: terminalTheme,
     defaultFolderFn: defaultFolderPath,
+    shortcutLabelFn: () => shortcutLabel("webuiShortcuts", "tempTerminalToggle"),
   });
   const tempTerminalClose = el("tempTerminalClose");
   const tempTerminalModal = el("tempTerminalModal");

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -710,6 +710,13 @@ function syncShortcutTooltips() {
     tempClose.title = "Detach temporary terminal (Ctrl+G)";
     tempClose.setAttribute("aria-label", tempClose.title);
   }
+  setShortcutTooltip("tempTerminalMinimize", "Minimize temporary terminal", "tempTerminalToggle");
+  const tempRestore = document.querySelector && document.querySelector(".temp-terminal-restore");
+  if (tempRestore) {
+    const text = titleWithWebuiShortcut("Show temporary terminal", "tempTerminalToggle");
+    tempRestore.title = text;
+    tempRestore.setAttribute("aria-label", text);
+  }
 }
 
 function shortcutCollisionMap() {

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -21,6 +21,7 @@
     var fontFamilyFn = opts.fontFamilyFn || function () { return "monospace"; };
     var themeFn = opts.themeFn || function () { return {}; };
     var defaultFolderFn = opts.defaultFolderFn || function () { return ""; };
+    var shortcutLabelFn = opts.shortcutLabelFn || function () { return ""; };
 
     var term = null;
     var termWs = null;
@@ -408,11 +409,25 @@
     function installMinimizeControl() {
       var modal = el(modalId);
       var button = modal && modal.querySelector && modal.querySelector(".temp-terminal-minimize");
+      setShortcutTitle(button, "Minimize temporary terminal");
       if (button && !button.__herdrTempTerminalMinimizeBound) {
         button.__herdrTempTerminalMinimizeBound = true;
         button.onclick = minimize;
       }
       ensureRestoreControl();
+    }
+
+    function shortcutTitle(action) {
+      var label = "";
+      try { label = shortcutLabelFn() || ""; } catch (e) {}
+      return label ? action + " (" + label + ")" : action;
+    }
+
+    function setShortcutTitle(node, action) {
+      if (!node) return;
+      var title = shortcutTitle(action);
+      node.title = title;
+      node.setAttribute && node.setAttribute("aria-label", title);
     }
 
     function ensureRestoreControl() {
@@ -422,8 +437,7 @@
       restoreButton = doc.createElement("button");
       restoreButton.type = "button";
       restoreButton.className = "temp-terminal-restore";
-      restoreButton.title = "Show temporary terminal";
-      restoreButton.setAttribute("aria-label", "Show temporary terminal");
+      setShortcutTitle(restoreButton, "Show temporary terminal");
       restoreButton.innerHTML = '<span class="temp-terminal-restore-icon" aria-hidden="true">▣</span><span class="temp-terminal-restore-label">Terminal</span>';
       restoreButton.onclick = restore;
       restoreButton.style.display = "none";
@@ -433,7 +447,10 @@
 
     function showRestoreControl() {
       var button = ensureRestoreControl();
-      if (button) button.style.display = "inline-flex";
+      if (button) {
+        setShortcutTitle(button, "Show temporary terminal");
+        button.style.display = "inline-flex";
+      }
     }
 
     function hideRestoreControl() {

--- a/src/assets/temp_terminal.test.mjs
+++ b/src/assets/temp_terminal.test.mjs
@@ -163,7 +163,7 @@ function context() {
   return vm.createContext(ctx);
 }
 
-async function openTempTerminal(ctx) {
+async function openTempTerminal(ctx, options = {}) {
   vm.runInContext(readFileSync(new URL("./shared/temp_terminal.js", import.meta.url), "utf8"), ctx);
   const tempTerminal = ctx.HerdrTempTerminal.create({
     el: ctx.document.getElementById,
@@ -173,6 +173,7 @@ async function openTempTerminal(ctx) {
     modalId: "tempTerminalModal",
     containerId: "tempTerminal",
     defaultFolderFn: () => "",
+    ...options,
   });
   tempTerminal.open();
   for (let i = 0; i < 8; i += 1) await Promise.resolve();
@@ -245,17 +246,20 @@ describe("temporary terminal", () => {
 
   it("minimizes to a corner restore control and restores the same live terminal", async () => {
     const ctx = context();
-    const tempTerminal = await openTempTerminal(ctx);
+    const tempTerminal = await openTempTerminal(ctx, { shortcutLabelFn: () => "Ctrl+B then Shift+M" });
     const modal = ctx.elements.get("tempTerminalModal");
+    const minimizeButton = modal.minimizeButton;
     const restoreButton = ctx.createdButtons.find((button) => button.className === "temp-terminal-restore");
     ok(restoreButton);
     equal(tempTerminal.isVisible(), true);
+    equal(minimizeButton.title, "Minimize temporary terminal (Ctrl+B then Shift+M)");
 
     tempTerminal.minimize();
     equal(tempTerminal.isVisible(), false);
     equal(modal.style.display, "none");
     equal(modal.attributes["aria-hidden"], "true");
     equal(restoreButton.style.display, "inline-flex");
+    equal(restoreButton.title, "Show temporary terminal (Ctrl+B then Shift+M)");
     equal(ctx.listeners.has("keydown"), false);
 
     restoreButton.onclick();


### PR DESCRIPTION
## Summary
- show the configured temp-terminal shortcut on the minimize button hover/aria label
- show the same shortcut on the minimized restore pill hover/aria label
- keep the label sourced from the user-configurable WebUI shortcut map
- cover default and custom shortcut labels in tests

## Validation
- node --test src/assets/app_load.test.mjs src/assets/temp_terminal.test.mjs
- node --test src/assets/*.test.mjs
- cargo test