### PR TITLE
MLO-120: chore bump version to 0.2.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-webui"
-version = "0.2.88"
+version = "0.2.89"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.88"
+version = "0.2.89"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"


### PR DESCRIPTION
## Summary

- Bump the WebUI version from 0.2.88 to 0.2.89.
- Prepare the merged Claurst detection changes for the next release.

## Test plan

- `cargo check --workspace`
- `cargo fmt --all --check`
