### PR TITLE
Improve Git UI panels and file exploration

### DIFF
--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -2024,6 +2024,17 @@ describe("app bundle load", () => {
     ok(!html.includes("panelSelector"));
   });
 
+  it("resizes workspace pane for an open panel selector", () => {
+    const renderSource = readFileSync(new URL("./desktop/app_js/render.js", import.meta.url), "utf8");
+    const chromeCss = readFileSync(new URL("./desktop/app_css/chrome.css", import.meta.url), "utf8");
+
+    match(renderSource, /function syncWorkspacePanelMenuSize\(\)/);
+    match(renderSource, /querySelector\("\.panel-menu"\)/);
+    match(renderSource, /--workspace-panel-menu-min-height/);
+    match(chromeCss, /\.sidebar-pane\.workspaces-pane\.panel-menu-open \{[\s\S]*?min-height: max\(20%, var\(--workspace-panel-menu-min-height, 0px\)\);/);
+    match(chromeCss, /\.sidebar-pane\.workspaces-pane\.panel-menu-open \.sidebar-scroll \{[\s\S]*?overflow: visible;/);
+  });
+
   it("captures terminal paste before xterm native paste", () => {
     match(source, /addEventListener\(\s*"paste"/);
     match(source, /stopImmediatePropagation\(\)/);

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -875,6 +875,21 @@ describe("app bundle load", () => {
     match(gitUiSource, /filterFiles/);
   });
 
+  it("uses shared file tree rows for Git files with Git metadata", () => {
+    const fileTreeSource = readFileSync(new URL("./shared/file_tree.js", import.meta.url), "utf8");
+    const gitLayoutCss = readFileSync(new URL("./desktop/git_ui/layout.css", import.meta.url), "utf8");
+
+    match(gitUiSource, /FileTree\.renderPathTree\(files, \{/);
+    match(gitUiSource, /statusForPath: fileTreeStatus/);
+    match(gitUiSource, /function fileSummaryEntries\(path, kind\)/);
+    match(gitUiSource, /function normalizeFileTreeStatus\(status, kind\)/);
+    match(fileTreeSource, /opts\.statusForPath\(dirPath, opts\.kind\)/);
+    match(fileTreeSource, /opts\.metaForPath\(dirPath, opts\.kind\)/);
+    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.git-ui-file \{[\s\S]*?display: grid;/);
+    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.git-conflict/);
+    match(gitLayoutCss, /\.git-ui-file-icon\.conflict/);
+  });
+
   it("keeps content search file expansion when context is reloaded", () => {
     const ctx = context();
     ctx.localStorage.setItem("herdr-web-options", JSON.stringify({ fileContentSearchDefaultExpanded: false }));

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -886,10 +886,11 @@ describe("app bundle load", () => {
     match(fileTreeSource, /opts\.statusForPath\(dirPath, opts\.kind\)/);
     match(fileTreeSource, /opts\.metaForPath\(dirPath, opts\.kind\)/);
     match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.git-ui-file \{[\s\S]*?display: grid;/);
-    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.git-conflict/);
-    match(gitLayoutCss, /--git-ui-tree-status-color: var\(--git-modified-color\)/);
-    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row:is\(\.git-modified, \.git-added, \.git-untracked, \.git-deleted, \.git-changed, \.git-conflict\) \.herdr-tree-name/);
-    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row:is\(\.git-modified, \.git-added, \.git-untracked, \.git-deleted, \.git-changed, \.git-conflict\) \.herdr-tree-icon:not\(\.herdr-tree-icon-filetype\)/);
+    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.git-ui-file:is\(\.git-modified, \.git-added, \.git-untracked, \.git-deleted, \.git-changed, \.git-conflict\)/);
+    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.git-ui-file:is\(\.git-modified, \.git-added, \.git-untracked, \.git-deleted, \.git-changed, \.git-conflict\) \{\s*color: var\(--fg\);/);
+    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.git-ui-dir:is\(\.git-modified, \.git-added, \.git-untracked, \.git-deleted, \.git-changed, \.git-conflict\) \{\s*color: var\(--muted\);/);
+    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.file\.git-ui-file \.herdr-tree-icon:not\(\.herdr-tree-icon-filetype\) \{\s*background: var\(--muted\);/);
+    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.dir\.git-ui-file \.herdr-tree-icon:not\(\.herdr-tree-icon-filetype\) \{\s*background: var\(--accent\);/);
     match(gitLayoutCss, /\.git-ui-file-icon\.conflict/);
   });
 

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -890,6 +890,25 @@ describe("app bundle load", () => {
     match(gitLayoutCss, /\.git-ui-file-icon\.conflict/);
   });
 
+  it("supports Ctrl+F search across compared Git diff text", () => {
+    const gitLogCss = readFileSync(new URL("./desktop/git_ui/log.css", import.meta.url), "utf8");
+    const gitDiffCss = readFileSync(new URL("./desktop/git_ui/diff.css", import.meta.url), "utf8");
+
+    match(gitUiSource, /function handleDiffSearchShortcut\(event, view\)/);
+    match(gitUiSource, /editableTarget\(event\.target\)/);
+    match(gitUiSource, /event\.ctrlKey && !event\.metaKey|!event\.ctrlKey && !event\.metaKey/);
+    match(gitUiSource, /id="gitUiDiffSearch"/);
+    match(gitUiSource, /state\.focusDiffSearch = true/);
+    match(gitUiSource, /function highlightDiffText\(code, path\)/);
+    match(gitUiSource, /const rows = unified \? unifiedRows\(chunk\) : sideBySideRows\(chunk\)/);
+    match(gitUiSource, /<mark class="git-ui-search-match">/);
+    match(gitUiSource, /renderDiffCode\(oldLine, newLine, path, "old"\)/);
+    match(gitUiSource, /renderDiffCode\(oldLine, newLine, path, "new"\)/);
+    match(gitUiSource, /highlightDiffText\(content\.slice\(changed\.start, changed\.end\), path\)/);
+    match(gitLogCss, /\.git-ui-diff-search \{/);
+    match(gitDiffCss, /\.git-ui-search-match \{/);
+  });
+
   it("keeps content search file expansion when context is reloaded", () => {
     const ctx = context();
     ctx.localStorage.setItem("herdr-web-options", JSON.stringify({ fileContentSearchDefaultExpanded: false }));

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -887,6 +887,9 @@ describe("app bundle load", () => {
     match(fileTreeSource, /opts\.metaForPath\(dirPath, opts\.kind\)/);
     match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.git-ui-file \{[\s\S]*?display: grid;/);
     match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row\.git-conflict/);
+    match(gitLayoutCss, /--git-ui-tree-status-color: var\(--git-modified-color\)/);
+    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row:is\(\.git-modified, \.git-added, \.git-untracked, \.git-deleted, \.git-changed, \.git-conflict\) \.herdr-tree-name/);
+    match(gitLayoutCss, /\.git-ui-list \.herdr-tree-row:is\(\.git-modified, \.git-added, \.git-untracked, \.git-deleted, \.git-changed, \.git-conflict\) \.herdr-tree-icon:not\(\.herdr-tree-icon-filetype\)/);
     match(gitLayoutCss, /\.git-ui-file-icon\.conflict/);
   });
 

--- a/src/assets/desktop/app_css/chrome.css
+++ b/src/assets/desktop/app_css/chrome.css
@@ -151,6 +151,13 @@
   flex: 0 0 var(--sidebar-workspace-percent, 68%);
   min-height: 20%;
 }
+.sidebar-pane.workspaces-pane.panel-menu-open {
+  min-height: max(20%, var(--workspace-panel-menu-min-height, 0px));
+  z-index: 2;
+}
+.sidebar-pane.workspaces-pane.panel-menu-open .sidebar-scroll {
+  overflow: visible;
+}
 .sidebar-pane.agents-pane {
   flex: 1 1 auto;
   min-height: 110px;

--- a/src/assets/desktop/app_js/render.js
+++ b/src/assets/desktop/app_js/render.js
@@ -39,6 +39,7 @@ function render() {
     workspaceContextActions.innerHTML !== workspaceContextHtml
   )
     workspaceContextActions.innerHTML = workspaceContextHtml;
+  syncWorkspacePanelMenuSize();
   const agentsHtml = renderAgents(wsById, tabById, tabCountsByWorkspace);
   if (agentsHtml !== lastAgentsHtml) {
     agents.innerHTML = agentsHtml;
@@ -73,6 +74,25 @@ function render() {
   }
   fitTerminalShell();
   if (typeof fitTerminalSurface === "function") fitTerminalSurface();
+}
+
+function syncWorkspacePanelMenuSize() {
+  const workspacePane = el("workspacePane"),
+    menu = workspacePane && workspacePane.querySelector && workspacePane.querySelector(".panel-menu");
+  if (!workspacePane) return;
+  if (!menu) {
+    workspacePane.classList.remove("panel-menu-open");
+    if (workspacePane.style.removeProperty)
+      workspacePane.style.removeProperty("--workspace-panel-menu-min-height");
+    else workspacePane.style.setProperty("--workspace-panel-menu-min-height", "0px");
+    return;
+  }
+  workspacePane.classList.add("panel-menu-open");
+  const paneRect = workspacePane.getBoundingClientRect ? workspacePane.getBoundingClientRect() : null,
+    menuRect = menu.getBoundingClientRect ? menu.getBoundingClientRect() : null;
+  if (!paneRect || !menuRect) return;
+  const minHeight = Math.max(0, Math.ceil(menuRect.bottom - paneRect.top + 10));
+  workspacePane.style.setProperty("--workspace-panel-menu-min-height", `${minHeight}px`);
 }
 window.HerdrDesktopRender = render;
 function syncProjectDashboard() {

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -872,6 +872,7 @@
         expandCompactMethod: "expandCompactDir",
         filterTerm: view.fileFilter || "",
         metaForPath: fileSummary,
+        statusForPath: fileTreeStatus,
       });
     }
     if (fileListMode() === "flat") return renderFlatFileList(files, kind, view);
@@ -1106,16 +1107,75 @@
   }
 
   function fileSummary(path, kind) {
+    const files = fileSummaryEntries(path, kind);
+    const status = fileTreeStatus(path, kind);
+    const icon = status === "added" || status === "untracked" ? "+" : status === "deleted" ? "−" : status === "conflict" ? "!" : "✎";
+    const cls = status === "added" || status === "untracked" ? "add" : status === "deleted" ? "del" : status === "conflict" ? "conflict" : "edit";
+    const totals = files.reduce((total, entry) => {
+      const additions = Number(entry.additions);
+      const deletions = Number(entry.deletions);
+      if (Number.isFinite(additions)) total.additions += additions;
+      if (Number.isFinite(deletions)) total.deletions += deletions;
+      return total;
+    }, { additions: 0, deletions: 0 });
+    const hasCounts = files.some((entry) => Number.isFinite(Number(entry.additions)) || Number.isFinite(Number(entry.deletions)));
+    const counts = hasCounts ? `<span class="git-ui-file-counts"><b>+${totals.additions}</b><i>-${totals.deletions}</i></span>` : "";
+    return `<span class="git-ui-file-summary"><span class="git-ui-file-icon ${cls}">${icon}</span>${counts}</span>`;
+  }
+
+  function fileSummaryEntries(path, kind) {
+    const exact = fileSummaryForPath(path, kind);
+    if (exact) return [exact];
+    const prefix = `${String(path || "").replace(/\/+$/, "")}/`;
+    return filesForKind(kind)
+      .filter((file) => String(file || "").startsWith(prefix))
+      .map((file) => fileSummaryForPath(file, kind))
+      .filter(Boolean);
+  }
+
+  function fileSummaryForPath(path, kind) {
     const view = active() || {};
     const statusSummaries = ((view.status || {}).summaries) || {};
     const summary = kind === "S" ? (statusSummaries.staged || {})[path] : kind === "M" ? (statusSummaries.unstaged || {})[path] : null;
-    const file = (kind === "C" ? commitPreviewFile(path) : null) || diffFile(path) || summary || {};
-    const status = file.status || (kind === "?" ? "added" : "modified");
-    const icon = status === "added" ? "+" : status === "deleted" ? "−" : "✎";
-    const cls = status === "added" ? "add" : status === "deleted" ? "del" : "edit";
-    const hasCounts = Number.isFinite(Number(file.additions)) && Number.isFinite(Number(file.deletions));
-    const counts = hasCounts ? `<span class="git-ui-file-counts"><b>+${Number(file.additions)}</b><i>-${Number(file.deletions)}</i></span>` : "";
-    return `<span class="git-ui-file-summary"><span class="git-ui-file-icon ${cls}">${icon}</span>${counts}</span>`;
+    return (kind === "C" ? commitPreviewFile(path) : null) || diffFile(path) || summary || null;
+  }
+
+  function filesForKind(kind) {
+    const view = active() || {};
+    const status = view.status || {};
+    if (kind === "S") return status.staged || [];
+    if (kind === "M") return status.unstaged || [];
+    if (kind === "?") return status.untracked || [];
+    if (kind === "U") return status.conflicted || [];
+    if (kind === "C") {
+      if (view.tab === "log") return (((view.selectedCommitPreview || {}).diff || {}).files || []).map((file) => file.path);
+      if (view.compareFilePaths && view.compareFilePaths.length) return view.compareFilePaths;
+      return ((view.diff && view.diff.files) || []).map((file) => file.path);
+    }
+    return [];
+  }
+
+  function fileTreeStatus(path, kind) {
+    const entries = fileSummaryEntries(path, kind);
+    const statuses = entries.map((entry) => normalizeFileTreeStatus(entry.status, kind));
+    if (!entries.length) statuses.push(normalizeFileTreeStatus("", kind));
+    if (statuses.includes("conflict")) return "conflict";
+    if (statuses.includes("deleted")) return "deleted";
+    if (statuses.includes("modified")) return "modified";
+    if (statuses.includes("changed")) return "changed";
+    if (statuses.includes("untracked")) return "untracked";
+    if (statuses.includes("added")) return "added";
+    return statuses[0] || "modified";
+  }
+
+  function normalizeFileTreeStatus(status, kind) {
+    const value = String(status || "").toLowerCase();
+    if (kind === "U" || value.includes("conflict")) return "conflict";
+    if (kind === "?" || value === "untracked") return "untracked";
+    if (value === "added" || value === "new") return "added";
+    if (value === "deleted" || value === "removed") return "deleted";
+    if (value === "renamed" || value === "copied") return "changed";
+    return "modified";
   }
 
   function renderGitViewTabs(tabs, activeTab) {

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -60,12 +60,18 @@
     // Git drawer owns keyboard while visible, so terminal/global shortcuts behind it do not receive input.
     event.stopPropagation();
     if (event.stopImmediatePropagation) event.stopImmediatePropagation();
+    if (handleDiffSearchShortcut(event, view)) return;
     if (isGitShortcutPrefix(event)) {
       state.shortcutPrefixUntil = Date.now() + 5000;
       event.preventDefault();
       return;
     }
     if (handleGitShortcut(event, view)) return;
+    if (event.key === "Escape" && isDiffSearchTarget(event.target)) {
+      event.preventDefault();
+      window.HerdrGitUi.clearDiffSearch();
+      return;
+    }
     if (event.key !== "Escape") return;
     event.preventDefault();
     if (state.contextMenu) {
@@ -118,6 +124,20 @@
 
   function isChangesListView(view) {
     return !!(view && view.tab === "changes" && currentMode() === "changes" && !view.file && !view.sideEditor);
+  }
+
+  function handleDiffSearchShortcut(event, view) {
+    if (!event || editableTarget(event.target)) return false;
+    const key = String(event.key || "").toLowerCase();
+    if (key !== "f" || (!event.ctrlKey && !event.metaKey) || event.altKey || event.shiftKey) return false;
+    if (!canSearchDiff(view)) return false;
+    event.preventDefault();
+    window.HerdrGitUi.openDiffSearch();
+    return true;
+  }
+
+  function isDiffSearchTarget(target) {
+    return !!(target && target.closest && target.closest("#gitUiDiffSearch"));
   }
 
   function isNotGitRepositoryMessage(message) {
@@ -402,6 +422,67 @@
 
   function highlight(code, path) {
     return Syntax.highlight(code, path);
+  }
+
+  function highlightDiffText(code, path) {
+    const query = diffSearchQuery();
+    if (!query) return highlight(code, path);
+    const text = String(code == null ? "" : code);
+    const lower = text.toLowerCase();
+    const needle = query.toLowerCase();
+    let index = 0;
+    let html = "";
+    while (index < text.length) {
+      const found = lower.indexOf(needle, index);
+      if (found < 0) break;
+      if (found > index) html += highlight(text.slice(index, found), path);
+      html += `<mark class="git-ui-search-match">${highlight(text.slice(found, found + query.length), path)}</mark>`;
+      index = found + query.length;
+    }
+    return html + highlight(text.slice(index), path);
+  }
+
+  function diffSearchQuery() {
+    const view = active() || {};
+    return String(view.diffSearchQuery || "").trim();
+  }
+
+  function canSearchDiff(view) {
+    if (!view || view.sideEditor) return false;
+    if (["history", "log", "stash", "cleanup", "conflicts"].includes(view.tab)) return false;
+    return !!(((view.diff || {}).files || []).length || view.file);
+  }
+
+  function countTextMatches(value, query) {
+    const needle = String(query || "").trim().toLowerCase();
+    if (!needle) return 0;
+    const text = String(value == null ? "" : value).toLowerCase();
+    let count = 0;
+    let index = 0;
+    while (index < text.length) {
+      const found = text.indexOf(needle, index);
+      if (found < 0) break;
+      count++;
+      index = found + needle.length;
+    }
+    return count;
+  }
+
+  function diffSearchMatchCount(view, query) {
+    const needle = String(query || "").trim();
+    if (!needle) return 0;
+    const unified = diffLayoutMode() === "unified";
+    return (((view && view.diff && view.diff.files) || [])).reduce((total, file) => {
+      return total + ((file.chunks || []).reduce((fileTotal, chunk) => {
+        const rows = unified ? unifiedRows(chunk) : sideBySideRows(chunk);
+        return fileTotal + rows.reduce((lineTotal, row) => {
+          if (unified) return lineTotal + countTextMatches((row.line || {}).content || "", needle);
+          return lineTotal
+            + countTextMatches((row.oldLine || {}).content || "", needle)
+            + countTextMatches((row.newLine || {}).content || "", needle);
+        }, 0);
+      }, 0));
+    }, 0);
   }
 
   async function api(url, opt) {
@@ -1353,7 +1434,17 @@
       : activeTab === "changes" && canEditCurrentFile(view)
         ? `<button class="git-ui-btn" title="${esc(titleWithGitShortcut("Edit side-by-side", "edit"))}" onclick="HerdrGitUi.editSideBySide()">Edit side-by-side</button>`
         : "";
-    return `<div class="git-ui-log-head">${back}${stateLabel}${changes}${history}${blame}${sideEditor}${conflicts ? `<button class="git-ui-btn ${activeTab === "conflicts" ? "active" : ""}" onclick="HerdrGitUi.tab('conflicts')">Conflicts</button>` : ""}${collapse}${compare}</div>`;
+    const search = renderDiffSearchControl(view);
+    return `<div class="git-ui-log-head">${back}${stateLabel}${changes}${history}${blame}${sideEditor}${conflicts ? `<button class="git-ui-btn ${activeTab === "conflicts" ? "active" : ""}" onclick="HerdrGitUi.tab('conflicts')">Conflicts</button>` : ""}${collapse}${search}${compare}</div>`;
+  }
+
+  function renderDiffSearchControl(view) {
+    if (!canSearchDiff(view)) return "";
+    const query = String(view.diffSearchQuery || "");
+    if (!view.diffSearchOpen && !query) return `<button class="git-ui-btn" title="Search compared text (Ctrl+F)" onclick="HerdrGitUi.openDiffSearch()">Search</button>`;
+    const count = query.trim() ? diffSearchMatchCount(view, query) : 0;
+    const countText = query.trim() ? `${count} match${count === 1 ? "" : "es"}` : "";
+    return `<label class="git-ui-diff-search" title="Search compared text"><span>Search</span><input id="gitUiDiffSearch" value="${esc(query)}" autocomplete="off" spellcheck="false" placeholder="Search compared text" oninput="HerdrGitUi.setDiffSearch(this.value)"></label><span class="git-ui-diff-search-count">${esc(countText)}</span><button class="git-ui-btn" title="Clear diff search" onclick="HerdrGitUi.clearDiffSearch()">×</button>`;
   }
 
   function canEditCurrentFile(view) {
@@ -1670,9 +1761,9 @@
   }
 
   function renderUnifiedDiffCode(line, rows, rowIndex, path) {
-    if (!line || !["delete", "add"].includes(line.line_type)) return highlight((line && line.content) || "", path);
+    if (!line || !["delete", "add"].includes(line.line_type)) return highlightDiffText((line && line.content) || "", path);
     const pair = unifiedChangePair(rows, rowIndex);
-    if (!pair) return highlight(line.content || "", path);
+    if (!pair) return highlightDiffText(line.content || "", path);
     return renderDiffCode(pair.oldLine, pair.newLine, path, line.line_type === "delete" ? "old" : "new");
   }
 
@@ -1703,13 +1794,13 @@
     const line = side === "old" ? oldLine : newLine;
     if (!line) return "";
     if (!oldLine || !newLine || oldLine.line_type !== "delete" || newLine.line_type !== "add") {
-      return highlight(line.content, path);
+      return highlightDiffText(line.content, path);
     }
     const parts = changedMiddle(oldLine.content || "", newLine.content || "");
     const content = side === "old" ? oldLine.content || "" : newLine.content || "";
     const changed = side === "old" ? parts.oldChanged : parts.newChanged;
-    if (!changed.length) return highlight(content, path);
-    return `${highlight(content.slice(0, changed.start), path)}<span class="git-ui-word-change">${highlight(content.slice(changed.start, changed.end), path)}</span>${highlight(content.slice(changed.end), path)}`;
+    if (!changed.length) return highlightDiffText(content, path);
+    return `${highlightDiffText(content.slice(0, changed.start), path)}<span class="git-ui-word-change">${highlightDiffText(content.slice(changed.start, changed.end), path)}</span>${highlightDiffText(content.slice(changed.end), path)}`;
   }
 
   function changedMiddle(oldText, newText) {
@@ -1996,6 +2087,7 @@
     if (nextContent && preserveContentScroll(activeView.tab))
       nextContent.scrollTop = activeView.contentScrollTop || 0;
     mountSideEditors();
+    focusDiffSearchIfNeeded();
     const view = activeView;
     if (view.tab === "log") renderLog(version).catch((e) => { view.error = e.message; render(); });
     if (view.tab === "stash") renderStash(version).catch((e) => { view.error = e.message; render(); });
@@ -2010,6 +2102,17 @@
     const scrollTop = preserveContentScroll(view.tab) ? (view.contentScrollTop || content.scrollTop || 0) : null;
     content.innerHTML = html;
     if (scrollTop !== null) content.scrollTop = scrollTop;
+  }
+
+  function focusDiffSearchIfNeeded() {
+    if (!state.focusDiffSearch) return;
+    state.focusDiffSearch = false;
+    setTimeout(() => {
+      const input = document.getElementById("gitUiDiffSearch");
+      if (!input) return;
+      input.focus();
+      if (input.setSelectionRange) input.setSelectionRange(input.value.length, input.value.length);
+    }, 0);
   }
 
   function mountSideEditors() {
@@ -2492,6 +2595,28 @@
         view.fileFilter = String(value || "");
         render();
       }, 300);
+    },
+    openDiffSearch() {
+      const view = active();
+      if (!canSearchDiff(view)) return;
+      view.diffSearchOpen = true;
+      state.focusDiffSearch = true;
+      render();
+    },
+    setDiffSearch(value) {
+      const view = active();
+      if (!view) return;
+      view.diffSearchOpen = true;
+      view.diffSearchQuery = String(value || "");
+      state.focusDiffSearch = true;
+      render();
+    },
+    clearDiffSearch() {
+      const view = active();
+      if (!view) return;
+      view.diffSearchOpen = false;
+      view.diffSearchQuery = "";
+      render();
     },
     toggleCleanupSelection(key, checked) {
       const view = active();

--- a/src/assets/desktop/git_ui/diff.css
+++ b/src/assets/desktop/git_ui/diff.css
@@ -490,3 +490,9 @@
   background: rgba(248, 81, 73, 0.36);
   border-radius: 2px;
 }
+.git-ui-search-match {
+  background: color-mix(in srgb, var(--accent) 38%, #ffd166 62%);
+  border-radius: 2px;
+  color: #111827;
+  padding: 0 1px;
+}

--- a/src/assets/desktop/git_ui/layout.css
+++ b/src/assets/desktop/git_ui/layout.css
@@ -396,12 +396,38 @@
   color: var(--muted);
   font-weight: 800;
 }
-.git-ui-list .herdr-tree-row.git-modified { color: var(--git-modified-color); }
+.git-ui-list .herdr-tree-row.git-modified {
+  --git-ui-tree-status-color: var(--git-modified-color);
+  color: var(--git-ui-tree-status-color);
+}
 .git-ui-list .herdr-tree-row.git-added,
-.git-ui-list .herdr-tree-row.git-untracked { color: var(--git-added-color); }
-.git-ui-list .herdr-tree-row.git-deleted { color: var(--git-deleted-color); }
-.git-ui-list .herdr-tree-row.git-changed { color: var(--git-changed-color); }
-.git-ui-list .herdr-tree-row.git-conflict { color: var(--git-conflict-color); }
+.git-ui-list .herdr-tree-row.git-untracked {
+  --git-ui-tree-status-color: var(--git-added-color);
+  color: var(--git-ui-tree-status-color);
+}
+.git-ui-list .herdr-tree-row.git-deleted {
+  --git-ui-tree-status-color: var(--git-deleted-color);
+  color: var(--git-ui-tree-status-color);
+}
+.git-ui-list .herdr-tree-row.git-changed {
+  --git-ui-tree-status-color: var(--git-changed-color);
+  color: var(--git-ui-tree-status-color);
+}
+.git-ui-list .herdr-tree-row.git-conflict {
+  --git-ui-tree-status-color: var(--git-conflict-color);
+  color: var(--git-ui-tree-status-color);
+}
+.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-caret,
+.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-kind,
+.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-name,
+.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-crumb,
+.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-sep,
+.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-icon {
+  color: var(--git-ui-tree-status-color);
+}
+.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-icon:not(.herdr-tree-icon-filetype) {
+  background: var(--git-ui-tree-status-color);
+}
 .git-ui-list .herdr-tree-caret,
 .git-ui-list .herdr-tree-kind {
   align-items: center;

--- a/src/assets/desktop/git_ui/layout.css
+++ b/src/assets/desktop/git_ui/layout.css
@@ -396,37 +396,29 @@
   color: var(--muted);
   font-weight: 800;
 }
-.git-ui-list .herdr-tree-row.git-modified {
-  --git-ui-tree-status-color: var(--git-modified-color);
-  color: var(--git-ui-tree-status-color);
+.git-ui-list .herdr-tree-row.git-ui-file:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) {
+  color: var(--fg);
 }
-.git-ui-list .herdr-tree-row.git-added,
-.git-ui-list .herdr-tree-row.git-untracked {
-  --git-ui-tree-status-color: var(--git-added-color);
-  color: var(--git-ui-tree-status-color);
+.git-ui-list .herdr-tree-row.git-ui-dir:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) {
+  color: var(--muted);
 }
-.git-ui-list .herdr-tree-row.git-deleted {
-  --git-ui-tree-status-color: var(--git-deleted-color);
-  color: var(--git-ui-tree-status-color);
+.git-ui-list .herdr-tree-row.git-ui-file .herdr-tree-caret,
+.git-ui-list .herdr-tree-row.git-ui-file .herdr-tree-sep {
+  color: var(--muted);
 }
-.git-ui-list .herdr-tree-row.git-changed {
-  --git-ui-tree-status-color: var(--git-changed-color);
-  color: var(--git-ui-tree-status-color);
+.git-ui-list .herdr-tree-row.file.git-ui-file .herdr-tree-kind,
+.git-ui-list .herdr-tree-row.file.git-ui-file .herdr-tree-icon {
+  color: var(--muted);
 }
-.git-ui-list .herdr-tree-row.git-conflict {
-  --git-ui-tree-status-color: var(--git-conflict-color);
-  color: var(--git-ui-tree-status-color);
+.git-ui-list .herdr-tree-row.file.git-ui-file .herdr-tree-icon:not(.herdr-tree-icon-filetype) {
+  background: var(--muted);
 }
-.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-caret,
-.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-kind,
-.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-name,
-.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-crumb,
-.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-sep,
-.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-icon {
-  color: var(--git-ui-tree-status-color);
+.git-ui-list .herdr-tree-row.dir.git-ui-file .herdr-tree-kind,
+.git-ui-list .herdr-tree-row.dir.git-ui-file .herdr-tree-icon {
+  color: var(--accent);
 }
-.git-ui-list .herdr-tree-row:is(.git-modified, .git-added, .git-untracked, .git-deleted, .git-changed, .git-conflict) .herdr-tree-icon:not(.herdr-tree-icon-filetype) {
-  background: var(--git-ui-tree-status-color);
+.git-ui-list .herdr-tree-row.dir.git-ui-file .herdr-tree-icon:not(.herdr-tree-icon-filetype) {
+  background: var(--accent);
 }
 .git-ui-list .herdr-tree-caret,
 .git-ui-list .herdr-tree-kind {

--- a/src/assets/desktop/git_ui/layout.css
+++ b/src/assets/desktop/git_ui/layout.css
@@ -363,6 +363,71 @@
   overflow-x: hidden;
   overflow-y: auto;
 }
+.git-ui-list .herdr-file-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 0;
+}
+.git-ui-list .herdr-tree-row.git-ui-file {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--fg);
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  font-size: 12px;
+  gap: 5px;
+  grid-template-columns: 14px 16px minmax(0, 1fr) auto;
+  justify-content: initial;
+  min-width: 0;
+  padding: 5px 6px 5px calc(6px + var(--tree-offset, 0px));
+  text-align: left;
+  width: 100%;
+}
+.git-ui-list .herdr-tree-row.git-ui-file:hover,
+.git-ui-list .herdr-tree-row.git-ui-file.active {
+  background: var(--panel2);
+  border-color: var(--border2);
+}
+.git-ui-list .herdr-tree-row.git-ui-dir {
+  color: var(--muted);
+  font-weight: 800;
+}
+.git-ui-list .herdr-tree-row.git-modified { color: var(--git-modified-color); }
+.git-ui-list .herdr-tree-row.git-added,
+.git-ui-list .herdr-tree-row.git-untracked { color: var(--git-added-color); }
+.git-ui-list .herdr-tree-row.git-deleted { color: var(--git-deleted-color); }
+.git-ui-list .herdr-tree-row.git-changed { color: var(--git-changed-color); }
+.git-ui-list .herdr-tree-row.git-conflict { color: var(--git-conflict-color); }
+.git-ui-list .herdr-tree-caret,
+.git-ui-list .herdr-tree-kind {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  min-width: 0;
+}
+.git-ui-list .herdr-tree-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.git-ui-list .herdr-tree-icon {
+  background: currentColor;
+  display: inline-block;
+  height: 14px;
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  width: 14px;
+}
+.git-ui-list .herdr-tree-icon-chevron-right { mask-image: url("/assets/icons/chevron-right.svg"); }
+.git-ui-list .herdr-tree-icon-chevron-down { mask-image: url("/assets/icons/chevron-down.svg"); }
+.git-ui-list .herdr-tree-icon-folder { mask-image: url("/assets/icons/folder.svg"); }
+.git-ui-list .herdr-tree-icon-file { mask-image: url("/assets/icons/file.svg"); }
 .git-ui-section-head {
   align-items: center;
   background: transparent;
@@ -644,6 +709,7 @@
 .git-ui-file-icon.add { color: var(--git-added-color); }
 .git-ui-file-icon.del { color: var(--git-deleted-color); }
 .git-ui-file-icon.edit { color: var(--git-modified-color); }
+.git-ui-file-icon.conflict { color: var(--git-conflict-color); }
 .git-ui-file-counts {
   font-size: 10px;
   font-style: normal;

--- a/src/assets/desktop/git_ui/log.css
+++ b/src/assets/desktop/git_ui/log.css
@@ -33,6 +33,37 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.git-ui-diff-search {
+  align-items: center;
+  border: 1px solid var(--border2);
+  border-radius: 999px;
+  color: var(--muted);
+  display: inline-flex;
+  flex: 1 1 220px;
+  gap: 6px;
+  max-width: 360px;
+  min-width: 180px;
+  padding: 3px 8px;
+}
+.git-ui-diff-search span,
+.git-ui-diff-search-count {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+}
+.git-ui-diff-search input {
+  background: transparent;
+  border: 0;
+  color: var(--fg);
+  flex: 1;
+  font: inherit;
+  min-width: 0;
+  outline: 0;
+  padding: 0;
+}
+.git-ui-diff-search-count {
+  min-width: 54px;
+}
 .git-ui-breadcrumbs {
   align-items: center;
   border: 1px solid var(--border2);

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -755,10 +755,13 @@
         browserFaviconError = false;
         mobileAttention.handleSound();
         mobileWorktrees.applyResult(worktrees);
-        if (!state.tabs.some((tab) => tab.tab_id === state.tab))
-          state.tab = (state.tabs[0] || {}).tab_id || null;
+        if (!state.tabs.some((tab) => tab.tab_id === state.tab)) {
+          const focused = state.tabs.find((tab) => tab.focused);
+          state.tab = (focused || state.tabs[0] || {}).tab_id || null;
+        }
         if (!state.panes.some((pane) => pane.pane_id === state.pane)) {
           const pane =
+            state.panes.find((item) => item.tab_id === state.tab && item.focused) ||
             state.panes.find((item) => item.tab_id === state.tab) ||
             state.panes[0];
           state.pane = pane && pane.pane_id;

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -86,6 +86,7 @@ function context(pathname = "/", options = {}) {
       getItem: (key) => localStorage.get(key) || null,
       setItem: (key, value) => localStorage.set(key, String(value)),
     },
+    confirm: options.confirm || (() => true),
     window: null,
     globalThis: null,
     Terminal: class {
@@ -191,9 +192,19 @@ function context(pathname = "/", options = {}) {
             ],
           }),
         };
+      const optionValue = (key, fallback) => {
+        const value = options[key];
+        return typeof value === "function"
+          ? value({ url, opt, requests })
+          : value === undefined
+            ? fallback
+            : value;
+      };
       const result = url.includes("workspaces")
         ? {
-            workspaces: [{ workspace_id: "w1", label: "alpha", pane_count: 1, cwd: "/tmp/alpha" }],
+            workspaces: optionValue("workspaces", [
+              { workspace_id: "w1", label: "alpha", pane_count: 1, cwd: "/tmp/alpha" },
+            ]),
           }
         : url.includes("worktrees")
           ? {
@@ -209,17 +220,17 @@ function context(pathname = "/", options = {}) {
             }
           : url.includes("tabs")
             ? {
-                tabs: [
+                tabs: optionValue("tabs", [
                   { workspace_id: "w1", tab_id: "w1:t1", number: 1 },
                   { workspace_id: "w1", tab_id: "w1:t2", number: 2 },
-                ],
+                ]),
               }
             : url.includes("panes")
               ? {
-                  panes: [
+                  panes: optionValue("panes", [
                     { tab_id: "w1:t1", pane_id: "w1:p1", terminal_id: "term1" },
                     { tab_id: "w1:t2", pane_id: "w1:p2", terminal_id: "term2" },
-                  ],
+                  ]),
                 }
               : {
                   agents: [
@@ -778,5 +789,41 @@ describe("mobile bundle load", () => {
     ok(html.includes("Close current panel"));
     ok(source.includes("mobile-tab-close"));
     equal(typeof ctx.HerdrMobile.closeCurrentPanel, "function");
+  });
+
+  it("closes current mobile panel and selects the focused fallback panel", async () => {
+    const remainingTabs = [
+      { workspace_id: "w1", tab_id: "w1:t2", number: 2, focused: true },
+    ];
+    const remainingPanes = [
+      { tab_id: "w1:t2", pane_id: "w1:p2", terminal_id: "term2", focused: true },
+    ];
+    const ctx = context("/session/default/workspace/w1/tab/t1/pane/p1", {
+      tabs: ({ requests }) =>
+        requests.some((request) => request.url === "/api/tabs/w1%3At1/close")
+          ? remainingTabs
+          : [
+              { workspace_id: "w1", tab_id: "w1:t1", number: 1 },
+              ...remainingTabs,
+            ],
+      panes: ({ requests }) =>
+        requests.some((request) => request.url === "/api/tabs/w1%3At1/close")
+          ? remainingPanes
+          : [
+              { tab_id: "w1:t1", pane_id: "w1:p1", terminal_id: "term1" },
+              ...remainingPanes,
+            ],
+    });
+    vm.runInContext(source, ctx);
+    await ctx.HerdrMobile.refresh();
+
+    await ctx.HerdrMobile.closeCurrentPanel();
+
+    ok(ctx.requests.some(
+      (request) => request.url === "/api/tabs/w1%3At1/close" && request.opt.method === "POST",
+    ));
+    equal(ctx.HerdrMobile.currentSelection().tab, "w1:t2");
+    equal(ctx.HerdrMobile.currentSelection().pane, "w1:p2");
+    equal(ctx.history.calls.at(-1).path, "/session/default/workspace/w1/tab/t2/pane/p2");
   });
 });

--- a/src/assets/shared/file_tree.js
+++ b/src/assets/shared/file_tree.js
@@ -109,8 +109,10 @@
         const collapsed = !!((opts.collapsedDirs || {})[dirPath]);
         const keydown = opts.activateMethod ? ` onkeydown="${callback}.${opts.activateMethod}(event)"` : "";
         const dirClass = opts.dirClass ? ` ${opts.dirClass}` : "";
+        const status = typeof opts.statusForPath === "function" ? opts.statusForPath(dirPath, opts.kind) : "";
+        const meta = typeof opts.metaForPath === "function" ? opts.metaForPath(dirPath, opts.kind) : "";
         const name = renderCompactDirName(compact.parts, opts, callback);
-        return `<div class="herdr-tree-row dir${dirClass}" role="treeitem" tabindex="0" aria-expanded="${collapsed ? "false" : "true"}" style="${indentStyle(level, opts)}" onclick="${callback}.${opts.toggleMethod || "toggle"}('${arg(dirPath)}')"${keydown}><span class="herdr-tree-caret">${icon(collapsed ? "closed" : "open")}</span><span class="herdr-tree-kind">${icon("dir", dirPath)}</span><span class="herdr-tree-name">${name}</span></div>${collapsed ? "" : renderPathNode(compact.child, dirPath, opts, level + 1)}`;
+        return `<div class="herdr-tree-row dir${dirClass}${status ? ` git-${status}` : ""}" role="treeitem" tabindex="0" aria-expanded="${collapsed ? "false" : "true"}" style="${indentStyle(level, opts)}" onclick="${callback}.${opts.toggleMethod || "toggle"}('${arg(dirPath)}')"${keydown}><span class="herdr-tree-caret">${icon(collapsed ? "closed" : "open")}</span><span class="herdr-tree-kind">${icon("dir", dirPath)}</span><span class="herdr-tree-name">${name}</span>${statusBadge(status)}${meta}</div>${collapsed ? "" : renderPathNode(compact.child, dirPath, opts, level + 1)}`;
       }
       const selected = opts.selectedPath === entry.path && (!opts.selectedKind || opts.selectedKind === opts.kind);
       const meta = typeof opts.metaForPath === "function" ? opts.metaForPath(entry.path, opts.kind) : "";

--- a/src/builtin_backend.rs
+++ b/src/builtin_backend.rs
@@ -497,7 +497,8 @@ impl BuiltinState {
             "tab.create" => {
                 let workspace_id = optional_string(&params, "workspace_id");
                 let label = optional_string(&params, "label");
-                let (tab, root_pane) = self.create_tab(workspace_id, label)?;
+                let focus = optional_bool(&params, "focus").unwrap_or(true);
+                let (tab, root_pane) = self.create_tab(workspace_id, label, focus)?;
                 Ok(json!({ "type": "tab_created", "tab": tab, "root_pane": root_pane }))
             }
             "tab.rename" => {
@@ -648,6 +649,7 @@ impl BuiltinState {
         &self,
         workspace_id: Option<String>,
         label: Option<String>,
+        focus: bool,
     ) -> Result<(Value, Value), String> {
         let mut data = self
             .data
@@ -704,9 +706,15 @@ impl BuiltinState {
             },
         );
         data.terminals.insert(terminal_id, terminal);
-        data.focused_workspace_id = Some(workspace_id);
-        data.focused_tab_id = Some(tab_id.clone());
-        data.focused_pane_id = Some(pane_id.clone());
+        if focus
+            || data.focused_workspace_id.is_none()
+            || data.focused_tab_id.is_none()
+            || data.focused_pane_id.is_none()
+        {
+            data.focused_workspace_id = Some(workspace_id);
+            data.focused_tab_id = Some(tab_id.clone());
+            data.focused_pane_id = Some(pane_id.clone());
+        }
         let tab = tab_json(data.tabs.get(&tab_id).unwrap(), &data);
         let pane = pane_json(data.panes.get(&pane_id).unwrap(), &data);
         Ok((tab, pane))
@@ -1662,6 +1670,10 @@ fn optional_string(params: &Value, key: &str) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+fn optional_bool(params: &Value, key: &str) -> Option<bool> {
+    params.get(key).and_then(Value::as_bool)
 }
 
 fn success_response(id: &str, result: Value) -> Value {
@@ -3217,6 +3229,42 @@ mod tests {
         let event = rx.recv_timeout(Duration::from_secs(1)).unwrap();
         assert_eq!(event["event"], "tab.created");
         assert_eq!(event["data"]["type"], "tab_created");
+    }
+
+    #[test]
+    fn builtin_tab_create_respects_focus_false() {
+        let state =
+            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell())).unwrap();
+        let workspace =
+            state.handle_request("seed", "workspace.create", json!({ "label": "Workspace" }));
+        let workspace_id = workspace["result"]["workspace"]["workspace_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let focused_tab_id = workspace["result"]["tab"]["tab_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let background_tab = state.handle_request(
+            "background-tab",
+            "tab.create",
+            json!({ "workspace_id": workspace_id, "label": "Temp", "focus": false }),
+        );
+        let background_tab_id = background_tab["result"]["tab"]["tab_id"].as_str().unwrap();
+        let snapshot = state.handle_request("snapshot", "session.snapshot", json!({}));
+
+        assert_eq!(
+            snapshot["result"]["snapshot"]["focused_tab_id"].as_str(),
+            Some(focused_tab_id.as_str())
+        );
+        let tabs = snapshot["result"]["snapshot"]["tabs"].as_array().unwrap();
+        assert!(tabs
+            .iter()
+            .any(|tab| tab["tab_id"] == focused_tab_id && tab["focused"] == true));
+        assert!(tabs
+            .iter()
+            .any(|tab| tab["tab_id"] == background_tab_id && tab["focused"] == false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fix temporary terminal background panel focus handling
- fix panel switching/close fallback behavior
- resize workspace pane when panel selector is open
- use shared file tree rendering in Git lists while restoring main-style colors
- add Ctrl/Cmd+F search across compared Git diff text

## Validation
- full JS asset test suite: `files=$(find src/assets -name '*.test.mjs' -print | sort); node --test $files`
- full Rust test suite: `cargo test --quiet`
- merged latest `origin/main` into `terminal_work`
- local deploy verified on `http://127.0.0.1:18787/?v=3b49ef3`