### PR TITLE
feat: implement jcode detection variant support (vanilla + alecuba16 fork)

### DIFF
--- a/src/builtin_backend.rs
+++ b/src/builtin_backend.rs
@@ -13,7 +13,7 @@ use interprocess::TryClone as _;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use serde_json::{json, Value};
 
-use crate::builtin_detection::{JcodeDetectionVariant, jcode::detect_jcode_status_with_variant};
+use crate::builtin_detection::{jcode::detect_jcode_status_with_variant, JcodeDetectionVariant};
 use crate::builtin_events::{BuiltinEventHub, PaneEventContext};
 use crate::protocol::{
     read_message, write_message, ClientInputEvent, ClientMessage, RenderEncoding, ServerMessage,
@@ -170,7 +170,11 @@ impl BuiltinBackendHandle {
         restrict_socket_permissions(&config.api_socket)?;
         restrict_socket_permissions(&config.client_socket)?;
 
-        let state = Arc::new(BuiltinState::new(config.cwd, config.shell, config.jcode_detection_variant)?);
+        let state = Arc::new(BuiltinState::new(
+            config.cwd,
+            config.shell,
+            config.jcode_detection_variant,
+        )?);
         let inner = Arc::new(BuiltinBackendInner {
             running: AtomicBool::new(true),
             api_socket: config.api_socket,
@@ -471,7 +475,11 @@ struct PaneRecord {
 }
 
 impl BuiltinState {
-    fn new(_cwd: PathBuf, shell: Option<String>, jcode_detection_variant: JcodeDetectionVariant) -> io::Result<Self> {
+    fn new(
+        _cwd: PathBuf,
+        shell: Option<String>,
+        jcode_detection_variant: JcodeDetectionVariant,
+    ) -> io::Result<Self> {
         let default_shell = shell.unwrap_or_else(default_shell);
         let state = Self {
             data: Mutex::new(BuiltinData {
@@ -2522,7 +2530,11 @@ fn osc_progress_status_for_agent(agent: &str, osc_progress: &str) -> Option<&'st
     }
 }
 
-fn detect_agent_status(agent: Option<&str>, text: &str, jcode_variant: JcodeDetectionVariant) -> &'static str {
+fn detect_agent_status(
+    agent: Option<&str>,
+    text: &str,
+    jcode_variant: JcodeDetectionVariant,
+) -> &'static str {
     let Some(agent) = agent else {
         return "unknown";
     };
@@ -3517,8 +3529,12 @@ mod tests {
 
     #[test]
     fn builtin_event_hub_publishes_mutation_events() {
-        let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
+        let state = BuiltinState::new(
+            std::env::current_dir().unwrap(),
+            Some(default_shell()),
+            JcodeDetectionVariant::Vanilla,
+        )
+        .unwrap();
         state.handle_request("seed", "workspace.create", json!({ "label": "Workspace" }));
         let rx = state.subscribe_events();
 
@@ -3531,8 +3547,12 @@ mod tests {
 
     #[test]
     fn builtin_tab_create_respects_focus_false() {
-        let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
+        let state = BuiltinState::new(
+            std::env::current_dir().unwrap(),
+            Some(default_shell()),
+            JcodeDetectionVariant::Vanilla,
+        )
+        .unwrap();
         let workspace =
             state.handle_request("seed", "workspace.create", json!({ "label": "Workspace" }));
         let workspace_id = workspace["result"]["workspace"]["workspace_id"]
@@ -3567,8 +3587,12 @@ mod tests {
 
     #[test]
     fn builtin_display_numbers_are_scoped_by_level() {
-        let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
+        let state = BuiltinState::new(
+            std::env::current_dir().unwrap(),
+            Some(default_shell()),
+            JcodeDetectionVariant::Vanilla,
+        )
+        .unwrap();
         let empty_snapshot = state.handle_request("empty", "session.snapshot", json!({}));
         assert_eq!(
             empty_snapshot["result"]["snapshot"]["workspaces"]
@@ -3646,8 +3670,12 @@ mod tests {
 
     #[test]
     fn terminal_output_publishes_agent_status_changes() {
-        let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
+        let state = BuiltinState::new(
+            std::env::current_dir().unwrap(),
+            Some(default_shell()),
+            JcodeDetectionVariant::Vanilla,
+        )
+        .unwrap();
         state.handle_request("seed", "workspace.create", json!({ "label": "Workspace" }));
         let rx = state.subscribe_events();
         let terminal = {
@@ -3762,17 +3790,32 @@ mod tests {
     fn detect_agent_status_with_osc_prefers_osc_over_screen_scrape() {
         // OSC says "idle" but screen shows working spinner
         assert_eq!(
-            detect_agent_status_with_osc(Some("jcode"), "⠋ sending… 0.3s", "jcode:idle", JcodeDetectionVariant::Vanilla),
+            detect_agent_status_with_osc(
+                Some("jcode"),
+                "⠋ sending… 0.3s",
+                "jcode:idle",
+                JcodeDetectionVariant::Vanilla
+            ),
             "idle"
         );
         // OSC says "working" but screen shows idle prompt
         assert_eq!(
-            detect_agent_status_with_osc(Some("jcode"), "❯", "jcode:working", JcodeDetectionVariant::Vanilla),
+            detect_agent_status_with_osc(
+                Some("jcode"),
+                "❯",
+                "jcode:working",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         // OSC says "blocked" with minimal screen
         assert_eq!(
-            detect_agent_status_with_osc(Some("jcode"), "❯", "jcode:blocked", JcodeDetectionVariant::Vanilla),
+            detect_agent_status_with_osc(
+                Some("jcode"),
+                "❯",
+                "jcode:blocked",
+                JcodeDetectionVariant::Vanilla
+            ),
             "blocked"
         );
     }
@@ -3825,39 +3868,75 @@ mod tests {
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "Asking user\nEnter your response\nSubmit", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "Asking user\nEnter your response\nSubmit",
+                JcodeDetectionVariant::Vanilla
+            ),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ running analysis", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "⠋ running analysis",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "Running tool bash", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "Running tool bash",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ thinking… 1.2s", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "⠋ thinking… 1.2s",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ streaming · ↑1.2k ↓42 · 1.2s", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "⠋ streaming · ↑1.2k ↓42 · 1.2s",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ sending… 0.3s", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "⠋ sending… 0.3s",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ connecting… 0.3s", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "⠋ connecting… 0.3s",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "··● bash ●·· · 12s", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "··● bash ●·· · 12s",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "··● bash ●··", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "··● bash ●··",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
@@ -3869,7 +3948,11 @@ mod tests {
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "●·· batch ··● · 2/5 done", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "●·· batch ··● · 2/5 done",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
@@ -3904,8 +3987,18 @@ mod tests {
             ),
             "idle"
         );
-        assert_eq!(detect_agent_status(Some("jcode"), "Session ready\n❯", JcodeDetectionVariant::Vanilla), "idle");
-        assert_eq!(detect_agent_status(Some("jcode"), "1> ", JcodeDetectionVariant::Vanilla), "idle");
+        assert_eq!(
+            detect_agent_status(
+                Some("jcode"),
+                "Session ready\n❯",
+                JcodeDetectionVariant::Vanilla
+            ),
+            "idle"
+        );
+        assert_eq!(
+            detect_agent_status(Some("jcode"), "1> ", JcodeDetectionVariant::Vanilla),
+            "idle"
+        );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
@@ -3947,7 +4040,11 @@ mod tests {
             "idle"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "··● bash ●·· · 12s\nSession ready\n❯ ", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "··● bash ●·· · 12s\nSession ready\n❯ ",
+                JcodeDetectionVariant::Vanilla
+            ),
             "idle"
         );
         assert_eq!(
@@ -3959,27 +4056,51 @@ mod tests {
             "idle"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "··● bash ●·· · 12s\n1> ", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "··● bash ●·· · 12s\n1> ",
+                JcodeDetectionVariant::Vanilla
+            ),
             "idle"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "Running tool bash\n1> typed input", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "Running tool bash\n1> typed input",
+                JcodeDetectionVariant::Vanilla
+            ),
             "idle"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "Session ready\n❯\n··● bash ●·· · 12s", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "Session ready\n❯\n··● bash ●·· · 12s",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "··● not a toolbar\n❯", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "··● not a toolbar\n❯",
+                JcodeDetectionVariant::Vanilla
+            ),
             "idle"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "plain prompt", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "plain prompt",
+                JcodeDetectionVariant::Vanilla
+            ),
             "unknown"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋running analysis", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                "⠋running analysis",
+                JcodeDetectionVariant::Vanilla
+            ),
             "unknown"
         );
 
@@ -4085,37 +4206,55 @@ mod tests {
         for allow in ["allow once", "always allow", "allow"] {
             for deny in ["deny", "reject", "cancel"] {
                 let text = format!("Permission request\n{allow}\n{deny}");
-                assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
+                assert_eq!(
+                    detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla),
+                    "blocked"
+                );
             }
         }
 
         for allow in ["allow", "yes"] {
             for deny in ["reject", "no", "cancel"] {
                 let text = format!("Approve?\n{allow}\n{deny}");
-                assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
+                assert_eq!(
+                    detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla),
+                    "blocked"
+                );
             }
         }
 
         for allow in ["allow", "yes", "proceed"] {
             for deny in ["reject", "no", "cancel"] {
                 let text = format!("Confirm action\n{allow}\n{deny}");
-                assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
+                assert_eq!(
+                    detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla),
+                    "blocked"
+                );
             }
         }
 
         for action in ["continue", "submit", "cancel"] {
             let text = format!("Enter your response\n{action}");
-            assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
+            assert_eq!(
+                detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla),
+                "blocked"
+            );
         }
 
         for prompt in ["enter your response", "awaiting input", "waiting for user"] {
             let text = format!("Asking user\n{prompt}");
-            assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
+            assert_eq!(
+                detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla),
+                "blocked"
+            );
         }
 
         for action in ["enter", "type", "respond"] {
             let text = format!("Awaiting input\n{action}");
-            assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
+            assert_eq!(
+                detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla),
+                "blocked"
+            );
         }
 
         for status in [
@@ -4123,11 +4262,17 @@ mod tests {
             "executing tool",
             "network disconnected, waiting to retry",
         ] {
-            assert_eq!(detect_agent_status(Some("jcode"), status, JcodeDetectionVariant::Vanilla), "working");
+            assert_eq!(
+                detect_agent_status(Some("jcode"), status, JcodeDetectionVariant::Vanilla),
+                "working"
+            );
         }
 
         for ready in ["session ready", "ready for input", "❯"] {
-            assert_eq!(detect_agent_status(Some("jcode"), ready, JcodeDetectionVariant::Vanilla), "idle");
+            assert_eq!(
+                detect_agent_status(Some("jcode"), ready, JcodeDetectionVariant::Vanilla),
+                "idle"
+            );
         }
     }
 
@@ -4185,7 +4330,11 @@ mod tests {
         let working_screen =
             terminal_screen_text_lossy("Session ready\n❯\r\u{1b}[2K··● bash ●·· · 12s");
         assert_eq!(
-            detect_agent_status(Some("jcode"), &working_screen, JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                &working_screen,
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
 
@@ -4202,7 +4351,11 @@ mod tests {
             "··● bash ●·· · 12s\r\u{1b}[2KApprove?\n❯ Allow\n  Reject\nEsc to cancel",
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), &blocked_screen, JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("jcode"),
+                &blocked_screen,
+                JcodeDetectionVariant::Vanilla
+            ),
             "blocked"
         );
     }
@@ -4316,38 +4469,73 @@ mod tests {
     #[test]
     fn detects_opencode_status_from_manifest_patterns() {
         assert_eq!(
-            detect_agent_status(Some("opencode"), "△ Permission required", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("opencode"),
+                "△ Permission required",
+                JcodeDetectionVariant::Vanilla
+            ),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "esc dismiss\nenter confirm\n↑↓ select", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("opencode"),
+                "esc dismiss\nenter confirm\n↑↓ select",
+                JcodeDetectionVariant::Vanilla
+            ),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "esc dismiss\nenter submit\n⇆ tab", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("opencode"),
+                "esc dismiss\nenter submit\n⇆ tab",
+                JcodeDetectionVariant::Vanilla
+            ),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "esc dismiss\nenter toggle\n↑↓ select", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("opencode"),
+                "esc dismiss\nenter toggle\n↑↓ select",
+                JcodeDetectionVariant::Vanilla
+            ),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "opencode · esc to interrupt", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("opencode"),
+                "opencode · esc to interrupt",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "opencode · esc again to interrupt", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("opencode"),
+                "opencode · esc again to interrupt",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "opencode escaped interrupt", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("opencode"),
+                "opencode escaped interrupt",
+                JcodeDetectionVariant::Vanilla
+            ),
             "unknown"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "esc interrupt before opencode", JcodeDetectionVariant::Vanilla),
+            detect_agent_status(
+                Some("opencode"),
+                "esc interrupt before opencode",
+                JcodeDetectionVariant::Vanilla
+            ),
             "unknown"
         );
-        assert_eq!(detect_agent_status(Some("opencode"), "■■■■", JcodeDetectionVariant::Vanilla), "working");
+        assert_eq!(
+            detect_agent_status(Some("opencode"), "■■■■", JcodeDetectionVariant::Vanilla),
+            "working"
+        );
     }
 
     #[test]
@@ -4376,7 +4564,12 @@ mod tests {
 
     #[test]
     fn builtin_worktree_remove_reports_unsupported_instead_of_false_success() {
-        let state = BuiltinState::new(std::env::temp_dir(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
+        let state = BuiltinState::new(
+            std::env::temp_dir(),
+            Some(default_shell()),
+            JcodeDetectionVariant::Vanilla,
+        )
+        .unwrap();
 
         let err = state
             .handle_request_inner("worktree.remove", json!({ "workspace_id": "ws_1" }))
@@ -4387,7 +4580,12 @@ mod tests {
 
     #[test]
     fn builtin_state_starts_without_auto_workspace() {
-        let state = BuiltinState::new(std::env::temp_dir(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
+        let state = BuiltinState::new(
+            std::env::temp_dir(),
+            Some(default_shell()),
+            JcodeDetectionVariant::Vanilla,
+        )
+        .unwrap();
 
         let snapshot = state.handle_request("snapshot", "session.snapshot", json!({}));
         let snapshot = &snapshot["result"]["snapshot"];
@@ -4512,8 +4710,12 @@ mod tests {
 
     #[test]
     fn closing_last_tab_auto_closes_workspace() {
-        let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
+        let state = BuiltinState::new(
+            std::env::current_dir().unwrap(),
+            Some(default_shell()),
+            JcodeDetectionVariant::Vanilla,
+        )
+        .unwrap();
         let workspace = state.handle_request(
             "seed",
             "workspace.create",
@@ -4552,8 +4754,12 @@ mod tests {
 
     #[test]
     fn closing_last_pane_auto_closes_tab_and_workspace() {
-        let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
+        let state = BuiltinState::new(
+            std::env::current_dir().unwrap(),
+            Some(default_shell()),
+            JcodeDetectionVariant::Vanilla,
+        )
+        .unwrap();
         let workspace = state.handle_request(
             "seed",
             "workspace.create",

--- a/src/builtin_backend.rs
+++ b/src/builtin_backend.rs
@@ -13,6 +13,7 @@ use interprocess::TryClone as _;
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use serde_json::{json, Value};
 
+use crate::builtin_detection::{JcodeDetectionVariant, jcode::detect_jcode_status_with_variant};
 use crate::builtin_events::{BuiltinEventHub, PaneEventContext};
 use crate::protocol::{
     read_message, write_message, ClientInputEvent, ClientMessage, RenderEncoding, ServerMessage,
@@ -126,6 +127,7 @@ pub(crate) struct BuiltinBackendConfig {
     pub client_socket: PathBuf,
     pub cwd: PathBuf,
     pub shell: Option<String>,
+    pub jcode_detection_variant: JcodeDetectionVariant,
 }
 
 pub(crate) struct BuiltinBackendHandle {
@@ -168,7 +170,7 @@ impl BuiltinBackendHandle {
         restrict_socket_permissions(&config.api_socket)?;
         restrict_socket_permissions(&config.client_socket)?;
 
-        let state = Arc::new(BuiltinState::new(config.cwd, config.shell)?);
+        let state = Arc::new(BuiltinState::new(config.cwd, config.shell, config.jcode_detection_variant)?);
         let inner = Arc::new(BuiltinBackendInner {
             running: AtomicBool::new(true),
             api_socket: config.api_socket,
@@ -427,6 +429,7 @@ struct BuiltinState {
     data: Mutex<BuiltinData>,
     default_shell: String,
     events: BuiltinEventHub,
+    jcode_detection_variant: JcodeDetectionVariant,
 }
 
 struct BuiltinData {
@@ -468,7 +471,7 @@ struct PaneRecord {
 }
 
 impl BuiltinState {
-    fn new(_cwd: PathBuf, shell: Option<String>) -> io::Result<Self> {
+    fn new(_cwd: PathBuf, shell: Option<String>, jcode_detection_variant: JcodeDetectionVariant) -> io::Result<Self> {
         let default_shell = shell.unwrap_or_else(default_shell);
         let state = Self {
             data: Mutex::new(BuiltinData {
@@ -483,6 +486,7 @@ impl BuiltinState {
             }),
             default_shell,
             events: BuiltinEventHub::new(),
+            jcode_detection_variant,
         };
         Ok(state)
     }
@@ -690,6 +694,7 @@ impl BuiltinState {
                 terminal_id: terminal_id.clone(),
             },
             pane_id.clone(),
+            self.jcode_detection_variant,
         )
         .map_err(|err| err.to_string())?;
         data.workspaces.insert(
@@ -772,6 +777,7 @@ impl BuiltinState {
                 terminal_id: terminal_id.clone(),
             },
             pane_id.clone(),
+            self.jcode_detection_variant,
         )
         .map_err(|err| err.to_string())?;
         data.tabs.insert(
@@ -849,6 +855,7 @@ impl BuiltinState {
                 terminal_id: terminal_id.clone(),
             },
             pane_id.clone(),
+            self.jcode_detection_variant,
         )
         .map_err(|err| err.to_string())?;
         data.workspaces.insert(
@@ -1245,6 +1252,7 @@ struct TerminalRuntime {
     subscribers: Mutex<Vec<mpsc::SyncSender<TerminalSubscriberMessage>>>,
     osc9_tracker: Mutex<Osc9Tracker>,
     exited: AtomicBool,
+    jcode_detection_variant: JcodeDetectionVariant,
 }
 
 #[derive(Clone)]
@@ -1263,6 +1271,7 @@ impl TerminalRuntime {
         event_hub: BuiltinEventHub,
         event_context: PaneEventContext,
         pane_id: String,
+        jcode_detection_variant: JcodeDetectionVariant,
     ) -> io::Result<Arc<Self>> {
         let pty_system = native_pty_system();
         let pair = pty_system
@@ -1323,6 +1332,7 @@ impl TerminalRuntime {
             subscribers: Mutex::new(Vec::new()),
             osc9_tracker: Mutex::new(Osc9Tracker::default()),
             exited: AtomicBool::new(false),
+            jcode_detection_variant,
         });
         let runtime_for_reader = Arc::clone(&runtime);
         thread::spawn(move || {
@@ -1488,7 +1498,12 @@ impl TerminalRuntime {
             .or(process_agent)
             .or_else(|| detect_agent_label_from_text(&tail))
             .map(str::to_string);
-        let status = match detect_agent_status_with_osc(agent.as_deref(), &tail, &osc_progress) {
+        let status = match detect_agent_status_with_osc(
+            agent.as_deref(),
+            &tail,
+            &osc_progress,
+            self.jcode_detection_variant,
+        ) {
             "unknown" if agent.is_some() => "idle",
             status => status,
         }
@@ -1764,7 +1779,14 @@ fn pane_agent_presentation(pane: &PaneRecord, data: &BuiltinData) -> PaneAgentPr
         .and_then(|terminal| terminal.osc9_tracker.lock().ok())
         .map(|tracker| tracker.latest_progress().to_string())
         .unwrap_or_default();
-    let status = match detect_agent_status_with_osc(agent, &tail, &osc_progress) {
+    let status = match detect_agent_status_with_osc(
+        agent,
+        &tail,
+        &osc_progress,
+        terminal
+            .map(|t| t.jcode_detection_variant)
+            .unwrap_or(JcodeDetectionVariant::Vanilla),
+    ) {
         "unknown" if agent.is_some() => "idle",
         status => status,
     };
@@ -2471,6 +2493,7 @@ fn detect_agent_status_with_osc(
     agent: Option<&str>,
     text: &str,
     osc_progress: &str,
+    jcode_variant: JcodeDetectionVariant,
 ) -> &'static str {
     if !osc_progress.is_empty() {
         let Some(agent) = agent else {
@@ -2480,7 +2503,7 @@ fn detect_agent_status_with_osc(
             return status;
         }
     }
-    detect_agent_status(agent, text)
+    detect_agent_status(agent, text, jcode_variant)
 }
 
 /// Map an OSC 9 progress payload to an agent status string.
@@ -2499,13 +2522,13 @@ fn osc_progress_status_for_agent(agent: &str, osc_progress: &str) -> Option<&'st
     }
 }
 
-fn detect_agent_status(agent: Option<&str>, text: &str) -> &'static str {
+fn detect_agent_status(agent: Option<&str>, text: &str, jcode_variant: JcodeDetectionVariant) -> &'static str {
     let Some(agent) = agent else {
         return "unknown";
     };
     let lower = text.to_lowercase();
     match agent {
-        "jcode" => detect_jcode_status(&lower),
+        "jcode" => detect_jcode_status_with_variant(&lower, jcode_variant),
         "opencode" => detect_opencode_status(&lower),
         "kilo" => detect_kilo_status(&lower),
         "amp" => detect_amp_status(&lower),
@@ -3075,7 +3098,7 @@ fn detect_jcode_status(lower: &str) -> &'static str {
     "unknown"
 }
 
-fn jcode_idle_line(line: &str) -> bool {
+pub(crate) fn jcode_idle_line(line: &str) -> bool {
     let line = line.trim();
     line == "❯"
         || jcode_numbered_prompt_line(line)
@@ -3083,7 +3106,7 @@ fn jcode_idle_line(line: &str) -> bool {
         || line.contains("ready for input")
 }
 
-fn jcode_numbered_prompt_line(line: &str) -> bool {
+pub(crate) fn jcode_numbered_prompt_line(line: &str) -> bool {
     let line = line.trim_start();
     let digit_count = line.chars().take_while(|ch| ch.is_ascii_digit()).count();
     digit_count > 0
@@ -3112,7 +3135,7 @@ fn detect_opencode_status(lower: &str) -> &'static str {
     "unknown"
 }
 
-fn jcode_blocked(text: &str) -> bool {
+pub(crate) fn jcode_blocked(text: &str) -> bool {
     (text.contains("permission")
         && contains_any(text, &["allow once", "always allow", "allow"])
         && contains_any(text, &["deny", "reject", "cancel"]))
@@ -3124,7 +3147,7 @@ fn jcode_blocked(text: &str) -> bool {
             && contains_any(text, &["reject", "no", "cancel"]))
 }
 
-fn jcode_question_blocked(text: &str) -> bool {
+pub(crate) fn jcode_question_blocked(text: &str) -> bool {
     (text.contains("enter your response") && contains_any(text, &["continue", "submit", "cancel"]))
         || (text.contains("asking user")
             && contains_any(
@@ -3134,7 +3157,7 @@ fn jcode_question_blocked(text: &str) -> bool {
         || (text.contains("awaiting input") && contains_any(text, &["enter", "type", "respond"]))
 }
 
-fn has_jcode_spinner(text: &str) -> bool {
+pub(crate) fn has_jcode_spinner(text: &str) -> bool {
     text.lines().any(|line| {
         let mut chars = line.trim_start().chars();
         matches!(chars.next(), Some(first) if is_braille(first))
@@ -3257,7 +3280,7 @@ fn has_opencode_interrupt_line(line: &str) -> bool {
     false
 }
 
-fn has_jcode_tool_bar(text: &str) -> bool {
+pub(crate) fn has_jcode_tool_bar(text: &str) -> bool {
     text.lines().any(jcode_tool_bar_line)
 }
 
@@ -3339,7 +3362,7 @@ fn has_opencode_progress(text: &str) -> bool {
     })
 }
 
-fn bottom_non_empty_lines(text: &str, count: usize) -> String {
+pub(crate) fn bottom_non_empty_lines(text: &str, count: usize) -> String {
     let mut lines = text
         .lines()
         .map(str::trim)
@@ -3352,7 +3375,7 @@ fn bottom_non_empty_lines(text: &str, count: usize) -> String {
     lines.join("\n")
 }
 
-fn contains_any(text: &str, needles: &[&str]) -> bool {
+pub(crate) fn contains_any(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
 }
 
@@ -3495,7 +3518,7 @@ mod tests {
     #[test]
     fn builtin_event_hub_publishes_mutation_events() {
         let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell())).unwrap();
+            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
         state.handle_request("seed", "workspace.create", json!({ "label": "Workspace" }));
         let rx = state.subscribe_events();
 
@@ -3509,7 +3532,7 @@ mod tests {
     #[test]
     fn builtin_tab_create_respects_focus_false() {
         let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell())).unwrap();
+            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
         let workspace =
             state.handle_request("seed", "workspace.create", json!({ "label": "Workspace" }));
         let workspace_id = workspace["result"]["workspace"]["workspace_id"]
@@ -3545,7 +3568,7 @@ mod tests {
     #[test]
     fn builtin_display_numbers_are_scoped_by_level() {
         let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell())).unwrap();
+            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
         let empty_snapshot = state.handle_request("empty", "session.snapshot", json!({}));
         assert_eq!(
             empty_snapshot["result"]["snapshot"]["workspaces"]
@@ -3624,7 +3647,7 @@ mod tests {
     #[test]
     fn terminal_output_publishes_agent_status_changes() {
         let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell())).unwrap();
+            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
         state.handle_request("seed", "workspace.create", json!({ "label": "Workspace" }));
         let rx = state.subscribe_events();
         let terminal = {
@@ -3664,6 +3687,7 @@ mod tests {
             hub,
             context,
             "pane_exit".to_string(),
+            JcodeDetectionVariant::Vanilla,
         )
         .unwrap();
         let (tx, rx) = mpsc::sync_channel(8);
@@ -3738,17 +3762,17 @@ mod tests {
     fn detect_agent_status_with_osc_prefers_osc_over_screen_scrape() {
         // OSC says "idle" but screen shows working spinner
         assert_eq!(
-            detect_agent_status_with_osc(Some("jcode"), "⠋ sending… 0.3s", "jcode:idle"),
+            detect_agent_status_with_osc(Some("jcode"), "⠋ sending… 0.3s", "jcode:idle", JcodeDetectionVariant::Vanilla),
             "idle"
         );
         // OSC says "working" but screen shows idle prompt
         assert_eq!(
-            detect_agent_status_with_osc(Some("jcode"), "❯", "jcode:working"),
+            detect_agent_status_with_osc(Some("jcode"), "❯", "jcode:working", JcodeDetectionVariant::Vanilla),
             "working"
         );
         // OSC says "blocked" with minimal screen
         assert_eq!(
-            detect_agent_status_with_osc(Some("jcode"), "❯", "jcode:blocked"),
+            detect_agent_status_with_osc(Some("jcode"), "❯", "jcode:blocked", JcodeDetectionVariant::Vanilla),
             "blocked"
         );
     }
@@ -3757,11 +3781,21 @@ mod tests {
     fn detect_agent_status_with_osc_falls_back_to_screen_scrape() {
         // No OSC payload -> screen-scrape detection
         assert_eq!(
-            detect_agent_status_with_osc(Some("jcode"), "⠋ sending… 0.3s", ""),
+            detect_agent_status_with_osc(
+                Some("jcode"),
+                "⠋ sending… 0.3s",
+                "",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
         assert_eq!(
-            detect_agent_status_with_osc(Some("jcode"), "Session ready\n❯", ""),
+            detect_agent_status_with_osc(
+                Some("jcode"),
+                "Session ready\n❯",
+                "",
+                JcodeDetectionVariant::Vanilla
+            ),
             "idle"
         );
     }
@@ -3770,7 +3804,12 @@ mod tests {
     fn detect_agent_status_with_osc_unknown_payload_falls_back() {
         // Unknown OSC payload format -> falls back to screen-scrape
         assert_eq!(
-            detect_agent_status_with_osc(Some("jcode"), "⠋ sending… 0.3s", "unknown:format"),
+            detect_agent_status_with_osc(
+                Some("jcode"),
+                "⠋ sending… 0.3s",
+                "unknown:format",
+                JcodeDetectionVariant::Vanilla
+            ),
             "working"
         );
     }
@@ -3780,158 +3819,167 @@ mod tests {
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "Permission required\nAllow once\nAlways allow\nDeny"
+                "Permission required\nAllow once\nAlways allow\nDeny",
+                JcodeDetectionVariant::Vanilla
             ),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "Asking user\nEnter your response\nSubmit"),
+            detect_agent_status(Some("jcode"), "Asking user\nEnter your response\nSubmit", JcodeDetectionVariant::Vanilla),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ running analysis"),
+            detect_agent_status(Some("jcode"), "⠋ running analysis", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "Running tool bash"),
+            detect_agent_status(Some("jcode"), "Running tool bash", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ thinking… 1.2s"),
+            detect_agent_status(Some("jcode"), "⠋ thinking… 1.2s", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ streaming · ↑1.2k ↓42 · 1.2s"),
+            detect_agent_status(Some("jcode"), "⠋ streaming · ↑1.2k ↓42 · 1.2s", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ sending… 0.3s"),
+            detect_agent_status(Some("jcode"), "⠋ sending… 0.3s", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋ connecting… 0.3s"),
+            detect_agent_status(Some("jcode"), "⠋ connecting… 0.3s", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "··● bash ●·· · 12s"),
+            detect_agent_status(Some("jcode"), "··● bash ●·· · 12s", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "··● bash ●··"),
+            detect_agent_status(Some("jcode"), "··● bash ●··", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "●·· batch ··● · 2/5 done · last done: read · 1m 3s"
+                "●·· batch ··● · 2/5 done · last done: read · 1m 3s",
+                JcodeDetectionVariant::Vanilla
             ),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "●·· batch ··● · 2/5 done"),
+            detect_agent_status(Some("jcode"), "●·· batch ··● · 2/5 done", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "↻ network disconnected, waiting to retry · websocket · 8s"
+                "↻ network disconnected, waiting to retry · websocket · 8s",
+                JcodeDetectionVariant::Vanilla
             ),
             "working"
         );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "Jcode is running this in the background. Progress, checkpoints, and completion will appear here.\n╭ ◌ bg run full Rust and JS tests · 5202362vb9 ╮\nLatest status: bg action=\"status\" task_id=\"5202362vb9\"\n❯"
-            ),
-            "idle"
-        );
-        assert_eq!(
-            detect_agent_status(
-                Some("jcode"),
-                "╭ ✓ bg run full Rust and JS tests completed · 5202362vb9 ╮\nexit 0 · 5.7s\n❯"
+                "Jcode is running this in the background. Progress, checkpoints, and completion will appear here.\n╭ ◌ bg run full Rust and JS tests · 5202362vb9 ╮\nLatest status: bg action=\"status\" task_id=\"5202362vb9\"\n❯",
+                JcodeDetectionVariant::Vanilla
             ),
             "idle"
         );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "Jcode is running this in the background. Progress, checkpoints, and completion will appear here.\n╭ ◌ bg run full Rust and JS tests · 5202362vb9 ╮\nLatest status: bg action=\"status\" task_id=\"5202362vb9\"\n╭ ✓ bg run full Rust and JS tests completed · 5202362vb9 ╮\nexit 0 · 5.7s\n❯"
-            ),
-            "idle"
-        );
-        assert_eq!(
-            detect_agent_status(Some("jcode"), "Session ready\n❯"),
-            "idle"
-        );
-        assert_eq!(detect_agent_status(Some("jcode"), "1> "), "idle");
-        assert_eq!(
-            detect_agent_status(
-                Some("jcode"),
-                "1>                                                            together_ai/revolut ca/glm 5 2 · ~/repo"
+                "╭ ✓ bg run full Rust and JS tests completed · 5202362vb9 ╮\nexit 0 · 5.7s\n❯",
+                JcodeDetectionVariant::Vanilla
             ),
             "idle"
         );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "We should deny this assumption in the explanation.\n❯ "
+                "Jcode is running this in the background. Progress, checkpoints, and completion will appear here.\n╭ ◌ bg run full Rust and JS tests · 5202362vb9 ╮\nLatest status: bg action=\"status\" task_id=\"5202362vb9\"\n╭ ✓ bg run full Rust and JS tests completed · 5202362vb9 ╮\nexit 0 · 5.7s\n❯",
+                JcodeDetectionVariant::Vanilla
+            ),
+            "idle"
+        );
+        assert_eq!(detect_agent_status(Some("jcode"), "Session ready\n❯", JcodeDetectionVariant::Vanilla), "idle");
+        assert_eq!(detect_agent_status(Some("jcode"), "1> ", JcodeDetectionVariant::Vanilla), "idle");
+        assert_eq!(
+            detect_agent_status(
+                Some("jcode"),
+                "1>                                                            together_ai/revolut ca/glm 5 2 · ~/repo",
+                JcodeDetectionVariant::Vanilla
             ),
             "idle"
         );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "Permission request\n❯ Allow once\n  Deny\nold response line 1\nold response line 2\nold response line 3\nold response line 4\nold response line 5\nold response line 6\nold response line 7\nold response line 8\n❯ "
+                "We should deny this assumption in the explanation.\n❯ ",
+                JcodeDetectionVariant::Vanilla
             ),
             "idle"
         );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "Processing request\nold response line 1\nold response line 2\nold response line 3\nold response line 4\n❯ "
+                "Permission request\n❯ Allow once\n  Deny\nold response line 1\nold response line 2\nold response line 3\nold response line 4\nold response line 5\nold response line 6\nold response line 7\nold response line 8\n❯ ",
+                JcodeDetectionVariant::Vanilla
             ),
             "idle"
         );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "··● bash ●·· · 12s\nold response line 1\nold response line 2\nold response line 3\nold response line 4\n❯ "
+                "Processing request\nold response line 1\nold response line 2\nold response line 3\nold response line 4\n❯ ",
+                JcodeDetectionVariant::Vanilla
             ),
-            "idle"
-        );
-        assert_eq!(
-            detect_agent_status(Some("jcode"), "··● bash ●·· · 12s\nSession ready\n❯ "),
             "idle"
         );
         assert_eq!(
             detect_agent_status(
                 Some("jcode"),
-                "Running tool bash\nresult mentions running tool\n❯ "
+                "··● bash ●·· · 12s\nold response line 1\nold response line 2\nold response line 3\nold response line 4\n❯ ",
+                JcodeDetectionVariant::Vanilla
             ),
             "idle"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "··● bash ●·· · 12s\n1> "),
+            detect_agent_status(Some("jcode"), "··● bash ●·· · 12s\nSession ready\n❯ ", JcodeDetectionVariant::Vanilla),
             "idle"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "Running tool bash\n1> typed input"),
+            detect_agent_status(
+                Some("jcode"),
+                "Running tool bash\nresult mentions running tool\n❯ ",
+                JcodeDetectionVariant::Vanilla
+            ),
             "idle"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "Session ready\n❯\n··● bash ●·· · 12s"),
+            detect_agent_status(Some("jcode"), "··● bash ●·· · 12s\n1> ", JcodeDetectionVariant::Vanilla),
+            "idle"
+        );
+        assert_eq!(
+            detect_agent_status(Some("jcode"), "Running tool bash\n1> typed input", JcodeDetectionVariant::Vanilla),
+            "idle"
+        );
+        assert_eq!(
+            detect_agent_status(Some("jcode"), "Session ready\n❯\n··● bash ●·· · 12s", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "··● not a toolbar\n❯"),
+            detect_agent_status(Some("jcode"), "··● not a toolbar\n❯", JcodeDetectionVariant::Vanilla),
             "idle"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "plain prompt"),
+            detect_agent_status(Some("jcode"), "plain prompt", JcodeDetectionVariant::Vanilla),
             "unknown"
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), "⠋running analysis"),
+            detect_agent_status(Some("jcode"), "⠋running analysis", JcodeDetectionVariant::Vanilla),
             "unknown"
         );
 
@@ -4025,7 +4073,7 @@ mod tests {
 
         for (agent, text, expected) in cases {
             assert_eq!(
-                detect_agent_status(Some(agent), text),
+                detect_agent_status(Some(agent), text, JcodeDetectionVariant::Vanilla),
                 expected,
                 "agent {agent} text {text:?}"
             );
@@ -4037,37 +4085,37 @@ mod tests {
         for allow in ["allow once", "always allow", "allow"] {
             for deny in ["deny", "reject", "cancel"] {
                 let text = format!("Permission request\n{allow}\n{deny}");
-                assert_eq!(detect_agent_status(Some("jcode"), &text), "blocked");
+                assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
             }
         }
 
         for allow in ["allow", "yes"] {
             for deny in ["reject", "no", "cancel"] {
                 let text = format!("Approve?\n{allow}\n{deny}");
-                assert_eq!(detect_agent_status(Some("jcode"), &text), "blocked");
+                assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
             }
         }
 
         for allow in ["allow", "yes", "proceed"] {
             for deny in ["reject", "no", "cancel"] {
                 let text = format!("Confirm action\n{allow}\n{deny}");
-                assert_eq!(detect_agent_status(Some("jcode"), &text), "blocked");
+                assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
             }
         }
 
         for action in ["continue", "submit", "cancel"] {
             let text = format!("Enter your response\n{action}");
-            assert_eq!(detect_agent_status(Some("jcode"), &text), "blocked");
+            assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
         }
 
         for prompt in ["enter your response", "awaiting input", "waiting for user"] {
             let text = format!("Asking user\n{prompt}");
-            assert_eq!(detect_agent_status(Some("jcode"), &text), "blocked");
+            assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
         }
 
         for action in ["enter", "type", "respond"] {
             let text = format!("Awaiting input\n{action}");
-            assert_eq!(detect_agent_status(Some("jcode"), &text), "blocked");
+            assert_eq!(detect_agent_status(Some("jcode"), &text, JcodeDetectionVariant::Vanilla), "blocked");
         }
 
         for status in [
@@ -4075,11 +4123,11 @@ mod tests {
             "executing tool",
             "network disconnected, waiting to retry",
         ] {
-            assert_eq!(detect_agent_status(Some("jcode"), status), "working");
+            assert_eq!(detect_agent_status(Some("jcode"), status, JcodeDetectionVariant::Vanilla), "working");
         }
 
         for ready in ["session ready", "ready for input", "❯"] {
-            assert_eq!(detect_agent_status(Some("jcode"), ready), "idle");
+            assert_eq!(detect_agent_status(Some("jcode"), ready, JcodeDetectionVariant::Vanilla), "idle");
         }
     }
 
@@ -4137,21 +4185,24 @@ mod tests {
         let working_screen =
             terminal_screen_text_lossy("Session ready\n❯\r\u{1b}[2K··● bash ●·· · 12s");
         assert_eq!(
-            detect_agent_status(Some("jcode"), &working_screen),
+            detect_agent_status(Some("jcode"), &working_screen, JcodeDetectionVariant::Vanilla),
             "working"
         );
 
         let idle_screen = terminal_screen_text_lossy(
             "Session ready\n··● bash ●·· · 12s\r\u{1b}[2KSession ready\n❯",
         );
-        assert_eq!(detect_agent_status(Some("jcode"), &idle_screen), "idle");
+        assert_eq!(
+            detect_agent_status(Some("jcode"), &idle_screen, JcodeDetectionVariant::Vanilla),
+            "idle"
+        );
         assert_eq!(detect_agent_label_from_text(&idle_screen), Some("jcode"));
 
         let blocked_screen = terminal_screen_text_lossy(
             "··● bash ●·· · 12s\r\u{1b}[2KApprove?\n❯ Allow\n  Reject\nEsc to cancel",
         );
         assert_eq!(
-            detect_agent_status(Some("jcode"), &blocked_screen),
+            detect_agent_status(Some("jcode"), &blocked_screen, JcodeDetectionVariant::Vanilla),
             "blocked"
         );
     }
@@ -4265,38 +4316,38 @@ mod tests {
     #[test]
     fn detects_opencode_status_from_manifest_patterns() {
         assert_eq!(
-            detect_agent_status(Some("opencode"), "△ Permission required"),
+            detect_agent_status(Some("opencode"), "△ Permission required", JcodeDetectionVariant::Vanilla),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "esc dismiss\nenter confirm\n↑↓ select"),
+            detect_agent_status(Some("opencode"), "esc dismiss\nenter confirm\n↑↓ select", JcodeDetectionVariant::Vanilla),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "esc dismiss\nenter submit\n⇆ tab"),
+            detect_agent_status(Some("opencode"), "esc dismiss\nenter submit\n⇆ tab", JcodeDetectionVariant::Vanilla),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "esc dismiss\nenter toggle\n↑↓ select"),
+            detect_agent_status(Some("opencode"), "esc dismiss\nenter toggle\n↑↓ select", JcodeDetectionVariant::Vanilla),
             "blocked"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "opencode · esc to interrupt"),
+            detect_agent_status(Some("opencode"), "opencode · esc to interrupt", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "opencode · esc again to interrupt"),
+            detect_agent_status(Some("opencode"), "opencode · esc again to interrupt", JcodeDetectionVariant::Vanilla),
             "working"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "opencode escaped interrupt"),
+            detect_agent_status(Some("opencode"), "opencode escaped interrupt", JcodeDetectionVariant::Vanilla),
             "unknown"
         );
         assert_eq!(
-            detect_agent_status(Some("opencode"), "esc interrupt before opencode"),
+            detect_agent_status(Some("opencode"), "esc interrupt before opencode", JcodeDetectionVariant::Vanilla),
             "unknown"
         );
-        assert_eq!(detect_agent_status(Some("opencode"), "■■■■"), "working");
+        assert_eq!(detect_agent_status(Some("opencode"), "■■■■", JcodeDetectionVariant::Vanilla), "working");
     }
 
     #[test]
@@ -4325,7 +4376,7 @@ mod tests {
 
     #[test]
     fn builtin_worktree_remove_reports_unsupported_instead_of_false_success() {
-        let state = BuiltinState::new(std::env::temp_dir(), Some(default_shell())).unwrap();
+        let state = BuiltinState::new(std::env::temp_dir(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
 
         let err = state
             .handle_request_inner("worktree.remove", json!({ "workspace_id": "ws_1" }))
@@ -4336,7 +4387,7 @@ mod tests {
 
     #[test]
     fn builtin_state_starts_without_auto_workspace() {
-        let state = BuiltinState::new(std::env::temp_dir(), Some(default_shell())).unwrap();
+        let state = BuiltinState::new(std::env::temp_dir(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
 
         let snapshot = state.handle_request("snapshot", "session.snapshot", json!({}));
         let snapshot = &snapshot["result"]["snapshot"];
@@ -4362,6 +4413,7 @@ mod tests {
             client_socket,
             cwd: std::env::temp_dir(),
             shell: Some(default_shell()),
+            jcode_detection_variant: JcodeDetectionVariant::Vanilla,
         })
         .unwrap();
         {
@@ -4423,6 +4475,7 @@ mod tests {
             client_socket: client_socket.clone(),
             cwd: std::env::temp_dir(),
             shell: Some(default_shell()),
+            jcode_detection_variant: JcodeDetectionVariant::Vanilla,
         })
         .unwrap();
         assert!(api_socket.exists());
@@ -4460,7 +4513,7 @@ mod tests {
     #[test]
     fn closing_last_tab_auto_closes_workspace() {
         let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell())).unwrap();
+            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
         let workspace = state.handle_request(
             "seed",
             "workspace.create",
@@ -4500,7 +4553,7 @@ mod tests {
     #[test]
     fn closing_last_pane_auto_closes_tab_and_workspace() {
         let state =
-            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell())).unwrap();
+            BuiltinState::new(std::env::current_dir().unwrap(), Some(default_shell()), JcodeDetectionVariant::Vanilla).unwrap();
         let workspace = state.handle_request(
             "seed",
             "workspace.create",

--- a/src/builtin_detection/jcode.rs
+++ b/src/builtin_detection/jcode.rs
@@ -1,0 +1,275 @@
+//! Jcode detection variants: vanilla (upstream) and alecuba16 (fork Overview panel).
+//!
+//! The `detect_jcode_status_with_variant` function selects the pattern set based on
+//! the `JcodeDetectionVariant` setting. OSC 9 progress payloads (emitted by vanilla's
+//! `herdr_detectable` branch) are handled upstream in `detect_agent_status_with_osc` and
+//! take precedence; this module only provides the screen-scrape fallback.
+
+use crate::builtin_detection::JcodeDetectionVariant;
+use crate::builtin_backend::{
+    bottom_non_empty_lines, contains_any, has_jcode_spinner, has_jcode_tool_bar,
+    jcode_blocked, jcode_idle_line, jcode_numbered_prompt_line, jcode_question_blocked,
+};
+
+/// Screen-scrape detection for jcode, selected by variant.
+pub fn detect_jcode_status_with_variant(lower: &str, variant: JcodeDetectionVariant) -> &'static str {
+    match variant {
+        JcodeDetectionVariant::Vanilla => detect_jcode_status_vanilla(lower),
+        JcodeDetectionVariant::Alecuba16 => detect_jcode_status_alecuba16(lower),
+    }
+}
+
+/// Vanilla jcode screen-scrape detection (upstream master output format).
+/// Matches: numbered prompts like `1> `, `❯` idle caret, `Session ready`,
+/// braille spinners `⠋ thinking…`, tool bar `··● bash ●··`.
+fn detect_jcode_status_vanilla(lower: &str) -> &'static str {
+    let bottom8 = bottom_non_empty_lines(lower, 8);
+    let bottom6 = bottom_non_empty_lines(lower, 6);
+    let bottom4 = bottom_non_empty_lines(lower, 4);
+    let bottom3 = bottom_non_empty_lines(lower, 3);
+
+    if jcode_blocked(&bottom8) || jcode_question_blocked(&bottom6) {
+        return "blocked";
+    }
+    if bottom3
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .is_some_and(jcode_idle_line)
+    {
+        return "idle";
+    }
+    if has_jcode_spinner(&bottom3)
+        || has_jcode_tool_bar(&bottom4)
+        || contains_any(
+            &bottom4,
+            &[
+                "running tool",
+                "executing tool",
+                "network disconnected, waiting to retry",
+            ],
+        )
+    {
+        return "working";
+    }
+    if (contains_any(&bottom3, &["session ready", "ready for input"])
+        || bottom3.lines().any(|line| line.trim() == "❯"))
+        && !contains_any(
+            &bottom3,
+            &["processing", "embedding", "running tool", "executing"],
+        )
+    {
+        return "idle";
+    }
+    "unknown"
+}
+
+/// alecuba16 fork screen-scrape detection (Overview panel output format).
+/// Distinct markers from the redesigned Overview widget:
+/// - Line 1: `N sessions · branch_name` (session count header)
+/// - Dashed separators: `- - - -` (repeated `- ` filling panel width)
+/// - Cost/tok footer: `💰 $X.XXXX  ↓k ↑k tok  ⌀N.N t/s`
+/// - Memory line: `🧠 N memories` (or `🧠 Memory disabled`)
+/// - Swarm line: `🐝 N sessions` (shown even when no swarm active: `🐝 0 sessions`)
+fn detect_jcode_status_alecuba16(lower: &str) -> &'static str {
+    let bottom8 = bottom_non_empty_lines(lower, 8);
+    let bottom6 = bottom_non_empty_lines(lower, 6);
+    let bottom4 = bottom_non_empty_lines(lower, 4);
+    let bottom3 = bottom_non_empty_lines(lower, 3);
+
+    // Blocked patterns (permission prompts, confirmations) — same as vanilla
+    if jcode_blocked(&bottom8) || jcode_question_blocked(&bottom6) {
+        return "blocked";
+    }
+
+    // Idle: last non-empty line is a prompt (`❯`, `1> `, `session ready`, `ready for input`)
+    if bottom3
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .is_some_and(|line| {
+            let line = line.trim();
+            line == "❯"
+                || jcode_numbered_prompt_line(line)
+                || line.contains("session ready")
+                || line.contains("ready for input")
+        })
+    {
+        return "idle";
+    }
+
+    // Working: spinner, tool bar, or explicit tool execution lines
+    if has_jcode_spinner(&bottom8)
+        || has_jcode_spinner(&bottom6)
+        || has_jcode_tool_bar(&bottom4)
+        || contains_any(
+            &bottom4,
+            &[
+                "running tool",
+                "executing tool",
+                "network disconnected, waiting to retry",
+            ],
+        )
+    {
+        return "working";
+    }
+
+    // Alecuba16-specific Overview panel markers that indicate an idle/waiting state:
+    // - Session count header (`N sessions`)
+    // - Dashed separator lines (`- - -`)
+    // - Cost/tok line with t/s footer (`⌀`)
+    // - Memory icon (`🧠`)
+    // - Swarm icon (`🐝`)
+    // If we see these Overview markers without a spinner/tool bar, the pane is idle.
+    let has_overview_markers = bottom8.lines().any(|line| {
+        let line = line.trim();
+        // Session count header: "N sessions" or "N sessions · branch"
+        (line.contains(" sessions") && line.split_whitespace().next().is_some_and(|w| w.parse::<usize>().is_ok()))
+        // Dashed separator: "- - -" (at least 2 dash-space pairs)
+        || line.starts_with("- ") && line.matches("- ").count() >= 2
+        // Cost/tok line with t/s: contains "⌀" and "tok"
+        || (line.contains("⌀") && line.contains("tok"))
+        // Memory icon
+        || line.starts_with("🧠 ")
+        // Swarm icon
+        || line.starts_with("🐝 ")
+    });
+
+    if has_overview_markers {
+        return "idle";
+    }
+
+    // Fallback: vanilla idle heuristics (prompt-like lines without working indicators)
+    if (contains_any(&bottom3, &["session ready", "ready for input"])
+        || bottom3.lines().any(|line| line.trim() == "❯"))
+        && !contains_any(
+            &bottom3,
+            &["processing", "embedding", "running tool", "executing"],
+        )
+    {
+        return "idle";
+    }
+
+    "unknown"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtin_detection::JcodeDetectionVariant;
+
+    #[test]
+    fn vanilla_idle_prompt() {
+        assert_eq!(
+            detect_jcode_status_with_variant("❯", JcodeDetectionVariant::Vanilla),
+            "idle"
+        );
+        assert_eq!(
+            detect_jcode_status_with_variant("1> ", JcodeDetectionVariant::Vanilla),
+            "idle"
+        );
+        assert_eq!(
+            detect_jcode_status_with_variant("Session ready\n❯", JcodeDetectionVariant::Vanilla),
+            "idle"
+        );
+    }
+
+    #[test]
+    fn vanilla_working_spinner() {
+        assert_eq!(
+            detect_jcode_status_with_variant("⠋ thinking…", JcodeDetectionVariant::Vanilla),
+            "working"
+        );
+        assert_eq!(
+            detect_jcode_status_with_variant("··● bash ●·· · 12s", JcodeDetectionVariant::Vanilla),
+            "working"
+        );
+    }
+
+    #[test]
+    fn vanilla_blocked() {
+        let blocked = "Permission request\n❯ Allow once\n  Deny";
+        assert_eq!(
+            detect_jcode_status_with_variant(&blocked.to_lowercase(), JcodeDetectionVariant::Vanilla),
+            "blocked"
+        );
+    }
+
+    #[test]
+    fn alecuba16_overview_idle() {
+        // Overview panel with session count, separator, cost line, memory, swarm
+        let overview = "3 sessions · fix/info_fields\n\
+- - - - - - - - - - - - - - - - - - - - - -\n\
+💰 $0.0012  ↓45k ↑12k tok  ⌀38.2 t/s\n\
+🧠 47 memories\n\
+🐝 3 sessions\n❯";
+        assert_eq!(
+            detect_jcode_status_with_variant(overview, JcodeDetectionVariant::Alecuba16),
+            "idle"
+        );
+    }
+
+    #[test]
+    fn alecuba16_overview_idle_no_prompt() {
+        // Overview panel visible, no prompt at bottom yet (still idle)
+        let overview = "1 session · main\n\
+- - - - - - - - - - - - - - - - - - - - - -\n\
+💰 $0.0000  ↓0 ↑0 tok  ⌀0.0 t/s\n\
+🧠 0 memories\n\
+🐝 0 sessions";
+        assert_eq!(
+            detect_jcode_status_with_variant(overview, JcodeDetectionVariant::Alecuba16),
+            "idle"
+        );
+    }
+
+    #[test]
+    fn alecuba16_working_spinner() {
+        let working = "⠋ sending… 0.3s\n\
+3 sessions · main\n\
+- - - - - - - - - - - - - - - - - - - - - -\n\
+💰 $0.0012  ↓45k ↑12k tok  ⌀38.2 t/s\n\
+🧠 47 memories\n\
+🐝 3 sessions";
+        assert_eq!(
+            detect_jcode_status_with_variant(&working.to_lowercase(), JcodeDetectionVariant::Alecuba16),
+            "working"
+        );
+    }
+
+    #[test]
+    fn alecuba16_blocked() {
+        let blocked = "Permission request\n❯ Allow once\n  Deny\n\
+3 sessions · main\n\
+- - - - - - - - - - - - - - - - - - - - - -\n\
+💰 $0.0012  ↓45k ↑12k tok  ⌀38.2 t/s\n\
+🧠 47 memories\n\
+🐝 3 sessions";
+        assert_eq!(
+            detect_jcode_status_with_variant(&blocked.to_lowercase(), JcodeDetectionVariant::Alecuba16),
+            "blocked"
+        );
+    }
+
+    #[test]
+    fn variant_dispatch_vanilla_default() {
+        assert_eq!(
+            detect_jcode_status_with_variant("❯", JcodeDetectionVariant::Vanilla),
+            "idle"
+        );
+    }
+
+    #[test]
+    fn variant_dispatch_alecuba16() {
+        let overview = "1 session · main\n- - - - \n💰 $0.00  ↓0 ↑0 tok  ⌀0.0 t/s\n🧠 0 memories\n🐝 0 sessions";
+        assert_eq!(
+            detect_jcode_status_with_variant(overview, JcodeDetectionVariant::Alecuba16),
+            "idle"
+        );
+        // Same input with vanilla variant should be unknown (no vanilla markers)
+        assert_eq!(
+            detect_jcode_status_with_variant(overview, JcodeDetectionVariant::Vanilla),
+            "unknown"
+        );
+    }
+}

--- a/src/builtin_detection/jcode.rs
+++ b/src/builtin_detection/jcode.rs
@@ -5,14 +5,17 @@
 //! `herdr_detectable` branch) are handled upstream in `detect_agent_status_with_osc` and
 //! take precedence; this module only provides the screen-scrape fallback.
 
-use crate::builtin_detection::JcodeDetectionVariant;
 use crate::builtin_backend::{
-    bottom_non_empty_lines, contains_any, has_jcode_spinner, has_jcode_tool_bar,
-    jcode_blocked, jcode_idle_line, jcode_numbered_prompt_line, jcode_question_blocked,
+    bottom_non_empty_lines, contains_any, has_jcode_spinner, has_jcode_tool_bar, jcode_blocked,
+    jcode_idle_line, jcode_numbered_prompt_line, jcode_question_blocked,
 };
+use crate::builtin_detection::JcodeDetectionVariant;
 
 /// Screen-scrape detection for jcode, selected by variant.
-pub fn detect_jcode_status_with_variant(lower: &str, variant: JcodeDetectionVariant) -> &'static str {
+pub fn detect_jcode_status_with_variant(
+    lower: &str,
+    variant: JcodeDetectionVariant,
+) -> &'static str {
     match variant {
         JcodeDetectionVariant::Vanilla => detect_jcode_status_vanilla(lower),
         JcodeDetectionVariant::Alecuba16 => detect_jcode_status_alecuba16(lower),
@@ -190,7 +193,10 @@ mod tests {
     fn vanilla_blocked() {
         let blocked = "Permission request\n❯ Allow once\n  Deny";
         assert_eq!(
-            detect_jcode_status_with_variant(&blocked.to_lowercase(), JcodeDetectionVariant::Vanilla),
+            detect_jcode_status_with_variant(
+                &blocked.to_lowercase(),
+                JcodeDetectionVariant::Vanilla
+            ),
             "blocked"
         );
     }
@@ -232,7 +238,10 @@ mod tests {
 🧠 47 memories\n\
 🐝 3 sessions";
         assert_eq!(
-            detect_jcode_status_with_variant(&working.to_lowercase(), JcodeDetectionVariant::Alecuba16),
+            detect_jcode_status_with_variant(
+                &working.to_lowercase(),
+                JcodeDetectionVariant::Alecuba16
+            ),
             "working"
         );
     }
@@ -246,7 +255,10 @@ mod tests {
 🧠 47 memories\n\
 🐝 3 sessions";
         assert_eq!(
-            detect_jcode_status_with_variant(&blocked.to_lowercase(), JcodeDetectionVariant::Alecuba16),
+            detect_jcode_status_with_variant(
+                &blocked.to_lowercase(),
+                JcodeDetectionVariant::Alecuba16
+            ),
             "blocked"
         );
     }

--- a/src/builtin_detection/mod.rs
+++ b/src/builtin_detection/mod.rs
@@ -1,0 +1,125 @@
+//! Modular built-in backend agent detection.
+//!
+//! This module groups per-agent screen-scrape detection logic so new agents
+//! (and forks of existing agents) can be added without growing the monolithic
+//! `builtin_backend.rs` switch. Each agent lives in its own submodule and
+//! exposes a `detect_<agent>_status(lower) -> &'static str` function plus any
+//! helpers it needs.
+//!
+//! Detection variants for the same agent (for example, jcode's upstream
+//! "vanilla" output format versus the alecuba16 fork's redesigned Overview
+//! panel) live side by side under the agent module and are selected at
+//! runtime through the persisted `JcodeDetectionVariant` setting.
+//!
+//! IMPORTANT: The jcode variant selector is a **temporary** affordance. It
+//! exists only while the upstream jcode TUI output format diverges from the
+//! alecuba16 fork. Once vanilla jcode adopts the same Overview panel layout,
+//! this selector should be removed and the two variants merged back into a
+//! single `detect_jcode_status` implementation. See `docs/features.md` and
+//! `docs/technical-details.md` for the temporary annotation.
+
+pub mod jcode;
+
+use serde::{Deserialize, Serialize};
+
+/// Selects which jcode screen-scrape pattern set the built-in backend uses.
+///
+/// `Vanilla` matches the upstream jcode master output format (numbered
+/// prompts like `1> `, the `❯` idle caret, the `··● bash ●··` tool bar).
+///
+/// `Alecuba16` matches the alecuba16 fork output format introduced by the
+/// `fix/info_fields` and `herdr_detectable` branches: a redesigned Overview
+/// panel with dashed separators, session-count header, memory/swarm icons,
+/// and a cost/tokens-per-second footer line.
+///
+/// This is a **temporary** selector that will be removed once vanilla jcode
+/// converges on the same output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum JcodeDetectionVariant {
+    /// Upstream jcode master output format.
+    Vanilla,
+    /// alecuba16 fork (`fix/info_fields` + `herdr_detectable`) output format.
+    #[default]
+    Alecuba16,
+}
+
+impl JcodeDetectionVariant {
+    /// Stable string used in settings JSON and API responses.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Vanilla => "vanilla",
+            Self::Alecuba16 => "alecuba16",
+        }
+    }
+
+    /// Parse a stored variant string. Unknown values fall back to `Vanilla`
+    /// so a corrupted settings file never breaks detection.
+    pub fn from_str(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "alecuba16" => Self::Alecuba16,
+            _ => Self::Vanilla,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_variant_is_alecuba16() {
+        assert_eq!(JcodeDetectionVariant::default(), JcodeDetectionVariant::Alecuba16);
+    }
+
+    #[test]
+    fn variant_round_trips_serde() {
+        for variant in [JcodeDetectionVariant::Vanilla, JcodeDetectionVariant::Alecuba16] {
+            let json = serde_json::to_string(&variant).expect("serialize");
+            let parsed: JcodeDetectionVariant =
+                serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(variant, parsed, "round trip for {variant:?} via {json:?}");
+        }
+    }
+
+    #[test]
+    fn variant_serde_uses_lowercase() {
+        assert_eq!(serde_json::to_string(&JcodeDetectionVariant::Vanilla).unwrap(), "\"vanilla\"");
+        assert_eq!(
+            serde_json::to_string(&JcodeDetectionVariant::Alecuba16).unwrap(),
+            "\"alecuba16\""
+        );
+    }
+
+    #[test]
+    fn from_str_parses_known_variants() {
+        assert_eq!(JcodeDetectionVariant::from_str("vanilla"), JcodeDetectionVariant::Vanilla);
+        assert_eq!(
+            JcodeDetectionVariant::from_str("alecuba16"),
+            JcodeDetectionVariant::Alecuba16
+        );
+    }
+
+    #[test]
+    fn from_str_falls_back_to_vanilla_for_unknown() {
+        assert_eq!(
+            JcodeDetectionVariant::from_str("unknown"),
+            JcodeDetectionVariant::Vanilla
+        );
+        assert_eq!(JcodeDetectionVariant::from_str(""), JcodeDetectionVariant::Vanilla);
+        assert_eq!(
+            JcodeDetectionVariant::from_str("ALECUBA16"),
+            JcodeDetectionVariant::Alecuba16,
+            "from_str should be case-insensitive"
+        );
+    }
+
+    #[test]
+    fn as_str_matches_serde_form() {
+        for variant in [JcodeDetectionVariant::Vanilla, JcodeDetectionVariant::Alecuba16] {
+            let serde = serde_json::to_string(&variant).unwrap();
+            let expected = format!("\"{}\"", variant.as_str());
+            assert_eq!(serde, expected, "as_str should match serde form for {variant:?}");
+        }
+    }
+}

--- a/src/builtin_detection/mod.rs
+++ b/src/builtin_detection/mod.rs
@@ -69,22 +69,30 @@ mod tests {
 
     #[test]
     fn default_variant_is_alecuba16() {
-        assert_eq!(JcodeDetectionVariant::default(), JcodeDetectionVariant::Alecuba16);
+        assert_eq!(
+            JcodeDetectionVariant::default(),
+            JcodeDetectionVariant::Alecuba16
+        );
     }
 
     #[test]
     fn variant_round_trips_serde() {
-        for variant in [JcodeDetectionVariant::Vanilla, JcodeDetectionVariant::Alecuba16] {
+        for variant in [
+            JcodeDetectionVariant::Vanilla,
+            JcodeDetectionVariant::Alecuba16,
+        ] {
             let json = serde_json::to_string(&variant).expect("serialize");
-            let parsed: JcodeDetectionVariant =
-                serde_json::from_str(&json).expect("deserialize");
+            let parsed: JcodeDetectionVariant = serde_json::from_str(&json).expect("deserialize");
             assert_eq!(variant, parsed, "round trip for {variant:?} via {json:?}");
         }
     }
 
     #[test]
     fn variant_serde_uses_lowercase() {
-        assert_eq!(serde_json::to_string(&JcodeDetectionVariant::Vanilla).unwrap(), "\"vanilla\"");
+        assert_eq!(
+            serde_json::to_string(&JcodeDetectionVariant::Vanilla).unwrap(),
+            "\"vanilla\""
+        );
         assert_eq!(
             serde_json::to_string(&JcodeDetectionVariant::Alecuba16).unwrap(),
             "\"alecuba16\""
@@ -93,7 +101,10 @@ mod tests {
 
     #[test]
     fn from_str_parses_known_variants() {
-        assert_eq!(JcodeDetectionVariant::from_str("vanilla"), JcodeDetectionVariant::Vanilla);
+        assert_eq!(
+            JcodeDetectionVariant::from_str("vanilla"),
+            JcodeDetectionVariant::Vanilla
+        );
         assert_eq!(
             JcodeDetectionVariant::from_str("alecuba16"),
             JcodeDetectionVariant::Alecuba16
@@ -106,7 +117,10 @@ mod tests {
             JcodeDetectionVariant::from_str("unknown"),
             JcodeDetectionVariant::Vanilla
         );
-        assert_eq!(JcodeDetectionVariant::from_str(""), JcodeDetectionVariant::Vanilla);
+        assert_eq!(
+            JcodeDetectionVariant::from_str(""),
+            JcodeDetectionVariant::Vanilla
+        );
         assert_eq!(
             JcodeDetectionVariant::from_str("ALECUBA16"),
             JcodeDetectionVariant::Alecuba16,
@@ -116,10 +130,16 @@ mod tests {
 
     #[test]
     fn as_str_matches_serde_form() {
-        for variant in [JcodeDetectionVariant::Vanilla, JcodeDetectionVariant::Alecuba16] {
+        for variant in [
+            JcodeDetectionVariant::Vanilla,
+            JcodeDetectionVariant::Alecuba16,
+        ] {
             let serde = serde_json::to_string(&variant).unwrap();
             let expected = format!("\"{}\"", variant.as_str());
-            assert_eq!(serde, expected, "as_str should match serde form for {variant:?}");
+            assert_eq!(
+                serde, expected,
+                "as_str should match serde form for {variant:?}"
+            );
         }
     }
 }

--- a/src/git_ui/mod.rs
+++ b/src/git_ui/mod.rs
@@ -764,7 +764,9 @@ mod tests {
     use super::log::*;
     use super::stash::*;
     use super::*;
-    use crate::{AuthConfig, BackendMode, JcodeDetectionVariant, NoSleepState, RuntimeServerSettings};
+    use crate::{
+        AuthConfig, BackendMode, JcodeDetectionVariant, NoSleepState, RuntimeServerSettings,
+    };
     use axum::body::to_bytes;
     use serde_json::Value;
     use std::collections::HashMap;

--- a/src/git_ui/mod.rs
+++ b/src/git_ui/mod.rs
@@ -764,7 +764,7 @@ mod tests {
     use super::log::*;
     use super::stash::*;
     use super::*;
-    use crate::{AuthConfig, BackendMode, NoSleepState, RuntimeServerSettings};
+    use crate::{AuthConfig, BackendMode, JcodeDetectionVariant, NoSleepState, RuntimeServerSettings};
     use axum::body::to_bytes;
     use serde_json::Value;
     use std::collections::HashMap;
@@ -814,6 +814,7 @@ mod tests {
                 default_folder: std::env::temp_dir().to_string_lossy().to_string(),
                 builtin_backend_enabled: true,
                 external_herdr_backend_enabled: true,
+                jcode_detection_variant: JcodeDetectionVariant::default(),
             })),
             no_sleep: Arc::new(Mutex::new(NoSleepState::default())),
             rebind_tx,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
+use crate::builtin_detection::JcodeDetectionVariant;
+
 mod assets;
 mod builtin_backend;
+mod builtin_detection;
 mod builtin_events;
 mod compat;
 mod file_browser;
@@ -181,6 +184,7 @@ struct PersistedServerSettings {
     default_folder: Option<String>,
     builtin_backend_enabled: Option<bool>,
     external_herdr_backend_enabled: Option<bool>,
+    jcode_detection_variant: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -195,6 +199,7 @@ struct RuntimeServerSettings {
     default_folder: String,
     builtin_backend_enabled: bool,
     external_herdr_backend_enabled: bool,
+    jcode_detection_variant: JcodeDetectionVariant,
 }
 
 struct NoSleepGuard {
@@ -596,6 +601,7 @@ fn default_runtime_server_settings(bind: SocketAddr) -> RuntimeServerSettings {
         default_folder: default_working_folder(None),
         builtin_backend_enabled: true,
         external_herdr_backend_enabled: true,
+        jcode_detection_variant: JcodeDetectionVariant::default(),
     }
 }
 
@@ -773,6 +779,9 @@ fn load_runtime_server_settings(default_bind: SocketAddr) -> io::Result<RuntimeS
     if let Some(enabled) = persisted.external_herdr_backend_enabled {
         settings.external_herdr_backend_enabled = enabled;
     }
+    if let Some(variant_str) = persisted.jcode_detection_variant {
+        settings.jcode_detection_variant = JcodeDetectionVariant::from_str(&variant_str);
+    }
     validate_runtime_server_settings(&settings)?;
     if missing_keys {
         save_runtime_server_settings(&settings)?;
@@ -797,6 +806,7 @@ fn save_runtime_server_settings(settings: &RuntimeServerSettings) -> io::Result<
         default_folder: Some(settings.default_folder.clone()),
         builtin_backend_enabled: Some(settings.builtin_backend_enabled),
         external_herdr_backend_enabled: Some(settings.external_herdr_backend_enabled),
+        jcode_detection_variant: Some(settings.jcode_detection_variant.as_str().to_string()),
     })?;
     fs::write(&path, content)?;
     #[cfg(unix)]
@@ -888,6 +898,7 @@ async fn main() -> io::Result<()> {
                 client_socket: _client_socket,
                 cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                 shell: server_settings.builtin_shell.clone(),
+                jcode_detection_variant: server_settings.jcode_detection_variant,
             },
         )?);
         let api_socket = handle.api_socket().to_path_buf();
@@ -2048,6 +2059,10 @@ async fn update_server_settings(
                     .map(|settings| settings.external_herdr_backend_enabled)
             })
             .unwrap_or(true),
+        jcode_detection_variant: current
+            .as_ref()
+            .map(|settings| settings.jcode_detection_variant)
+            .unwrap_or_default(),
     };
     let bind_changed = current
         .as_ref()
@@ -2204,6 +2219,12 @@ fn ensure_builtin_session(state: &WebState, session: Option<&str>) -> Result<(),
             client_socket,
             cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             shell,
+            jcode_detection_variant: state
+                .server_settings
+                .lock()
+                .ok()
+                .map(|settings| settings.jcode_detection_variant)
+                .unwrap_or_default(),
         })
         .map_err(|err| err.to_string())?;
     state
@@ -3948,6 +3969,7 @@ mod tests {
                 default_folder: std::env::temp_dir().to_string_lossy().to_string(),
                 builtin_backend_enabled: true,
                 external_herdr_backend_enabled: true,
+                jcode_detection_variant: JcodeDetectionVariant::default(),
             })),
             no_sleep: Arc::new(Mutex::new(NoSleepState::default())),
             rebind_tx,
@@ -4704,6 +4726,7 @@ mod tests {
             default_folder: std::env::temp_dir().to_string_lossy().to_string(),
             builtin_backend_enabled: true,
             external_herdr_backend_enabled: true,
+            jcode_detection_variant: JcodeDetectionVariant::default(),
         })
         .unwrap();
 
@@ -4726,6 +4749,7 @@ mod tests {
             default_folder: std::env::temp_dir().to_string_lossy().to_string(),
             builtin_backend_enabled: true,
             external_herdr_backend_enabled: true,
+            jcode_detection_variant: JcodeDetectionVariant::default(),
         }) {
             Ok(_) => panic!("expected public auth config to fail"),
             Err(err) => err,


### PR DESCRIPTION
## Summary

Implements jcode detection variant support for herdr-webui's builtin backend. Two divergent jcode worlds exist:

- **Vanilla** (upstream jcode): emits structured OSC 9 payloads (/) that Herdr already parses; screen-scrape fallback matches numbered prompts (),  caret, braille spinners,  tool bar
- **alecuba16 fork** (this repo): redesigned Overview panel with session count header, dashed separators, cost/tok footer (), memory (), swarm () - emits NO OSC 9, so detection falls back to screen-scraping

## Changes

1. **Settings persistence**: Added  field to  and  with load/save to 

2. **Call chain threading**:  →  →  all receive and store the variant

3. **New module** : 
   -  - dispatches to variant-specific logic
   -  - upstream patterns
   -  - fork Overview panel patterns

4. **Helper exports**: Made 8 jcode helper functions  for the jcode module

5. **Detection signatures**: Updated  and  to accept 

6. **Default variant**: Changed from  to  for this fork

7. **Tests**: Fixed all 10 broken test calls, 3 failing detection tests; all 225 tests pass (37 lib + 183 bin + 5 tui)

**OSC 9 remains authoritative** - the variant only selects the screen-scrape fallback when OSC 9 is silent.