### PR TITLE
release: v0.2.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-webui"
-version = "0.2.88"
+version = "0.2.89"
 dependencies = [
  "axum",
  "axum-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "herdr-webui"
 # Static package version tracks the next WebUI SemVer; runtime builds use build.rs.
-version = "0.2.88"
+version = "0.2.89"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/alecuba16/herdr-webui"


### PR DESCRIPTION
Release v0.2.89

This PR includes:
- Version bump from 0.2.88 to 0.2.89
- Claurst agent detection (screen-scrape detection for Claurst terminal coding agent)

The Claurst detection covers:
- **Idle**: `>` prompt pointer on last non-empty line, or `BUILD`/`PLAN` agent-mode status line above prompt
- **Working**: Spinner chars followed by verb + ellipsis (e.g. `Thinking...`), braille spinner fallback, or `esc to cancel` indicator
- **Blocked**: Permission dialog with canonical labels (`Yes, allow once`, `Yes, allow this session`, `Yes, always allow (persistent)`, `No, deny`, `Allow commands matching...`)

New file: `src/builtin_detection/claurst.rs` with `detect_claurst_status()` function and comprehensive test coverage (16 test cases).