### PR TITLE
fix: bump wire protocol 16 -> 18 for Herdr 0.7.5+ compatibility

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,10 +61,10 @@ const HERDR_WEBUI_VERSION: &str = env!("HERDR_WEBUI_VERSION");
 const INSTALL_LABEL: &str = "herdr-web";
 const MAX_FRAME_SIZE: usize = 2 * 1024 * 1024;
 const MAX_GRAPHICS_FRAME_SIZE: usize = 32 * 1024 * 1024;
-const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 14;
-const PROTOCOL_VERSION: u32 = 16;
-const MIN_BACKEND_VERSION: &str = "0.7.0";
-const MAX_TESTED_BACKEND_VERSION: &str = "0.7.3";
+const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 16;
+const PROTOCOL_VERSION: u32 = 18;
+const MIN_BACKEND_VERSION: &str = "0.7.3";
+const MAX_TESTED_BACKEND_VERSION: &str = "0.7.5";
 const DEFAULT_FOLDER_READ_TIMEOUT: Duration = Duration::from_millis(1500);
 
 type LocalStream = interprocess::local_socket::Stream;
@@ -4105,7 +4105,7 @@ mod tests {
     fn builtin_event_hub_detection_only_matches_builtin_protocol_16() {
         assert!(backend_uses_builtin_event_hub(&BackendInfo {
             version: Some("builtin-0.1.0".to_string()),
-            protocol: Some(16),
+            protocol: Some(18),
         }));
         assert!(!backend_uses_builtin_event_hub(&BackendInfo {
             version: Some("builtin-0.1.0".to_string()),
@@ -4113,11 +4113,11 @@ mod tests {
         }));
         assert!(!backend_uses_builtin_event_hub(&BackendInfo {
             version: Some("1.2.3".to_string()),
-            protocol: Some(16),
+            protocol: Some(18),
         }));
         assert!(!backend_uses_builtin_event_hub(&BackendInfo {
             version: None,
-            protocol: Some(16),
+            protocol: Some(18),
         }));
     }
 
@@ -5060,22 +5060,14 @@ mod tests {
     #[test]
     fn classifies_backend_compatibility() {
         assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.6.9"), Some(PROTOCOL_VERSION)),
+            backend_compatibility_for_supported_range(Some("0.7.2"), Some(PROTOCOL_VERSION)),
             BackendCompatibility::TooOld
         );
         assert_eq!(
             backend_compatibility_for_supported_range(
-                Some("0.7.0"),
+                Some("0.7.3"),
                 Some(MIN_SUPPORTED_PROTOCOL_VERSION),
             ),
-            BackendCompatibility::Compatible
-        );
-        assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.0"), Some(PROTOCOL_VERSION)),
-            BackendCompatibility::Compatible
-        );
-        assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.1"), Some(PROTOCOL_VERSION)),
             BackendCompatibility::Compatible
         );
         assert_eq!(
@@ -5084,6 +5076,14 @@ mod tests {
         );
         assert_eq!(
             backend_compatibility_for_supported_range(Some("0.7.4"), Some(PROTOCOL_VERSION)),
+            BackendCompatibility::Compatible
+        );
+        assert_eq!(
+            backend_compatibility_for_supported_range(Some("0.7.5"), Some(PROTOCOL_VERSION)),
+            BackendCompatibility::Compatible
+        );
+        assert_eq!(
+            backend_compatibility_for_supported_range(Some("0.7.6"), Some(PROTOCOL_VERSION)),
             BackendCompatibility::UntestedNewer
         );
         assert_eq!(
@@ -5095,11 +5095,11 @@ mod tests {
             BackendCompatibility::Unknown
         );
         assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.0"), None),
+            backend_compatibility_for_supported_range(Some("0.7.3"), None),
             BackendCompatibility::Unknown
         );
         assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.0"), Some(PROTOCOL_VERSION + 1)),
+            backend_compatibility_for_supported_range(Some("0.7.3"), Some(PROTOCOL_VERSION + 1)),
             BackendCompatibility::ProtocolMismatch
         );
     }
@@ -5108,19 +5108,19 @@ mod tests {
     fn terminal_protocol_fallback_retries_only_newer_client_mismatch() {
         assert!(should_retry_legacy_protocol(
             PROTOCOL_VERSION,
-            "client version 16 is newer than server version 15; please upgrade the herdr server",
+            "client version 18 is newer than server version 17; please upgrade the herdr server",
         ));
         assert!(should_retry_legacy_protocol(
             PROTOCOL_VERSION - 1,
-            "client version 15 is newer than server version 14; please upgrade the herdr server",
+            "client version 17 is newer than server version 16; please upgrade the herdr server",
         ));
         assert!(!should_retry_legacy_protocol(
             MIN_SUPPORTED_PROTOCOL_VERSION,
-            "client version 14 is newer than server version 13; please upgrade the herdr server",
+            "client version 16 is newer than server version 15; please upgrade the herdr server",
         ));
         assert!(!should_retry_legacy_protocol(
             PROTOCOL_VERSION,
-            "client version 16 is older than the minimum supported version 17",
+            "client version 18 is older than the minimum supported version 19",
         ));
         assert!(!should_retry_legacy_protocol(
             PROTOCOL_VERSION,
@@ -5439,7 +5439,7 @@ mod tests {
     async fn versions_api_reports_backend_compatibility_from_fake_socket() {
         let (socket, handle) = fake_api_socket(json!({
             "id": "web:ping",
-            "result": { "version": "0.7.0", "protocol": PROTOCOL_VERSION }
+            "result": { "version": "0.7.5", "protocol": PROTOCOL_VERSION }
         }));
         let mut state = test_state();
         state.api_socket = Some(socket.clone());
@@ -5456,7 +5456,7 @@ mod tests {
             .unwrap();
         let body = response_json(response).await;
 
-        assert_eq!(body["backend"], "0.7.0");
+        assert_eq!(body["backend"], "0.7.5");
         assert_eq!(body["min_backend"], MIN_BACKEND_VERSION);
         assert_eq!(body["max_tested_backend"], MAX_TESTED_BACKEND_VERSION);
         assert_eq!(body["protocol_version"], PROTOCOL_VERSION);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -253,6 +253,13 @@ pub(crate) enum ServerMessage {
     MouseCapture {
         enabled: bool,
     },
+    /// Whether the focused terminal requests Kitty report-all keyboard input.
+    /// The backend sends this so the client can adjust its input handling;
+    /// a web client does not act on it, so we only need to deserialize it.
+    /// Added in protocol 18.
+    KittyKeyboardReportAll {
+        enabled: bool,
+    },
     /// Forwarded macOS prefix-mode ASCII input-source switch request. The
     /// backend sends this to the foreground client so it can swap the host
     /// keyboard layout; a web client has no host keyboard to switch, so we


### PR DESCRIPTION
## Summary

Fixes #105

Herdr 0.7.5 bumped the wire protocol to 17, and Herdr master is already at 18. This PR updates herdr-webui's external connectivity module to match.

## Changes

- **Bump `PROTOCOL_VERSION` from 16 to 18** — matches Herdr master protocol version
- **Raise `MIN_SUPPORTED_PROTOCOL_VERSION` from 14 to 16** — drops protocols 14 and 15, keeping only 3 supported protocols (16, 17, 18) as requested
- **Update `MIN_BACKEND_VERSION` from 0.7.0 to 0.7.3** — aligns with the new minimum protocol
- **Update `MAX_TESTED_BACKEND_VERSION` from 0.7.3 to 0.7.5** — tested against Herdr 0.7.5
- **Add `KittyKeyboardReportAll` variant to `ServerMessage`** — new server-to-client message added in protocol 18 (deserialized but not acted on by web client)
- **Update all protocol-version-dependent tests**

## Protocol 16 -> 18 delta

- Protocol 17: added `ObserveTerminal` and `ControlTerminal` client messages (herdr-webui never sends these)
- Protocol 18: added `KittyKeyboardReportAll` server message (now handled by this PR)
- No changes to `FrameData`, `TerminalFrame`, or `CellData` wire formats

## Test results

All 225 Rust tests pass. All 248 JS tests pass.