### PR TITLE
feat: add panel close button visibility setting (always/smart)

### DIFF
--- a/src/assets/app.html
+++ b/src/assets/app.html
@@ -108,6 +108,13 @@
               >Ask this browser to show system notifications when an agent needs attention.</small
             ></span
           ></label
+        ><label class="option"
+          ><span>Panel close button visibility<small
+            >Smart hides the per-panel ✕ close button when only one panel is open. Always shows it regardless of panel count.</small
+          ></span><select class="settings-select" id="optPanelCloseMode"
+            ><option value="smart">Smart (only when multiple panels)</option
+            ><option value="always">Always show</option></select
+          ></label
         >
         <div class="modal-actions">
           <button class="btn" id="settingsClose">Close</button>

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -239,6 +239,7 @@ describe("app bundle load", () => {
     ctx.localStorage.setItem("herdr-web-options", JSON.stringify({
       globalShortcutPrefix: "Ctrl+Q",
       webuiShortcuts: { help: "Shift+Slash", settings: "KeyS", newWorkspace: "KeyN", sidebar: "KeyB", newPanel: "KeyP", closePanel: "KeyX", closeWorkspace: "Shift+KeyX", removeWorktree: "Delete" },
+      panelCloseMode: "always"
     }));
     vm.runInContext(source, ctx);
     ctx.applyOptions();
@@ -260,6 +261,48 @@ describe("app bundle load", () => {
     const actions = ctx.selectedWorkspaceActionButtons({ workspace_id: "w1", worktree: { checkout_path: "/tmp/wt", is_linked_worktree: true } });
     ok(actions.includes('Ctrl+Q then Shift+X'));
     ok(actions.includes('Ctrl+Q then Delete'));
+  });
+
+  it("hides panel close button in smart mode when only one panel", () => {
+    const ctx = context();
+    ctx.localStorage.setItem("herdr-web-options", JSON.stringify({
+      globalShortcutPrefix: "Ctrl+Q",
+      webuiShortcuts: { help: "Shift+Slash", settings: "KeyS", newWorkspace: "KeyN", sidebar: "KeyB", newPanel: "KeyP", closePanel: "KeyX", closeWorkspace: "Shift+KeyX", removeWorktree: "Delete" },
+      panelCloseMode: "smart"
+    }));
+    vm.runInContext(source, ctx);
+    ctx.applyOptions();
+
+    vm.runInContext(`
+      state.ws = "w1";
+      state.tab = "t1";
+      state.tabs = [{ workspace_id: "w1", tab_id: "t1", label: "Shell" }];
+    `, ctx);
+    const html = ctx.renderPanelField();
+    ok(!html.includes('class="mini warn panel-close"'), "close button should be hidden with single panel in smart mode");
+  });
+
+  it("shows panel close button in smart mode when multiple panels", () => {
+    const ctx = context();
+    ctx.localStorage.setItem("herdr-web-options", JSON.stringify({
+      globalShortcutPrefix: "Ctrl+Q",
+      webuiShortcuts: { help: "Shift+Slash", settings: "KeyS", newWorkspace: "KeyN", sidebar: "KeyB", newPanel: "KeyP", closePanel: "KeyX", closeWorkspace: "Shift+KeyX", removeWorktree: "Delete" },
+      panelCloseMode: "smart"
+    }));
+    vm.runInContext(source, ctx);
+    ctx.applyOptions();
+
+    vm.runInContext(`
+      state.ws = "w1";
+      state.tab = "t1";
+      state.tabs = [
+        { workspace_id: "w1", tab_id: "t1", label: "Shell" },
+        { workspace_id: "w1", tab_id: "t2", label: "Git" }
+      ];
+    `, ctx);
+    const html = ctx.renderPanelField();
+    ok(html.includes('class="mini warn panel-close"'), "close button should be visible with multiple panels in smart mode");
+    ok(html.includes('title="Close current panel (Ctrl+Q then X)"'), "close button should have shortcut tooltip");
   });
 
   it("adds configured shortcut labels to Git tooltips", () => {
@@ -2448,6 +2491,7 @@ describe("app bundle load", () => {
 
   it("renders current panel as label with add and close buttons", () => {
     const ctx = context();
+    ctx.localStorage.setItem("herdr-web-options", JSON.stringify({ panelCloseMode: "always" }));
     vm.runInContext(source, ctx);
     const html = vm.runInContext(
       `state.ws = "ws1";

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -262,6 +262,12 @@ el("optShowTabActivity").onchange = () => {
   applyOptions();
   render();
 };
+el("optPanelCloseMode").onchange = () => {
+  options.panelCloseMode = el("optPanelCloseMode").value;
+  saveOptions();
+  applyOptions();
+  render();
+};
 el("optWorkspaceSort").onchange = () => {
   options.workspaceSort = el("optWorkspaceSort").value;
   saveOptions();

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -1082,6 +1082,7 @@ const defaultOptions = {
   fileContentSearchRegex: false,
   editorFindShortcutEnabled: true,
   showTabActivity: false,
+  panelCloseMode: "smart",
   worktreeAutoDiscoverSeconds: 3,
   generateWorktreeNames: false,
   worktreeDefaultDirectory: "",
@@ -1251,6 +1252,7 @@ function normalizeOptions(value) {
   next.fileContentSearchRegex = next.fileContentSearchRegex === true;
   next.editorFindShortcutEnabled = next.editorFindShortcutEnabled !== false;
   next.showTabActivity = next.showTabActivity === true;
+  next.panelCloseMode = ["always", "smart"].includes(next.panelCloseMode) ? next.panelCloseMode : "smart";
   next.worktreeAutoDiscoverSeconds = Math.max(
     0,
     Math.min(
@@ -1564,6 +1566,7 @@ function groupSettingsSections() {
         "optWorkingDismissMinutes",
         "optCloseShortcut",
         "optShowTabActivity",
+        "optPanelCloseMode",
       ],
     },
     {
@@ -1709,6 +1712,7 @@ function applyOptions() {
     fileContentSearchRegex = el("optFileContentSearchRegex"),
     scrollLinesValue = el("scrollLinesValue"),
     showTabActivity = el("optShowTabActivity"),
+    panelCloseMode = el("optPanelCloseMode"),
     worktreeAutoDiscover = el("optWorktreeAutoDiscover"),
     generateWorktreeNames = el("optGenerateWorktreeNames"),
     worktreeDefaultDirectory = el("optWorktreeDefaultDirectory"),
@@ -1795,6 +1799,7 @@ function applyOptions() {
   if (scrollLinesValue)
     scrollLinesValue.textContent = String(options.scrollLines || 3);
   if (showTabActivity) showTabActivity.checked = !!options.showTabActivity;
+  if (panelCloseMode) panelCloseMode.value = options.panelCloseMode || "smart";
   if (worktreeAutoDiscover)
     worktreeAutoDiscover.value = String(
       options.worktreeAutoDiscoverSeconds ?? 3,

--- a/src/assets/desktop/app_js/panel_switcher.js
+++ b/src/assets/desktop/app_js/panel_switcher.js
@@ -30,6 +30,12 @@ function panelTooltip(tab, index, tabs = state.tabs || []) {
     : `Current panel: ${visible} · ${title}. Double-click to rename.`;
 }
 
+function canClosePanel(tabs) {
+  if (!tabs || !tabs.length) return false;
+  if (!options || options.panelCloseMode !== "always") return tabs.length > 1;
+  return true;
+}
+
 function renderPanelField() {
   if (!state.ws) return '<span class="panel-field-empty">No panel</span>';
   const tabs = state.tabs || [];
@@ -37,16 +43,16 @@ function renderPanelField() {
   const currentIndex = current ? tabs.findIndex((t) => t.tab_id === current.tab_id) : -1;
   const currentLabel = current ? panelVisibleLabel(current, currentIndex, tabs) : "No panel";
   const hasSwitcher = tabs.length > 1;
+  const showClose = canClosePanel(tabs);
+  const closeButtonAttr = (tabId) => `<button class="mini warn panel-close" title="${escapeAttr(titleWithWebuiShortcut("Close current panel", "closePanel"))}" onclick="event.preventDefault();event.stopPropagation();closeTab('${tabId}')">✕</button>`;
   if (current && state.editingTab === current.tab_id)
-    return `<div class="panel-field"><input class="panel-label panel-rename-input tab-rename-input" value="${escapeAttr(state.editingTabValue)}" onmousedown="event.stopPropagation()" onclick="event.stopPropagation()" onblur="commitTabRename('${current.tab_id}')" oninput="state.editingTabValue=this.value" onkeydown="tabRenameKey(event,'${current.tab_id}')"><button class="mini panel-add" title="${escapeAttr(titleWithWebuiShortcut("New panel", "newPanel"))}" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button><button class="mini warn panel-close" title="${escapeAttr(titleWithWebuiShortcut("Close current panel", "closePanel"))}" onclick="event.preventDefault();event.stopPropagation();closeTab('${current.tab_id}')">✕</button></div>`;
+    return `<div class="panel-field"><input class="panel-label panel-rename-input tab-rename-input" value="${escapeAttr(state.editingTabValue)}" onmousedown="event.stopPropagation()" onclick="event.stopPropagation()" onblur="commitTabRename('${current.tab_id}')" oninput="state.editingTabValue=this.value" onkeydown="tabRenameKey(event,'${current.tab_id}')"><button class="mini panel-add" title="${escapeAttr(titleWithWebuiShortcut("New panel", "newPanel"))}" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button>${showClose ? closeButtonAttr(current.tab_id) : ""}</div>`;
   const menu = hasSwitcher && state.panelMenuOpen
     ? `<div class="panel-menu">${tabs.map((tab, index) => `<button class="panel-menu-item${tab.tab_id === state.tab ? " active" : ""}" title="${escapeAttr(tabTitle(tab))}" onclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;go(state.ws,decodeURIComponent('${encodeURIComponent(tab.tab_id)}'))">${escapeHtml(panelVisibleLabel(tab, index, tabs))}</button>`).join("")}</div>`
     : "";
   const caret = hasSwitcher ? '<span class="panel-caret">▼</span>' : "";
   const click = hasSwitcher ? "togglePanelMenu()" : "";
-  const close = current
-    ? `<button class="mini warn panel-close" title="${escapeAttr(titleWithWebuiShortcut("Close current panel", "closePanel"))}" onclick="event.preventDefault();event.stopPropagation();closeTab('${current.tab_id}')">✕</button>`
-    : "";
+  const close = current && showClose ? closeButtonAttr(current.tab_id) : "";
   return `<div class="panel-field"><button class="panel-label" title="${escapeAttr(current ? panelTooltip(current, currentIndex, tabs) : "No panel")}" onclick="event.preventDefault();event.stopPropagation();${click}" ondblclick="event.preventDefault();event.stopPropagation();state.panelMenuOpen=false;${current ? `startTabRename('${current.tab_id}','${escapeAttr(panelRenameInitialLabel(current))}')` : ""}"><span>${escapeHtml(currentLabel)}</span>${caret}</button>${menu}<button class="mini panel-add" title="${escapeAttr(titleWithWebuiShortcut("New panel", "newPanel"))}" onclick="event.preventDefault();event.stopPropagation();newTab()">+</button>${close}</div>`;
 }
 


### PR DESCRIPTION
## Summary

Adds a new setting  that controls when the per-panel ✕ close button is shown in the panel switcher.

## Options

- **Smart (default)**: Hide the close button when only one panel is open. Shows it when multiple panels are open.
- **Always**: Always show the close button regardless of panel count.

## Changes

- Added  option to  and  in 
- Added select dropdown in Settings modal (under 'Agents and alerts' section)
- Added onchange binding in 
- Updated  to sync the setting
- Added  to  for proper settings organization
- Modified  in  to respect the option via new  helper
- Added tests covering both modes in 

## Testing

All 257 existing tests pass, plus 2 new tests for the smart mode behavior.