### PR TITLE
Make diff horizontal scroll file-level instead of per-line

### DIFF
--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -671,31 +671,6 @@
     return `.../${parts.slice(-3).join("/")}`;
   }
 
-  let diffScrollSyncBound = false;
-  function bindDiffScrollSync() {
-    if (diffScrollSyncBound) return;
-    diffScrollSyncBound = true;
-    // Mirror horizontal scroll between the old/new code cells of a side-by-side
-    // diff row so wide lines stay aligned. Each cell scrolls on its own
-    // (overflow-x: auto in diff.css); this keeps the two sides in lockstep.
-    document.addEventListener("scroll", function (event) {
-      const node = event.target;
-      if (!node || !node.classList || !node.classList.contains("git-ui-code")) return;
-      const row = node.closest && node.closest(".git-ui-diff-row");
-      if (!row) return;
-      if (node._syncingScroll) return;
-      const others = row.querySelectorAll(".git-ui-code");
-      for (const other of others) {
-        if (other === node) continue;
-        if (other.scrollLeft === node.scrollLeft) continue;
-        other._syncingScroll = true;
-        other.scrollLeft = node.scrollLeft;
-        // clear the flag next tick so the mirrored scroll event can fire
-        setTimeout(() => { other._syncingScroll = false; }, 0);
-      }
-    }, true);
-  }
-
   function ensurePanel() {
     let panel = document.getElementById("gitUiPanel");
     if (panel) return panel;
@@ -706,7 +681,6 @@
     panel.tabIndex = -1;
     panel.style.display = "none";
     if (shell && shell.parentNode) shell.parentNode.appendChild(panel);
-    bindDiffScrollSync();
     return panel;
   }
 
@@ -1734,7 +1708,7 @@
     const body = diffLayoutMode() === "unified"
       ? rows.map((row, rowIndex) => renderUnifiedLine(row, path, index, rows, rowIndex, contextArrows)).join("")
       : rows.map((row, rowIndex) => renderLine(row, path, index, rows, rowIndex, contextArrows, !!file.preview_large_diff)).join("");
-    return `<div class="git-ui-hunk ${diffLayoutMode() === "unified" ? "git-ui-hunk-unified" : ""}"><div class="git-ui-hunk-head"><span>${esc(chunk.header)}</span>${actions}</div>${body}</div>`;
+    return `<div class="git-ui-hunk ${diffLayoutMode() === "unified" ? "git-ui-hunk-unified" : ""}"><div class="git-ui-hunk-head"><span>${esc(chunk.header)}</span>${actions}</div><div class="git-ui-hunk-scroll">${body}</div></div>`;
   }
 
   function contextArrowsForChunk(chunks, index) {

--- a/src/assets/desktop/git_ui/diff.css
+++ b/src/assets/desktop/git_ui/diff.css
@@ -319,19 +319,27 @@
   border-right: 1px solid var(--border);
   border-top: 1px solid var(--border);
 }
+.git-ui-hunk-scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
 .git-ui-diff-row {
   display: grid;
-  grid-template-columns: 26px minmax(0, 1fr) 132px minmax(0, 1fr);
+  grid-template-columns: 26px min-content 132px min-content;
   font-family: var(--mono-font);
   font-size: 12px;
   line-height: 1.45;
+  width: max-content;
+  min-width: 100%;
 }
 .git-ui-unified-row {
   display: grid;
-  grid-template-columns: 26px 74px 34px minmax(0, 1fr);
+  grid-template-columns: 26px 74px 34px min-content;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
   line-height: 1.45;
+  width: max-content;
+  min-width: 100%;
 }
 .git-ui-unified-lines {
   background: var(--panel);
@@ -372,9 +380,6 @@
   user-select: none;
 }
 .git-ui-unified-text {
-  min-width: 0;
-  overflow-x: auto;
-  overflow-y: hidden;
   white-space: pre;
 }
 .git-ui-context-cell {
@@ -457,9 +462,6 @@
   color: var(--accent);
 }
 .git-ui-code {
-  min-width: 0;
-  overflow-x: auto;
-  overflow-y: hidden;
   padding: 1px 8px;
   white-space: pre;
 }


### PR DESCRIPTION
Each diff line scrolled independently (overflow-x: auto on each code cell). Move scroll to the hunk level so all rows in a hunk scroll together. Code columns use min-content so they expand to fit the widest line, and a .git-ui-hunk-scroll wrapper with overflow-x: auto clips the overflow. Removes the per-cell scroll sync listener since both sides scroll together naturally now.