### PR TITLE
Terminal fixes: text selection, height fill, scroll-follow

### DIFF
--- a/src/assets/app.html
+++ b/src/assets/app.html
@@ -125,6 +125,7 @@
           </div>
         </div>
         <div class="temp-terminal-body">
+          <button class="terminal-follow-button temp-terminal-follow" id="tempTerminalFollowButton" type="button" hidden title="Go to latest terminal output and resume follow" aria-label="Go to latest terminal output and resume follow">↓ Tail</button>
           <div class="terminal" id="tempTerminal"></div>
         </div>
       </div>

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -939,7 +939,7 @@ describe("app bundle load", () => {
     match(tempTerminalSource, /function waitForTerminalFit\(container, attempt, callback\)/);
     match(tempTerminalSource, /HerdrTerminalFit\.gridSize\(container, term/);
     match(tempTerminalSource, /HerdrTerminalFit\.cellSize\(term, container/);
-    match(tempTerminalSource, /HerdrTerminalFit\.fitTerminalToContainer\(container, \{ height: box\.height \}\)/);
+    match(tempTerminalSource, /HerdrTerminalFit\.fitTerminalToContainer\(termEl, \{ height: box\.height \}\)/);
     match(terminalFitSource, /function cellSize\(term, container, fallback\)/);
     match(terminalFitSource, /function gridSize\(container, term, options\)/);
     match(terminalFitSource, /function fitTerminalToContainer\(container, options\)/);

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -937,7 +937,7 @@ describe("app bundle load", () => {
     match(tempTerminalSource, /function connectTerminalWsAfterLayout\(terminalId, attempt\)/);
     match(tempTerminalSource, /ensureTerminalSurface\(container\)/);
     match(tempTerminalSource, /function waitForTerminalFit\(container, attempt, callback\)/);
-    match(tempTerminalSource, /HerdrTerminalFit\.gridSize\(container, term/);
+    match(tempTerminalSource, /HerdrTerminalFit\.gridSize\(measureTarget, term/);
     match(tempTerminalSource, /HerdrTerminalFit\.cellSize\(term, container/);
     match(tempTerminalSource, /HerdrTerminalFit\.fitTerminalToContainer\(termEl, \{ height: box\.height \}\)/);
     match(terminalFitSource, /function cellSize\(term, container, fallback\)/);

--- a/src/assets/desktop/app_css/modals.css
+++ b/src/assets/desktop/app_css/modals.css
@@ -261,6 +261,11 @@
 .temp-terminal-modal {
   position: relative;
 }
+.temp-terminal-follow {
+  bottom: 14px;
+  right: 14px;
+  z-index: 10;
+}
 .temp-terminal-confirm {
   position: absolute;
   inset: 0;

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -152,9 +152,26 @@ async function connectTerminal() {
       true,
     );
     const shell = el("terminalShell");
-    shell.addEventListener("mousedown", () =>
-      setTimeout(focusTerminal, 0),
-    );
+    shell.addEventListener("mousedown", (e) => {
+      // Only shift focus to the terminal on a simple click, not a text
+      // selection drag. Calling textarea.focus() on the next tick
+      // collapses the native DOM selection, making it impossible to
+      // select terminal text for copying.
+      if (e.button !== 0 || e.shiftKey) return;
+      const startX = e.clientX, startY = e.clientY;
+      let dragged = false;
+      const onMove = (ev) => {
+        if (Math.abs(ev.clientX - startX) > 3 || Math.abs(ev.clientY - startY) > 3)
+          dragged = true;
+      };
+      const onUp = () => {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+        if (!dragged) focusTerminal();
+      };
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+    });
     terminal.addEventListener("wheel", handleTerminalWheel, { passive: false, capture: true });
     terminal.addEventListener("touchstart", handleTerminalTouchStart, { passive: true, capture: true });
     terminal.addEventListener("touchmove", handleTerminalTouchMove, { passive: false, capture: true });

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -152,26 +152,11 @@ async function connectTerminal() {
       true,
     );
     const shell = el("terminalShell");
-    shell.addEventListener("mousedown", (e) => {
-      // Only shift focus to the terminal on a simple click, not a text
-      // selection drag. Calling textarea.focus() on the next tick
-      // collapses the native DOM selection, making it impossible to
-      // select terminal text for copying.
-      if (e.button !== 0 || e.shiftKey) return;
-      const startX = e.clientX, startY = e.clientY;
-      let dragged = false;
-      const onMove = (ev) => {
-        if (Math.abs(ev.clientX - startX) > 3 || Math.abs(ev.clientY - startY) > 3)
-          dragged = true;
-      };
-      const onUp = () => {
-        document.removeEventListener("mousemove", onMove);
-        document.removeEventListener("mouseup", onUp);
-        if (!dragged) focusTerminal();
-      };
-      document.addEventListener("mousemove", onMove);
-      document.addEventListener("mouseup", onUp);
-    });
+    if (window.HerdrTerminalRenderer && window.HerdrTerminalRenderer.attachClickFocus) {
+      window.HerdrTerminalRenderer.attachClickFocus(shell, focusTerminal);
+    } else {
+      shell.addEventListener("mousedown", () => setTimeout(focusTerminal, 0));
+    }
     terminal.addEventListener("wheel", handleTerminalWheel, { passive: false, capture: true });
     terminal.addEventListener("touchstart", handleTerminalTouchStart, { passive: true, capture: true });
     terminal.addEventListener("touchmove", handleTerminalTouchMove, { passive: false, capture: true });

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -1027,6 +1027,11 @@ body.mobile-keyboard-open .mobile-screen.terminal-active .mobile-tabs {
 .temp-terminal-modal {
   position: relative;
 }
+.temp-terminal-follow {
+  bottom: 14px;
+  right: 14px;
+  z-index: 10;
+}
 .temp-terminal-confirm {
   position: absolute;
   inset: 0;

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -330,6 +330,7 @@
             </div>
           </div>
           <div class="temp-terminal-body">
+            <button class="terminal-follow-button temp-terminal-follow" id="tempTerminalFollowButton" type="button" hidden title="Go to latest terminal output and resume follow" aria-label="Go to latest terminal output and resume follow">↓ Tail</button>
             <div class="terminal" id="tempTerminal"></div>
           </div>
         </div>

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -714,7 +714,9 @@
 
     function fitTerminalDomToContainer(container) {
       var box = HerdrTerminalFit.visibleBox(container, { width: 0, height: 0 }) || { width: 0, height: 0 };
-      HerdrTerminalFit.fitTerminalToContainer(container, { height: box.height });
+      var termEl = term && term.element ? term.element : container.querySelector && container.querySelector(".wterm");
+      if (!termEl) termEl = container;
+      HerdrTerminalFit.fitTerminalToContainer(termEl, { height: box.height });
     }
 
     return { open: open, requestClose: requestClose, close: close, minimize: minimize, restore: restore, isVisible: isVisible, handleResize: handleResize, handlePaneExited: handlePaneExited };

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -154,7 +154,15 @@
       document.addEventListener("keydown", tempTerminalKeydown, true);
       var modal = el(modalId);
       if (modal) {
-        modal.addEventListener("pointerdown", focusTerminalFromEvent, true);
+        if (window.HerdrTerminalRenderer && window.HerdrTerminalRenderer.attachClickFocus) {
+          window.HerdrTerminalRenderer.attachClickFocus(
+            modal,
+            focusTerminalSoon,
+            function (event) { return isCloseControl(event && event.target); }
+          );
+        } else {
+          modal.addEventListener("pointerdown", focusTerminalFromEvent, true);
+        }
         modal.addEventListener("focusin", focusTerminalFromEvent, true);
       }
     }
@@ -165,7 +173,9 @@
       document.removeEventListener("keydown", tempTerminalKeydown, true);
       var modal = el(modalId);
       if (modal) {
-        modal.removeEventListener("pointerdown", focusTerminalFromEvent, true);
+        if (!window.HerdrTerminalRenderer || !window.HerdrTerminalRenderer.attachClickFocus) {
+          modal.removeEventListener("pointerdown", focusTerminalFromEvent, true);
+        }
         modal.removeEventListener("focusin", focusTerminalFromEvent, true);
       }
     }

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -394,7 +394,10 @@
     }
 
     function terminalGridSize(container) {
-      return HerdrTerminalFit.gridSize(container, term, {
+      // Measure the parent (.temp-terminal-body) for available space, since
+      // wterm sets a fixed inline height on container (term.element).
+      var measureTarget = container.parentElement || container;
+      return HerdrTerminalFit.gridSize(measureTarget, term, {
         fallbackWidth: 720,
         fallbackHeight: 420,
         fallbackCell: { width: 9, height: 20 },
@@ -471,7 +474,8 @@
     }
 
     function terminalFitReady(container, size) {
-      var box = HerdrTerminalFit.visibleBox(container, { width: 0, height: 0 }) || { width: 0, height: 0 };
+      var measureTarget = container.parentElement || container;
+      var box = HerdrTerminalFit.visibleBox(measureTarget, { width: 0, height: 0 }) || { width: 0, height: 0 };
       var cell = HerdrTerminalFit.cellSize(term, container, { width: 9, height: 20 });
       return box.width >= 320 && box.height >= 120 && cell.width >= 4 && cell.height >= 8 && size.cols >= 40;
     }
@@ -723,7 +727,13 @@
     }
 
     function fitTerminalDomToContainer(container) {
-      var box = HerdrTerminalFit.visibleBox(container, { width: 0, height: 0 }) || { width: 0, height: 0 };
+      // wterm's _lockHeight() sets a fixed inline pixel height on the terminal
+      // element (container == term.element). Measuring container.clientHeight
+      // returns that locked height, not the available space. Measure the parent
+      // (.temp-terminal-body) instead, then apply the available height to the
+      // terminal element so it fills the full vertical space.
+      var parent = container.parentElement;
+      var box = HerdrTerminalFit.visibleBox(parent || container, { width: 0, height: 0 }) || { width: 0, height: 0 };
       var termEl = term && term.element ? term.element : container.querySelector && container.querySelector(".wterm");
       if (!termEl) termEl = container;
       HerdrTerminalFit.fitTerminalToContainer(termEl, { height: box.height });

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -240,6 +240,25 @@
 
     function focusTerminalFromEvent(event) {
       if (isCloseControl(event && event.target)) return;
+      // Don't steal focus during text selection drag. pointerdown fires
+      // before the user starts dragging; focusing the hidden textarea on
+      // the next tick collapses the native DOM selection.
+      if (event.type === "pointerdown" && event.button === 0 && !event.shiftKey) {
+        var startX = event.clientX, startY = event.clientY;
+        var dragged = false;
+        var onMove = function (ev) {
+          if (Math.abs(ev.clientX - startX) > 3 || Math.abs(ev.clientY - startY) > 3)
+            dragged = true;
+        };
+        var onUp = function () {
+          document.removeEventListener("mousemove", onMove);
+          document.removeEventListener("mouseup", onUp);
+          if (!dragged) focusTerminalSoon();
+        };
+        document.addEventListener("mousemove", onMove);
+        document.addEventListener("mouseup", onUp);
+        return;
+      }
       focusTerminalSoon();
     }
 

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -46,6 +46,8 @@
     var keyTrapBound = false;
     var isMinimized = false;
     var restoreButton = null;
+    var followPaused = false;
+    var scrollBound = false;
 
     function open() {
       if (isOpen) {
@@ -80,6 +82,7 @@
       isOpen = false;
       isMinimized = false;
       closing = true;
+      setFollowPaused(false);
       removeInputTrap();
       hideRestoreControl();
       disconnectWs();
@@ -455,6 +458,7 @@
         onData: function (data) { sendInput(data); },
       }).then(function (created) {
         term = created;
+        bindTerminalScrollEvents(container);
         try { term.focus(); } catch (e) {}
         refreshTerminalFitAfterFontLoad();
         return term;
@@ -589,6 +593,8 @@
       writeQueue = [];
       writeFlushPending = false;
       linkProvider = null;
+      scrollBound = false;
+      followPaused = false;
       if (term) {
         try { term.destroy(); } catch (e) {}
         term = null;
@@ -653,6 +659,53 @@
         termWs.send(bytes.slice(i, i + chunkSize));
     }
 
+    function terminalAtBottom() {
+      try { return !term || !term.atBottom || term.atBottom(); }
+      catch (e) { return true; }
+    }
+
+    function setFollowPaused(paused) {
+      followPaused = !!paused;
+      var button = el("tempTerminalFollowButton");
+      if (!button) return;
+      button.hidden = !followPaused;
+      button.setAttribute && button.setAttribute("aria-hidden", followPaused ? "false" : "true");
+    }
+
+    function scrollToTail() {
+      setFollowPaused(false);
+      try { if (term) term.scrollToBottom(); } catch (e) {}
+      try { term.focus(); } catch (e) {}
+    }
+
+    function bindTerminalScrollEvents(container) {
+      if (scrollBound || !term || !term.element) return;
+      scrollBound = true;
+      var termEl = term.element;
+      // Wheel scrolling: scroll lines, pause follow when not at bottom
+      termEl.addEventListener("wheel", function (event) {
+        if (event.ctrlKey || event.metaKey || !term) return;
+        if (term.usesNormalBuffer && !term.usesNormalBuffer()) return;
+        event.preventDefault();
+        var rowH = term.rowHeight ? term.rowHeight() : 17;
+        var lines = Math.max(1, Math.round(Math.abs(event.deltaY) / Math.max(1, rowH)));
+        try { term.scrollLines(event.deltaY < 0 ? -lines : lines); } catch (e) {}
+        setFollowPaused(!terminalAtBottom());
+      }, { passive: false });
+      // Scroll event (touch drag, scrollbar): sync follow state
+      termEl.addEventListener("scroll", function () {
+        setFollowPaused(!terminalAtBottom());
+      }, { passive: true });
+      // Follow button click
+      var button = el("tempTerminalFollowButton");
+      if (button) button.onclick = scrollToTail;
+    }
+
+    function maybeAutoScrollToBottom() {
+      if (followPaused) return;
+      try { if (term) term.scrollToBottom(); } catch (e) {}
+    }
+
     function enqueueFrame(data) {
       var size = typeof data === "string" ? data.length : data.length;
       if (!writeFlushPending && writeQueue.length === 0 && term && size <= 8192) {
@@ -692,7 +745,11 @@
 
     function writeFrame(data) {
       if (!term) return;
-      try { term.write(data); } catch (e) { try { term.write(data); } catch (e2) {} }
+      try { term.write(data, maybeAutoScrollToBottom); } catch (e) { try { term.write(data); maybeAutoScrollToBottom(); } catch (e2) {} }
+      // Fallback: RAF-based auto-scroll in case write callback not called
+      if (typeof globalThis.requestAnimationFrame === "function") {
+        globalThis.requestAnimationFrame(maybeAutoScrollToBottom);
+      }
     }
 
     function isVisible() { return isOpen && !isMinimized; }

--- a/src/assets/shared/terminal_adapter.js
+++ b/src/assets/shared/terminal_adapter.js
@@ -460,6 +460,35 @@
     return Math.max(1, Math.round(delta / rowHeight));
   }
 
+  /**
+   * Attaches a pointerdown listener that calls `focus()` only when the mouse
+   * stays within a 3px radius (a click, not a text-selection drag).  This
+   * prevents textarea.focus() from collapsing native DOM text selection.
+   *
+   * @param {HTMLElement} element - Element to listen on.
+   * @param {function} focus - Called when the gesture is a click, not a drag.
+   * @param {function} [shouldIgnore] - Return true to skip focus for this event.
+   */
+  function attachClickFocus(element, focus, shouldIgnore) {
+    element.addEventListener("pointerdown", function (event) {
+      if (shouldIgnore && shouldIgnore(event)) return;
+      if (event.button !== 0 || event.shiftKey) return;
+      var startX = event.clientX, startY = event.clientY;
+      var dragged = false;
+      var onMove = function (ev) {
+        if (Math.abs(ev.clientX - startX) > 3 || Math.abs(ev.clientY - startY) > 3)
+          dragged = true;
+      };
+      var onUp = function () {
+        root.document.removeEventListener("mousemove", onMove);
+        root.document.removeEventListener("mouseup", onUp);
+        if (!dragged) focus();
+      };
+      root.document.addEventListener("mousemove", onMove);
+      root.document.addEventListener("mouseup", onUp);
+    });
+  }
+
   root.HerdrTerminalRenderer = {
     create: HerdrWtermAdapter.create,
     normalizeCore,
@@ -467,6 +496,7 @@
     applyThemeVars,
     filterTerminalImageSequences,
     terminalImageProtocolSummary,
+    attachClickFocus,
   };
   if (typeof module !== "undefined" && module.exports) module.exports = root.HerdrTerminalRenderer;
 })(typeof globalThis !== "undefined" ? globalThis : window);

--- a/src/assets/temp_terminal.test.mjs
+++ b/src/assets/temp_terminal.test.mjs
@@ -106,6 +106,7 @@ function context() {
 
   ctx = {
     TextEncoder,
+    fitCalls: [],
     HerdrTerminalRenderer: {
       create(target, options) {
         const term = new FakeTerminal(options);
@@ -147,7 +148,9 @@ function context() {
       cellSize() {
         return { width: 9, height: 20 };
       },
-      fitTerminalToContainer() {},
+      fitTerminalToContainer(target, opts) {
+        ctx.fitCalls.push({ target, opts });
+      },
       gridSize() {
         return { cols: 88, rows: 22 };
       },
@@ -378,6 +381,17 @@ describe("temporary terminal", () => {
       ok(/width:\s*100%;/.test(wtermRule), cssPath);
       ok(/overflow-x:\s*hidden;/.test(wtermRule), cssPath);
       ok(/overflow-y:\s*auto;/.test(wtermRule), cssPath);
+    }
+  });
+
+  it("fits the terminal element not the container div", async () => {
+    const ctx = context();
+    await openTempTerminal(ctx);
+    ok(ctx.fitCalls.length > 0, "expected fitTerminalToContainer calls");
+    const container = ctx.elements.get("tempTerminal");
+    for (const call of ctx.fitCalls) {
+      ok(call.target !== container, "fitTerminalToContainer should not target the container div");
+      ok(call.opts && call.opts.height > 0, "fitTerminalToContainer should receive a positive height");
     }
   });
 });


### PR DESCRIPTION
## Summary

Three terminal UX fixes across desktop panel and temp terminal:

### 1. Terminal text selection (ec90925, 85ae2cc, 598b1ab)
- **Root cause**: `mousedown`/`pointerdown` handler called `setTimeout(focusTerminal, 0)` unconditionally, which focused the hidden textarea on the next tick, collapsing any in-progress DOM text selection.
- **Fix**: Track mouse movement between pointerdown and mouseup. Only focus the terminal if the mouse moved less than 3px (a click, not a drag).
- Extracted shared `attachClickFocus` utility into `terminal_adapter.js` used by both desktop and temp terminal.

### 2. Temp terminal height (838620f, 9035654)
- **Root cause**: `fitTerminalDomToContainer` measured `container.clientHeight` but the container is the wterm terminal element, which has a fixed inline pixel height set by wterm's `_lockHeight()` (`rows * rowHeight + padding` ≈ half the modal).
- **Fix**: All three measurement functions (`terminalGridSize`, `terminalFitReady`, `fitTerminalDomToContainer`) now measure `container.parentElement` (`.temp-terminal-body`) for available height instead.

### 3. Scroll-follow with '↓ Tail' button (bc200e2)
- **Problem**: Temp terminal had no scroll-follow logic. New output always scrolled to bottom even when reading scrollback.
- **Fix**: Added wheel handler, scroll event listener, auto-scroll-after-write (only when not paused), and a '↓ Tail' follow button in both desktop and mobile layouts. Clicking the button resumes follow and scrolls to bottom.

### Test results
- All 142 JS tests pass