### PR TITLE
chore: bump version to 0.2.86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-webui"
-version = "0.2.84"
+version = "0.2.86"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.85"
+version = "0.2.86"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"


### PR DESCRIPTION
## Summary

Version bump to 0.2.86 for release. Includes the feature from #110:

### Git in-diff editing in both layouts
- Renames the `Edit side-by-side` toolbar button to `Edit`.
- Makes the Git hunk editor layout-aware: side-by-side keeps the previous (read-only) and current (editable) panes; unified shows a single editable hunk column (GitHub-style). Edits persist when switching layouts.
- Shares conflict-block `Use HEAD`, `Use parent`, and `Use remote` controls across both editor layouts.

## Changes
- `Cargo.toml`: `0.2.85` → `0.2.86`
- `Cargo.lock`: synced

## Validation
- `cargo build --release` clean (only pre-existing dead-code warning).
- Local binary reports `snapshot-...` (tag build will report `v0.2.86`).