### PR TITLE
fix: add missing @font-face for bundled Nerd Font

### DIFF
--- a/src/assets/desktop/app_css/base.css
+++ b/src/assets/desktop/app_css/base.css
@@ -1,3 +1,16 @@
+@font-face {
+  font-family: "Herdr JetBrainsMono Nerd Font Mono";
+  src:
+    local("JetBrainsMono Nerd Font Mono"),
+    local("JetBrainsMonoNerdFontMono-Regular"),
+    url("/assets/fonts/JetBrainsMonoNerdFontMono-Regular.ttf")
+      format("truetype");
+  font-style: normal;
+  font-weight: 400;
+  font-variant: normal;
+  font-display: swap;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -34,7 +47,9 @@ body {
   --editor-syntax-operator: #cdd6f4;
   --editor-syntax-meta: #b4befe;
   --editor-syntax-invalid: #f38ba8;
-  --mono-font: "Herdr JetBrainsMono Nerd Font Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --mono-font:
+    "Herdr JetBrainsMono Nerd Font Mono", ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, monospace;
   margin: 0;
   background: var(--bg);
   color: var(--fg);

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -1,3 +1,14 @@
+@font-face {
+  font-family: "Herdr JetBrainsMono Nerd Font Mono";
+  src: local("JetBrainsMono Nerd Font Mono"),
+       local("JetBrainsMonoNerdFontMono-Regular"),
+       url("/assets/fonts/JetBrainsMonoNerdFontMono-Regular.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 400;
+  font-variant: normal;
+  font-display: swap;
+}
+
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
**Bug:** Nerd Font icons (git branch symbols, devicons, etc.) didn't render in the terminal on chrome in mobile because the bundled `JetBrainsMonoNerdFontMono-Regular.ttf` was served at `/assets/fonts/` but never registered via `@font-face` in CSS. The browser couldn't resolve the `"Herdr JetBrainsMono Nerd Font Mono"` font family name.

**Fix:** Added `@font-face` declarations in `base.css` (desktop) and `app.css` (mobile) that map the font family name to the bundled TTF URL.

**Testing:** Verified icons render correctly on both desktop and mobile. Desktop with MesloLGS NF installed still works (falls back to it when bundled font unavailable), mobile now works without any system fonts.

**Before:**
<img width="1080" height="2400" alt="IMG_20260802_043143" src="https://github.com/user-attachments/assets/5f7d9509-36de-4c05-ae09-e48903e48726" />

**After:**
<img width="1080" height="2400" alt="IMG_20260802_043243" src="https://github.com/user-attachments/assets/1ef10e22-1fad-40f8-9f86-af97e3eb10d0" />