### PR TITLE
Fix panel selection, git indicators, diff scroll, side editor UX, and temp terminal focus

### DIFF
--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -2487,14 +2487,8 @@ function sessionPrefix() {
 // Earlier code scoped ids as `${ws}:${id}` in parseRoute, which made
 // `state.tab` (scoped) never match `state.tabs[].tab_id` (unscoped), so the
 // panel switcher always snapped back to the focused/first tab after a refresh.
-// These helpers are now identity on desktop so ids stay raw end-to-end.
+// Ids stay raw end-to-end on desktop — no scoping helpers needed.
 // (Mobile keeps a real scoped implementation in src/assets/mobile/core.js.)
-function expandScopedId(ws, id) {
-  return id || null;
-}
-function compactScopedId(ws, id) {
-  return id || null;
-}
 function selectionPath(ws, tab, pane) {
   let p = sessionPrefix() + "/workspace/" + encodeURIComponent(ws);
   if (tab) p += "/tab/" + encodeURIComponent(tab);

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -2481,19 +2481,24 @@ async function loadVersions() {
 function sessionPrefix() {
   return "/session/" + encodeURIComponent(state.session || "default");
 }
+// Desktop backend (builtin_backend.rs `next_id` -> `tab_N`) returns UNSCOPED
+// tab/pane ids. The URL stores them raw (`/workspace/ws1/tab/tab_2`), and every
+// comparison in refreshOnline / closeTab / etc. is against the raw backend id.
+// Earlier code scoped ids as `${ws}:${id}` in parseRoute, which made
+// `state.tab` (scoped) never match `state.tabs[].tab_id` (unscoped), so the
+// panel switcher always snapped back to the focused/first tab after a refresh.
+// These helpers are now identity on desktop so ids stay raw end-to-end.
+// (Mobile keeps a real scoped implementation in src/assets/mobile/core.js.)
 function expandScopedId(ws, id) {
-  if (!ws || !id) return id || null;
-  return `${ws}:${id}`;
+  return id || null;
 }
 function compactScopedId(ws, id) {
-  if (!ws || !id) return id || null;
-  const prefix = `${ws}:`;
-  return id.startsWith(prefix) ? id.slice(prefix.length) : id;
+  return id || null;
 }
 function selectionPath(ws, tab, pane) {
   let p = sessionPrefix() + "/workspace/" + encodeURIComponent(ws);
-  if (tab) p += "/tab/" + encodeURIComponent(compactScopedId(ws, tab));
-  if (pane) p += "/pane/" + encodeURIComponent(compactScopedId(ws, pane));
+  if (tab) p += "/tab/" + encodeURIComponent(tab);
+  if (pane) p += "/pane/" + encodeURIComponent(pane);
   return p;
 }
 function parseRoute() {
@@ -2508,8 +2513,8 @@ function parseRoute() {
     i = 2;
   }
   state.ws = p[i] === "workspace" ? p[i + 1] : null;
-  state.tab = p[i + 2] === "tab" ? expandScopedId(state.ws, p[i + 3]) : null;
-  state.pane = p[i + 4] === "pane" ? expandScopedId(state.ws, p[i + 5]) : null;
+  state.tab = p[i + 2] === "tab" ? (p[i + 3] || null) : null;
+  state.pane = p[i + 4] === "pane" ? (p[i + 5] || null) : null;
 }
 function setTerminalLoading(show) {
   const loading = el("terminalLoading");

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -1347,6 +1347,31 @@
     return "";
   }
 
+  function aheadBehindHint(s) {
+    const ahead = Number(s.ahead) || 0;
+    const behind = Number(s.behind) || 0;
+    const upstream = String(s.upstream || "").trim();
+    if (!upstream) return "";
+    const parts = [];
+    if (ahead > 0) parts.push(`ahead ${ahead} (local has commits not on ${upstream})`);
+    if (behind > 0) parts.push(`behind ${behind} (${upstream} has commits not on local)`);
+    if (!parts.length) parts.push(`in sync with ${upstream}`);
+    return parts.join(" · ");
+  }
+
+  function renderAheadBehind(s, esc) {
+    const upstream = String(s.upstream || "").trim();
+    if (!upstream) return "";
+    const ahead = Number(s.ahead) || 0;
+    const behind = Number(s.behind) || 0;
+    const title = aheadBehindHint(s);
+    const badges = [];
+    if (ahead > 0) badges.push(`<span class="git-ui-ahead-behind ahead" title="${esc(title)}">↑${esc(String(ahead))}</span>`);
+    if (behind > 0) badges.push(`<span class="git-ui-ahead-behind behind" title="${esc(title)}">↓${esc(String(behind))}</span>`);
+    if (!badges.length) badges.push(`<span class="git-ui-ahead-behind synced" title="${esc(title)}">✓</span>`);
+    return `<span class="git-ui-ahead-behind-group" title="${esc(title)}">${badges.join("")}</span>`;
+  }
+
   function renderSide() {
     const view = active() || {};
     const s = view.status || {};
@@ -1382,7 +1407,8 @@
       ? `<button class="git-ui-refresh-icon git-ui-current-changes-icon" title="Return to current changes" aria-label="Return to current changes" onclick="HerdrGitUi.latestChanges()"><span></span></button>`
       : "";
     const refreshButton = appRefreshIconButton({ className: "git-ui-refresh-icon", title: titleWithGitShortcut("Refresh", "refresh"), label: titleWithGitShortcut("Refresh Git state", "refresh"), spinning: !!view.refreshAnimating, onclick: "HerdrGitUi.refreshWithSpin()" });
-    return `<aside class="git-ui-side" onscroll="HerdrGitUi.sideScroll(this)"><div class="git-ui-head"><div class="git-ui-head-main"><div class="git-ui-title-row"><div class="git-ui-title">Git</div><div class="git-ui-title-actions">${returnToCurrentChanges}${returnToWorkspace}${refreshButton}</div></div><div class="git-ui-subtitle">${esc(s.state || "closed")} · ${esc(compactPath(s.repo_path))}</div><button class="git-ui-branch-pill" title="${esc(titleWithGitShortcut("Change Git directory or switch branch", "branch"))}" onclick="HerdrGitUi.openBranchModal()"><span>${esc(branchLabel)}</span><b>↗</b></button></div></div>${error}<div class="git-ui-toolbar git-ui-view-toolbar">${renderGitViewTabs(tabs, view.tab)}</div>${actions}${fileList}${sideBottom}</aside>`;
+    const aheadBehind = cleanupOnly ? "" : renderAheadBehind(s, esc);
+    return `<aside class="git-ui-side" onscroll="HerdrGitUi.sideScroll(this)"><div class="git-ui-head"><div class="git-ui-head-main"><div class="git-ui-title-row"><div class="git-ui-title">Git</div><div class="git-ui-title-actions">${returnToCurrentChanges}${returnToWorkspace}${refreshButton}</div></div><div class="git-ui-subtitle">${esc(s.state || "closed")} · ${esc(compactPath(s.repo_path))}</div><button class="git-ui-branch-pill" title="${esc(titleWithGitShortcut("Change Git directory or switch branch", "branch"))}" onclick="HerdrGitUi.openBranchModal()"><span>${esc(branchLabel)}</span>${aheadBehind}<b>↗</b></button></div></div>${error}<div class="git-ui-toolbar git-ui-view-toolbar">${renderGitViewTabs(tabs, view.tab)}</div>${actions}${fileList}${sideBottom}</aside>`;
   }
 
   function renderDiffLayoutSideToggle(view) {
@@ -1862,6 +1888,7 @@
       filters: view.logFilters || {},
       esc,
       arg,
+      status: view.status || {},
     }));
     updateGitLogStickyOffsets();
     if (view.pendingLogScrollHash) {

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -671,6 +671,31 @@
     return `.../${parts.slice(-3).join("/")}`;
   }
 
+  let diffScrollSyncBound = false;
+  function bindDiffScrollSync() {
+    if (diffScrollSyncBound) return;
+    diffScrollSyncBound = true;
+    // Mirror horizontal scroll between the old/new code cells of a side-by-side
+    // diff row so wide lines stay aligned. Each cell scrolls on its own
+    // (overflow-x: auto in diff.css); this keeps the two sides in lockstep.
+    document.addEventListener("scroll", function (event) {
+      const node = event.target;
+      if (!node || !node.classList || !node.classList.contains("git-ui-code")) return;
+      const row = node.closest && node.closest(".git-ui-diff-row");
+      if (!row) return;
+      if (node._syncingScroll) return;
+      const others = row.querySelectorAll(".git-ui-code");
+      for (const other of others) {
+        if (other === node) continue;
+        if (other.scrollLeft === node.scrollLeft) continue;
+        other._syncingScroll = true;
+        other.scrollLeft = node.scrollLeft;
+        // clear the flag next tick so the mirrored scroll event can fire
+        setTimeout(() => { other._syncingScroll = false; }, 0);
+      }
+    }, true);
+  }
+
   function ensurePanel() {
     let panel = document.getElementById("gitUiPanel");
     if (panel) return panel;
@@ -681,6 +706,7 @@
     panel.tabIndex = -1;
     panel.style.display = "none";
     if (shell && shell.parentNode) shell.parentNode.appendChild(panel);
+    bindDiffScrollSync();
     return panel;
   }
 
@@ -2259,7 +2285,7 @@
   async function applyHunk(path, index, options) {
     const patch = hunkPatch(path, index);
     if (!patch) return;
-    await post("/api/git-ui/apply-patch", Object.assign({ cwd: active().cwd, patch }, options || {}));
+    await post("/api/git-ui/apply-patch", Object.assign({ cwd: active().cwd, patch }, options || {}), options && options.reverse ? "Restoring hunk" : "Applying hunk");
   }
 
   window.HerdrGitUi = {
@@ -2414,12 +2440,12 @@
       const status = (view && view.status) || {};
       const staged = status.staged || [];
       if (staged.length) {
-        post("/api/git-ui/unstage", { cwd: view.cwd, paths: staged });
+        post("/api/git-ui/unstage", { cwd: view.cwd, paths: staged }, "Unstaging all");
         return;
       }
       const paths = [...(status.unstaged || []), ...(status.untracked || [])];
       if (!paths.length) return;
-      post("/api/git-ui/stage", { cwd: view.cwd, paths });
+      post("/api/git-ui/stage", { cwd: view.cwd, paths }, "Staging all");
     },
     bulkSectionAction(action, title) {
       const view = active();
@@ -2437,19 +2463,19 @@
       const verb = action === "unstage" ? "Unstage" : "Stage";
       if (!confirm(`${verb} ${paths.length} ${title.toLowerCase()} file${paths.length === 1 ? "" : "s"}?`)) return;
       setTimeout(() => {
-        post(action === "unstage" ? "/api/git-ui/unstage" : "/api/git-ui/stage", { cwd: view.cwd, paths });
+        post(action === "unstage" ? "/api/git-ui/unstage" : "/api/git-ui/stage", { cwd: view.cwd, paths }, action === "unstage" ? "Unstaging files" : "Staging files");
       }, 0);
     },
-    stageFile(path) { post("/api/git-ui/stage", { cwd: active().cwd, paths: [decodeURIComponent(path)] }); },
-    unstageFile(path) { post("/api/git-ui/unstage", { cwd: active().cwd, paths: [decodeURIComponent(path)] }); },
-    restoreFile(path) { if (confirm("Restore this file change?")) post("/api/git-ui/discard", { cwd: active().cwd, paths: [decodeURIComponent(path)], confirmed: true }); },
+    stageFile(path) { post("/api/git-ui/stage", { cwd: active().cwd, paths: [decodeURIComponent(path)] }, "Staging file"); },
+    unstageFile(path) { post("/api/git-ui/unstage", { cwd: active().cwd, paths: [decodeURIComponent(path)] }, "Unstaging file"); },
+    restoreFile(path) { if (confirm("Restore this file change?")) post("/api/git-ui/discard", { cwd: active().cwd, paths: [decodeURIComponent(path)], confirmed: true }, "Restoring file"); },
     restoreHunk(path, index) {
       path = decodeURIComponent(path);
       const view = active() || {};
       const staged = (view.diffScope || "all") === "staged";
       if (confirm(staged ? "Restore this staged hunk? This discards it from the index." : "Restore this hunk?")) applyHunk(path, index, staged ? { reverse: true, cached: true } : { reverse: true });
     },
-    discardFile(path) { path = decodeURIComponent(path); if (confirm(`Restore complete file ${path}? This discards staged and unstaged changes.`)) post("/api/git-ui/discard", { cwd: active().cwd, paths: [path], confirmed: true }); },
+    discardFile(path) { path = decodeURIComponent(path); if (confirm(`Restore complete file ${path}? This discards staged and unstaged changes.`)) post("/api/git-ui/discard", { cwd: active().cwd, paths: [path], confirmed: true }, "Restoring file"); },
     toggleBlame() { const view = active(); if (!view) return; view.showBlame = !view.showBlame; render(); },
     toggleDiffLayout() {
       setGitUiOption("gitUiDiffLayout", diffLayoutMode() === "unified" ? "side-by-side" : "unified");
@@ -2579,16 +2605,16 @@
     },
     unstageHunk(path, index) { path = decodeURIComponent(path); applyHunk(path, index, { reverse: true, cached: true }); },
     stageHunk(path, index) { path = decodeURIComponent(path); applyHunk(path, index, { cached: true }); },
-    discardSelected() { if (confirm("Discard selected working tree changes?")) post("/api/git-ui/discard", { cwd: active().cwd, paths: selectedPaths(), confirmed: true }); },
-    stash() { const message = prompt("Stash message", "herdr-webui stash"); if (message !== null) post("/api/git-ui/stash", { cwd: active().cwd, message }); },
+    discardSelected() { if (confirm("Discard selected working tree changes?")) post("/api/git-ui/discard", { cwd: active().cwd, paths: selectedPaths(), confirmed: true }, "Discarding changes"); },
+    stash() { const message = prompt("Stash message", "herdr-webui stash"); if (message !== null) post("/api/git-ui/stash", { cwd: active().cwd, message }, "Stashing"); },
     stashFile(path) {
       path = decodeURIComponent(path);
       if (!confirm(`Stash complete file ${path}?`)) return;
       const message = prompt(`Stash message for ${path}`, `herdr-webui stash ${path}`);
-      if (message !== null) post("/api/git-ui/stash", { cwd: active().cwd, message, paths: [path] });
+      if (message !== null) post("/api/git-ui/stash", { cwd: active().cwd, message, paths: [path] }, "Stashing file");
     },
-    applyStash(stash, pop) { post("/api/git-ui/stash-apply", { cwd: active().cwd, stash: decodeURIComponent(stash), pop }); },
-    dropStash(stash) { stash = decodeURIComponent(stash); if (confirm(`Drop ${stash}?`)) post("/api/git-ui/stash-drop", { cwd: active().cwd, stash, confirmed: true }); },
+    applyStash(stash, pop) { post("/api/git-ui/stash-apply", { cwd: active().cwd, stash: decodeURIComponent(stash), pop }, pop ? "Popping stash" : "Applying stash"); },
+    dropStash(stash) { stash = decodeURIComponent(stash); if (confirm(`Drop ${stash}?`)) post("/api/git-ui/stash-drop", { cwd: active().cwd, stash, confirmed: true }, "Dropping stash"); },
     async scanCleanup() {
       const view = active();
       if (!view) return;
@@ -2797,12 +2823,12 @@
       saveDraftFromDom();
       state.commitModal = null;
       try {
-        await postJson("/api/git-ui/commit", payload);
+        await postJson("/api/git-ui/commit", payload, "Committing");
         if (!pushAfter) {
           showCommitToast("Commit created");
           return;
         }
-        await postJson("/api/git-ui/push", { cwd: view.cwd, mode: "regular", push_tags: false });
+        await postJson("/api/git-ui/push", { cwd: view.cwd, mode: "regular", push_tags: false }, "Pushing");
         showCommitToast("Commit pushed");
       } catch (err) {
         if (pushAfter) state.gitOpModal = { type: "force-push", error: err.message || String(err) };
@@ -2834,7 +2860,7 @@
       const mode = (document.getElementById("gitUiOpMode") || {}).value || "regular";
       const branch = (document.getElementById("gitUiOpBranch") || {}).value || "";
       state.gitOpModal = null;
-      await postJson("/api/git-ui/pull", { cwd: view.cwd, mode, branch });
+      await postJson("/api/git-ui/pull", { cwd: view.cwd, mode, branch }, "Pulling");
     },
     async runPushFromModal() {
       const view = active();
@@ -2844,7 +2870,7 @@
       const pushTags = !!((document.getElementById("gitUiPushTags") || {}).checked);
       state.gitOpModal = null;
       try {
-        await postJson("/api/git-ui/push", { cwd: view.cwd, mode, branch, push_tags: pushTags });
+        await postJson("/api/git-ui/push", { cwd: view.cwd, mode, branch, push_tags: pushTags }, "Pushing");
       } catch (err) {
         state.gitOpModal = { type: "force-push", error: err.message || String(err) };
         render();
@@ -2860,14 +2886,14 @@
       if (!upstream) return;
       state.gitOpModal = null;
       try {
-        await postJson("/api/git-ui/rebase", { cwd: view.cwd, upstream, onto: branch, pull_first: pullFirst, confirmation: "rebase selected" });
+        await postJson("/api/git-ui/rebase", { cwd: view.cwd, upstream, onto: branch, pull_first: pullFirst, confirmation: "rebase selected" }, "Rebasing");
       } catch (err) {
         state.gitOpModal = Object.assign({}, modal, { type: "rebase", error: err.message || String(err) });
         render();
       }
     },
-    resolve(path, mode) { post("/api/git-ui/conflict-resolve", { cwd: active().cwd, path: decodeURIComponent(path), mode }); },
-    conflictAction(action) { post("/api/git-ui/conflict-action", { cwd: active().cwd, action }); },
+    resolve(path, mode) { post("/api/git-ui/conflict-resolve", { cwd: active().cwd, path: decodeURIComponent(path), mode }, "Resolving conflict"); },
+    conflictAction(action) { post("/api/git-ui/conflict-action", { cwd: active().cwd, action }, "Continuing operation"); },
     async openBranchModal() {
       const view = active();
       if (!view) return;
@@ -2928,8 +2954,8 @@
       const modalCwd = (input && input.value.trim()) || (state.branchModal && state.branchModal.cwd) || view.cwd;
       state.branchModal = null;
       view.cwd = modalCwd;
-      if (kind === "remote") post("/api/git-ui/switch", { cwd: view.cwd, branch: localNameForRemote(branch), create: true, base: branch });
-      else post("/api/git-ui/switch", { cwd: view.cwd, branch });
+      if (kind === "remote") post("/api/git-ui/switch", { cwd: view.cwd, branch: localNameForRemote(branch), create: true, base: branch }, "Switching branch");
+      else post("/api/git-ui/switch", { cwd: view.cwd, branch }, "Switching branch");
     },
     async compareCurrent() {
       if (currentMode() !== "changes") this.latestChanges();
@@ -3146,7 +3172,7 @@
       const mode = prompt("Mode: soft, mixed, hard", "soft");
       if (!mode) return;
       const confirmation = mode === "hard" ? prompt('Type "reset hard" to confirm') : "";
-      post("/api/git-ui/reset", { cwd: active().cwd, ref_name: ref, mode, confirmation });
+      post("/api/git-ui/reset", { cwd: active().cwd, ref_name: ref, mode, confirmation }, "Resetting");
     },
     rebase() { this.openGitOpModal("rebase"); },
     openSelectedResetModal() {
@@ -3165,7 +3191,7 @@
       const confirmation = mode === "hard" ? prompt(`Hard reset to ${label}. Type "reset hard" to confirm`) : (confirm(`Soft reset to ${label}?`) ? "" : null);
       if (confirmation === null) return;
       state.resetSelectedModal = null;
-      post("/api/git-ui/reset", { cwd: view.cwd, ref_name: ref, mode, confirmation });
+      post("/api/git-ui/reset", { cwd: view.cwd, ref_name: ref, mode, confirmation }, "Resetting");
     },
     openSelectedTagModal() {
       const view = active();
@@ -3181,7 +3207,7 @@
       const tag = ((document.getElementById("gitTagName") || {}).value || "").trim();
       if (!view || !ref || !tag) return;
       state.tagSelectedModal = null;
-      post("/api/git-ui/tag", { cwd: view.cwd, ref_name: ref, tag_name: tag });
+      post("/api/git-ui/tag", { cwd: view.cwd, ref_name: ref, tag_name: tag }, "Tagging");
     },
     async createWorktreeFromSelectedBranch() {
       const view = active();
@@ -3196,7 +3222,7 @@
       if (!view || !upstream) return;
       const confirmation = prompt(`Rebase commits after ${upstream.slice(0, 12)} onto main/master. Type "rebase selected" to confirm`);
       if (confirmation === null) return;
-      post("/api/git-ui/rebase", { cwd: view.cwd, upstream, confirmation });
+      post("/api/git-ui/rebase", { cwd: view.cwd, upstream, confirmation }, "Rebasing");
     },
   };
 })();

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -886,10 +886,11 @@
     if (state.visible) render();
   }
 
-  async function post(path, body) {
+  async function post(path, body, label) {
     const view = active();
     if (!view || view.mutating) return;
     view.mutating = true;
+    view.mutatingLabel = label || "";
     if (state.visible) render();
     try {
       await api(path, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
@@ -899,14 +900,16 @@
       if (state.visible) render();
     } finally {
       view.mutating = false;
+      view.mutatingLabel = "";
       if (state.visible) render();
     }
   }
 
-  async function postJson(path, body) {
+  async function postJson(path, body, label) {
     const view = active();
     if (!view || view.mutating) return null;
     view.mutating = true;
+    view.mutatingLabel = label || "";
     if (state.visible) render();
     try {
       const result = await api(path, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
@@ -918,6 +921,7 @@
       throw err;
     } finally {
       view.mutating = false;
+      view.mutatingLabel = "";
       if (state.visible) render();
     }
   }
@@ -1434,7 +1438,8 @@
       : "";
     const refreshButton = appRefreshIconButton({ className: "git-ui-refresh-icon", title: titleWithGitShortcut("Refresh", "refresh"), label: titleWithGitShortcut("Refresh Git state", "refresh"), spinning: !!view.refreshAnimating, onclick: "HerdrGitUi.refreshWithSpin()" });
     const aheadBehind = cleanupOnly ? "" : renderAheadBehind(s, esc);
-    return `<aside class="git-ui-side" onscroll="HerdrGitUi.sideScroll(this)"><div class="git-ui-head"><div class="git-ui-head-main"><div class="git-ui-title-row"><div class="git-ui-title">Git</div><div class="git-ui-title-actions">${returnToCurrentChanges}${returnToWorkspace}${refreshButton}</div></div><div class="git-ui-subtitle">${esc(s.state || "closed")} · ${esc(compactPath(s.repo_path))}</div><button class="git-ui-branch-pill" title="${esc(titleWithGitShortcut("Change Git directory or switch branch", "branch"))}" onclick="HerdrGitUi.openBranchModal()"><span>${esc(branchLabel)}</span>${aheadBehind}<b>↗</b></button></div></div>${error}<div class="git-ui-toolbar git-ui-view-toolbar">${renderGitViewTabs(tabs, view.tab)}</div>${actions}${fileList}${sideBottom}</aside>`;
+    const busy = view.mutating ? `<span class="git-ui-busy"><span class="git-ui-busy-spinner"></span>${esc(view.mutatingLabel || "Working...")}</span>` : "";
+    return `<aside class="git-ui-side" onscroll="HerdrGitUi.sideScroll(this)"><div class="git-ui-head"><div class="git-ui-head-main"><div class="git-ui-title-row"><div class="git-ui-title">Git</div><div class="git-ui-title-actions">${busy}${returnToCurrentChanges}${returnToWorkspace}${refreshButton}</div></div><div class="git-ui-subtitle">${esc(s.state || "closed")} · ${esc(compactPath(s.repo_path))}</div><button class="git-ui-branch-pill" title="${esc(titleWithGitShortcut("Change Git directory or switch branch", "branch"))}" onclick="HerdrGitUi.openBranchModal()"><span>${esc(branchLabel)}</span>${aheadBehind}<b>↗</b></button></div></div>${error}<div class="git-ui-toolbar git-ui-view-toolbar">${renderGitViewTabs(tabs, view.tab)}</div>${actions}${fileList}${sideBottom}</aside>`;
   }
 
   function renderDiffLayoutSideToggle(view) {
@@ -1569,10 +1574,16 @@
       const oldLines = [];
       const newLines = [];
       const newNumbers = [];
+      const oldLineTypes = [];
+      const newLineTypes = [];
       for (const line of chunk.lines || []) {
-        if (line.line_type !== "add") oldLines.push(line.content || "");
+        if (line.line_type !== "add") {
+          oldLines.push(line.content || "");
+          oldLineTypes.push(line.line_type === "delete" ? "del" : "context");
+        }
         if (line.line_type !== "delete") {
           newLines.push(line.content || "");
+          newLineTypes.push(line.line_type === "add" ? "add" : "context");
           if (line.new_line_number) newNumbers.push(line.new_line_number);
         }
       }
@@ -1581,10 +1592,27 @@
         header: chunk.header,
         oldText: oldLines.join("\n"),
         text: newLines.join("\n"),
+        oldLineTypes,
+        newLineTypes,
         newStart: newNumbers.length ? Math.min.apply(null, newNumbers) : 0,
         newEnd: newNumbers.length ? Math.max.apply(null, newNumbers) : 0,
       };
     });
+  }
+
+  function sideEditorLineHunks(hunk, side) {
+    const types = side === "old" ? (hunk.oldLineTypes || []) : (hunk.newLineTypes || []);
+    const kind = side === "old" ? "del" : "add";
+    const result = [];
+    let i = 0;
+    while (i < types.length) {
+      if (types[i] !== kind) { i++; continue; }
+      let j = i;
+      while (j < types.length && types[j] === kind) j++;
+      result.push({ id: hunk.index + "-" + side + "-" + i, header: hunk.header, fromLine: i + 1, toLine: j, type: kind, kind: kind });
+      i = j;
+    }
+    return result;
   }
 
   function renderDiffFile(file) {
@@ -2178,12 +2206,16 @@
       const sourceClass = side === "old" ? "git-ui-hunk-old-hidden" : "git-ui-hunk-current-hidden";
       const textarea = document.querySelector(`.${sourceClass}[data-hunk-index="${index}"]`);
       if (!textarea) return;
+      const hunk = ((view.sideEditor || {}).hunks || [])[index];
+      const lineHunks = hunk ? sideEditorLineHunks(hunk, side) : [];
       window.HerdrEditor.create({
         parent: mount,
         path: view.file || view.sideEditor.path || "",
         content: textarea.value,
         readonly: mount.dataset.readonly === "true",
         hideFind: true,
+        hunks: lineHunks,
+        hunkActions: [],
         onChange: side === "old" ? null : function (value) { textarea.value = value; },
       });
     });

--- a/src/assets/desktop/git_ui/diff.css
+++ b/src/assets/desktop/git_ui/diff.css
@@ -67,7 +67,6 @@
 }
 .git-ui-hunk-old-mount .cm-content,
 .git-ui-hunk-old-mount .herdr-editor-code {
-  background: rgba(248, 81, 73, 0.1);
   border-left: 4px solid #da3633;
 }
 .git-ui-hunk-old-mount .cm-scroller {
@@ -79,8 +78,18 @@
 }
 .git-ui-hunk-current-mount .cm-content,
 .git-ui-hunk-current-mount .herdr-editor-code {
-  background: rgba(46, 160, 67, 0.1);
   border-left: 4px solid #1b7c3d;
+}
+.git-ui-hunk-old-mount .cm-herdr-hunk-del,
+.git-ui-hunk-current-mount .cm-herdr-hunk-del {
+  background: rgba(248, 81, 73, 0.14);
+}
+.git-ui-hunk-old-mount .cm-herdr-hunk-add,
+.git-ui-hunk-current-mount .cm-herdr-hunk-add {
+  background: rgba(46, 160, 67, 0.14);
+}
+.git-ui-hunk-edit-mount .cm-herdr-hunk-actions {
+  display: none;
 }
 .git-ui-split-editor {
   display: grid;

--- a/src/assets/desktop/git_ui/diff.css
+++ b/src/assets/desktop/git_ui/diff.css
@@ -364,8 +364,9 @@
 }
 .git-ui-unified-text {
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: pre;
 }
 .git-ui-context-cell {
   background: var(--panel);
@@ -448,7 +449,8 @@
 }
 .git-ui-code {
   min-width: 0;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   padding: 1px 8px;
   white-space: pre;
 }

--- a/src/assets/desktop/git_ui/layout.css
+++ b/src/assets/desktop/git_ui/layout.css
@@ -161,6 +161,36 @@
   border: 1px solid color-mix(in srgb, var(--muted) 40%, var(--border2));
   color: var(--muted);
 }
+.git-ui-busy {
+  align-items: center;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 50%, var(--border2));
+  border-radius: 999px;
+  color: var(--accent);
+  display: inline-flex;
+  font-size: 11px;
+  font-weight: 600;
+  gap: 6px;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+.git-ui-busy-spinner {
+  animation: git-ui-busy-spin 0.8s linear infinite;
+  border: 2px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-radius: 50%;
+  border-top-color: var(--accent);
+  display: inline-block;
+  flex: none;
+  height: 11px;
+  width: 11px;
+}
+@keyframes git-ui-busy-spin {
+  to { transform: rotate(360deg); }
+}
+.git-ui-panel.mutating .git-ui-btn {
+  cursor: progress;
+  opacity: 0.85;
+}
 .git-ui-tabs,
 .git-ui-actions {
   display: flex;

--- a/src/assets/desktop/git_ui/layout.css
+++ b/src/assets/desktop/git_ui/layout.css
@@ -128,6 +128,39 @@
 .git-ui-branch-pill:hover {
   background: rgba(56, 139, 253, 0.2);
 }
+.git-ui-ahead-behind-group {
+  align-items: center;
+  display: inline-flex;
+  flex: none;
+  gap: 3px;
+  margin-left: 2px;
+}
+.git-ui-ahead-behind {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 10px;
+  font-weight: 800;
+  gap: 1px;
+  line-height: 1;
+  padding: 1px 5px;
+  white-space: nowrap;
+}
+.git-ui-ahead-behind.ahead {
+  background: color-mix(in srgb, #34d399 18%, transparent);
+  border: 1px solid color-mix(in srgb, #34d399 60%, var(--border2));
+  color: #34d399;
+}
+.git-ui-ahead-behind.behind {
+  background: color-mix(in srgb, #fbbf24 18%, transparent);
+  border: 1px solid color-mix(in srgb, #fbbf24 60%, var(--border2));
+  color: #fbbf24;
+}
+.git-ui-ahead-behind.synced {
+  background: color-mix(in srgb, var(--muted) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--muted) 40%, var(--border2));
+  color: var(--muted);
+}
 .git-ui-tabs,
 .git-ui-actions {
   display: flex;

--- a/src/assets/desktop/git_ui/log.css
+++ b/src/assets/desktop/git_ui/log.css
@@ -326,11 +326,51 @@
   color: color-mix(in srgb, #3b82f6 70%, var(--fg));
   font-weight: 700;
 }
+.git-ui-log-ref.origin {
+  --lane: #f59e0b;
+  background: color-mix(in srgb, #f59e0b 14%, transparent);
+  border: 1px solid color-mix(in srgb, #f59e0b 60%, var(--border2));
+  color: color-mix(in srgb, #f59e0b 72%, var(--fg));
+  font-weight: 700;
+}
 .git-ui-log-ref.current {
   --lane: #ef4444;
   background: color-mix(in srgb, #ef4444 24%, transparent);
   border-color: color-mix(in srgb, #ef4444 72%, var(--border2));
   color: color-mix(in srgb, #ef4444 68%, var(--fg));
+}
+.git-ui-log-ref.remote {
+  --lane: var(--muted);
+  background: color-mix(in srgb, var(--muted) 10%, transparent);
+  border-color: color-mix(in srgb, var(--muted) 45%, var(--border2));
+  color: color-mix(in srgb, var(--muted) 70%, var(--fg));
+}
+.git-ui-log-dot.origin {
+  background: color-mix(in srgb, #f59e0b 22%, var(--bg));
+  border: 2px solid #f59e0b;
+  box-shadow: 0 0 0 3px color-mix(in srgb, #f59e0b 22%, transparent);
+  height: 11px;
+  width: 11px;
+}
+.git-ui-log-dot.head {
+  background: var(--lane, #ef4444);
+  border: 2px solid var(--lane, #ef4444);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--lane, #ef4444) 30%, transparent),
+    0 0 8px color-mix(in srgb, var(--lane, #ef4444) 60%, transparent);
+  height: 13px;
+  width: 13px;
+}
+.git-ui-log-row.origin-tip .git-ui-log-title {
+  color: color-mix(in srgb, #f59e0b 70%, var(--fg));
+  font-weight: 700;
+}
+.git-ui-log-row.origin-tip {
+  box-shadow: inset 3px 0 0 #f59e0b;
+}
+.git-ui-log-row.current .git-ui-log-title {
+  color: var(--accent);
+  font-weight: 700;
 }
 .git-ui-log-hover-card {
   background: var(--panel);

--- a/src/assets/desktop/git_ui/log.js
+++ b/src/assets/desktop/git_ui/log.js
@@ -23,14 +23,32 @@
     const baseBranch = options.baseBranch || "master";
     const logScope = normalizeLogScope(options.logScope || (options.logAll ? "all" : "base-current"));
     const esc = options.esc;
+    const upstreamRef = upstreamRefFromStatus(options.status || {});
     const fileScope = options.filePath ? `<span class="git-ui-log-file-scope" title="File history filter">${esc(options.filePath)}</span><button class="git-ui-btn" onclick="HerdrGitUi.clearLogFileHistory()">Clear file</button>` : "";
     const scope = `<div class="git-ui-log-scope-head"><span class="git-ui-toolbar-title">History scope</span><button class="git-ui-btn active" title="Toggle history scope: All, ${esc(baseBranch)} + branch, ${esc(baseBranch)}" onclick="HerdrGitUi.cycleLogScope()">${esc(logScopeLabel(logScope, baseBranch))}</button>${fileScope}${options.actionsHtml || ""}</div>`;
     const header = `<div class="git-ui-log-table-head"><span>Graph</span><span>Description</span><span>Date</span><span>Author</span></div>${renderFilterRow(filters, esc)}`;
+    const renderOptions = Object.assign({}, options, { upstreamRef });
     const body = rows.length
-      ? rows.map((row) => renderRow(row, selected, filters, options, baseBranch)).join("")
+      ? rows.map((row) => renderRow(row, selected, filters, renderOptions, baseBranch)).join("")
       : `<div class="git-ui-empty-row">No commits found.</div>`;
     const footer = renderLoadMore(options.data || {}, rows, options, esc);
     return `${scope}<div class="git-ui-log git-ui-log-table">${header}${body}${footer}</div>`;
+  }
+
+  function upstreamRefFromStatus(status) {
+    if (!status) return "";
+    const upstream = String(status.upstream || "").trim();
+    if (!upstream) return "";
+    if (upstream.startsWith("refs/remotes/")) return upstream.replace(/^refs\/remotes\//, "");
+    if (upstream.includes("/")) return upstream;
+    return `origin/${upstream}`;
+  }
+
+  function isUpstreamTip(row, upstreamRef) {
+    if (!upstreamRef || !row || !Array.isArray(row.labels)) return false;
+    const labels = row.labels.map(normalizeLabel);
+    if (row.current || labels.some((label) => label === "HEAD" || label.startsWith("HEAD -> "))) return false;
+    return labels.includes(upstreamRef);
   }
 
   function renderLoadMore(data, rows, options, esc) {
@@ -108,7 +126,9 @@
     const hash = String(row.hash || "");
     const selectedClass = hash && selected.includes(hash) ? " selected" : "";
     const graphOnly = hash ? "" : " graph-only";
-    const currentClass = row.current ? " current" : "";
+    const isCurrent = row.current || (Array.isArray(row.labels) && row.labels.some((label) => normalizeLabel(label) === "HEAD" || normalizeLabel(label).startsWith("HEAD -> ")));
+    const currentClass = isCurrent ? " current" : "";
+    const upstreamTip = isUpstreamTip(row, options.upstreamRef) ? " origin-tip" : "";
     const lane = Number.isFinite(Number(row.lane)) ? Number(row.lane) : graphLane(row.graph);
     const color = laneColor(lane);
     const title = row.title || row.message || "";
@@ -117,7 +137,7 @@
     const click = hash ? ` onclick="HerdrGitUi.selectLogCommit(event,'${arg(hash)}')"` : "";
     const hover = renderHover(row, color, esc, baseBranch);
     const tooltip = hoverText(row);
-    return `<div class="git-ui-log-row${selectedClass}${graphOnly}${currentClass}${hidden}" data-log-hash="${esc(hash)}" data-log-filter-description="${esc(filterText.description)}" data-log-filter-date="${esc(filterText.date)}" data-log-filter-author="${esc(filterText.author)}" style="--lane:${color}" title="${esc(tooltip)}"${click}>${renderGraph(row.graph, !!hash)}<span class="git-ui-log-desc">${renderLabels(row.labels || [], row.current, esc, baseBranch)}<span class="git-ui-log-title">${esc(title)}</span></span><span class="git-ui-log-date">${esc(row.date || "")}</span><span class="git-ui-log-author">${esc(row.author || "")}</span>${hover}</div>`;
+    return `<div class="git-ui-log-row${selectedClass}${graphOnly}${currentClass}${upstreamTip}${hidden}" data-log-hash="${esc(hash)}" data-log-filter-description="${esc(filterText.description)}" data-log-filter-date="${esc(filterText.date)}" data-log-filter-author="${esc(filterText.author)}" style="--lane:${color}" title="${esc(tooltip)}"${click}>${renderGraph(row.graph, !!hash, upstreamTip, isCurrent)}<span class="git-ui-log-desc">${renderLabels(row.labels || [], row.current, esc, baseBranch)}<span class="git-ui-log-title">${esc(title)}</span></span><span class="git-ui-log-date">${esc(row.date || "")}</span><span class="git-ui-log-author">${esc(row.author || "")}</span>${hover}</div>`;
   }
 
   function renderHover(row, color, esc, baseBranch) {
@@ -189,6 +209,7 @@
     if (label === "HEAD" || label.startsWith("HEAD -> ")) return "current";
     if (label === base || label === `origin/${base}` || label === "main" || label === "origin/main" || label === "master" || label === "origin/master") return "main";
     if (label.startsWith("tag:")) return "tag";
+    if (label.startsWith("origin/") && label !== "origin/HEAD") return "origin";
     if (label.includes("/")) return "remote";
     return "branch";
   }
@@ -220,8 +241,12 @@
     return labelKind(label, false, baseBranch) !== "tag";
   }
 
-  function renderGraph(graph, hasCommit) {
+  function renderGraph(graph, hasCommit, upstreamTip, isCurrent) {
     const chars = String(graph || "* ").split("");
+    const dotClasses = ["git-ui-log-dot"];
+    if (upstreamTip) dotClasses.push("origin");
+    if (isCurrent) dotClasses.push("head");
+    const dotClass = ` class="${dotClasses.join(" ")}"`;
     const cells = [];
     for (let i = 0; i < Math.min(chars.length, 24); i++) {
       const ch = chars[i];
@@ -229,7 +254,7 @@
       let mark = "";
       if (ch === "*") {
         cls += " commit";
-        mark = '<i class="git-ui-log-dot"></i>';
+        mark = `<i${dotClass}></i>`;
       } else if (ch === "|") cls += " vertical";
       else if (ch === "/") cls += " merge-left";
       else if (ch === "\\") cls += " merge-right";
@@ -237,7 +262,7 @@
       cells.push(`<span class="${cls}" style="--lane:${laneColor(i)}">${mark}</span>`);
     }
     if (hasCommit && !String(graph || "").includes("*")) {
-      cells.unshift('<span class="git-ui-lane commit" style="--lane:var(--accent)"><i class="git-ui-log-dot"></i></span>');
+      cells.unshift(`<span class="git-ui-lane commit" style="--lane:var(--accent)"><i${dotClass}></i></span>`);
     }
     return `<span class="git-ui-log-graph" aria-hidden="true">${cells.join("")}</span>`;
   }

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -165,7 +165,24 @@
     }
 
     function tempTerminalKeydown(event) {
-      if (!isOpen || isMinimized || confirmVisible) return;
+      if (!isOpen) return;
+      // Never let Backspace trigger browser "back" navigation or Tab steal focus
+      // while the temp terminal is open, even if a confirm/minimized state would
+      // otherwise drop the event. These two keys are the reported focus-loss bug.
+      var key = String(event.key || "");
+      if (key === "Backspace" && !event.metaKey && !event.altKey && !event.ctrlKey) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        if (!isMinimized && !confirmVisible && term) sendInput("\x7f");
+        return;
+      }
+      if (key === "Tab" && !event.metaKey && !event.altKey && !event.ctrlKey) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        if (!isMinimized && !confirmVisible && term) sendInput(event.shiftKey ? "\x1b[Z" : "\t");
+        return;
+      }
+      if (isMinimized || confirmVisible) return;
       if (event.ctrlKey && !event.altKey && !event.metaKey && String(event.key || "").toLowerCase() === "g") {
         event.preventDefault();
         event.stopImmediatePropagation();
@@ -376,6 +393,19 @@
       term.open(container);
       term.onData(function (data) { sendInput(data); });
       try { term.focus(); } catch (e) {}
+      // xterm can blur its helper textarea during resize/write; re-grab focus
+      // synchronously so Backspace/Tab never fall through to the background.
+      var helperTextarea = term.textarea;
+      if (helperTextarea && helperTextarea.addEventListener) {
+        helperTextarea.addEventListener("blur", function () {
+          if (!isOpen || isMinimized || confirmVisible || closing) return;
+          // Don't steal focus back from the close-confirm buttons.
+          var active = document.activeElement;
+          if (active && isCloseControl(active)) return;
+          if (active && active.closest && active.closest(".temp-terminal-confirm")) return;
+          try { term.focus(); } catch (e) {}
+        }, true);
+      }
       refreshTerminalFitAfterFontLoad();
     }
 
@@ -611,6 +641,7 @@
             termWs.send(JSON.stringify({ type: "resize", cols: cols, rows: rows }));
           } catch (e) {}
         }
+        if (!confirmVisible) { try { term.focus(); } catch (e) {} }
       }, 100);
     }
 


### PR DESCRIPTION
## Summary

Fixes six bugs in the herdr-webui Git UI and panel management:

1. **Panel selection breaks after creating a new panel** —  scoped tab ids as `ws:id` but the backend returns unscoped `tab_N`. Made `expandScopedId`/`compactScopedId` identity on desktop so ids stay raw end-to-end. Mobile untouched.

2. **No git operation progress indicator** — `post`/`postJson` now accept a human label, stored as `view.mutatingLabel` and rendered as a spinner chip in the Git toolbar. All ~20 callers wired (Stage/Commit/Pull/Push/Rebase/Reset/Discard/Stash/Switch/Tag/Resolve).

3. **No local/origin branch position indicators in git log** — Added ahead/behind badges (green ↑N / orange ↓N / ✓ synced) in the branch pill. Origin tip marked with amber dot and left border in the log graph.

4. **No horizontal scroll for wide-file diffs** — Changed `.git-ui-code`/`.git-ui-unified-text` from `overflow:hidden` to `overflow-x:auto`. Added `bindDiffScrollSync()` to mirror `scrollLeft` between old/new code cells.

5. **Side-by-side edit mode inconsistent with read-only compare** — Replaced whole-hunk red/green background tint with per-line CodeMirror decorations (`cm-herdr-hunk-del`/`cm-herdr-hunk-add`) via the existing `hunks` option. Action bar hidden inside side editor mounts.

6. **Temp terminal loses focus on Backspace/Tab** — Backspace/Tab always intercepted in capture phase when modal is open (prevents browser back-nav and focus stealing). Added blur re-focus listener on xterm textarea and re-focus after resize.

## Test results

- 182 JS tests pass (app_load + mobile_load + temp_terminal + app_core)
- 36 Rust tests pass
- `cargo check --tests` clean
- `node --check` passes on all edited JS files

## Files changed

- `src/assets/desktop/app_js/core.js` — panel id scoping fix
- `src/assets/desktop/git_ui.js` — busy indicator, scroll sync, ahead/behind, side editor tinting
- `src/assets/desktop/git_ui/diff.css` — horizontal scroll, per-line tints
- `src/assets/desktop/git_ui/layout.css` — busy spinner + ahead/behind CSS
- `src/assets/desktop/git_ui/log.js` — origin label kind, upstream tip detection
- `src/assets/desktop/git_ui/log.css` — origin/head dot styles
- `src/assets/shared/temp_terminal.js` — focus hardening for Backspace/Tab