### PR TITLE
release: v0.2.88

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-webui"
-version = "0.2.87"
+version = "0.2.88"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.87"
+version = "0.2.88"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"


### PR DESCRIPTION
Bump version to 0.2.88. Includes fix for stale agent presentation cache (#115).