### PR TITLE
Add global blocking loading overlay for async actions

### DIFF
--- a/.github/workflows/webui-ci.yml
+++ b/.github/workflows/webui-ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Check
         run: cargo check --target-dir target
 
+      - name: JS tests
+        run: node --test src/assets/*.test.mjs
+
       - name: Test
         run: cargo test --target-dir target
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -529,4 +529,85 @@ mod tests {
         assert_eq!(content_type(&icon_trash_svg().await), svg);
         assert_eq!(content_type(&icon_search_svg().await), svg);
     }
+
+    #[test]
+    fn app_html_contains_blocking_overlay() {
+        assert!(APP_HTML.contains(r#"id="blockingOverlay""#));
+        assert!(APP_HTML.contains(r#"class="blocking-overlay""#));
+        assert!(APP_HTML.contains(r#"id="blockingOverlayLabel""#));
+    }
+
+    #[test]
+    fn desktop_css_contains_blocking_overlay_styles() {
+        assert!(DESKTOP_CSS.contains(".blocking-overlay"));
+        assert!(DESKTOP_CSS.contains("z-index: 1300"));
+    }
+
+    #[test]
+    fn desktop_js_defines_blocking_functions() {
+        assert!(DESKTOP_JS.contains("function showBlocking("));
+        assert!(DESKTOP_JS.contains("function hideBlocking("));
+        assert!(DESKTOP_JS.contains("function resetBlocking("));
+        assert!(DESKTOP_JS.contains("window.showBlocking"));
+        assert!(DESKTOP_JS.contains("window.hideBlocking"));
+        assert!(DESKTOP_JS.contains("window.resetBlocking"));
+        assert!(DESKTOP_JS.contains("unhandledrejection"));
+        assert!(DESKTOP_JS.contains("blockingOverlayDepth"));
+    }
+
+    #[test]
+    fn desktop_js_wraps_actions_with_blocking() {
+        // Worktree actions
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Creating worktree"#));
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Opening worktree"#));
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Removing worktree"#));
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Closing workspace"#));
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Creating panel"#));
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Closing panel"#));
+
+        // Session/settings actions
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Launching session"#));
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Closing session"#));
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Saving settings"#));
+
+        // Workspace create
+        assert!(DESKTOP_JS.contains(r#"showBlocking("Creating workspace"#));
+
+        // catch-block hideBlocking before confirmation dialogs
+        assert!(DESKTOP_JS.contains("confirmForceWorktreeRemove"));
+        assert!(DESKTOP_JS.contains("confirmContinueWithoutPull"));
+    }
+
+    #[test]
+    fn git_ui_js_wraps_actions_with_blocking() {
+        assert!(DESKTOP_GIT_UI_JS.contains("showBlocking"));
+        assert!(DESKTOP_GIT_UI_JS.contains("hideBlocking"));
+        assert!(DESKTOP_GIT_UI_JS.contains(r#"showBlocking("Saving file"#));
+        assert!(DESKTOP_GIT_UI_JS.contains(r#"showBlocking("Deleting"#));
+        assert!(DESKTOP_GIT_UI_JS.contains(r#"showBlocking("Removing worktree"#));
+        // Defensive guards for test compatibility
+        assert!(DESKTOP_GIT_UI_JS.contains(r#"typeof showBlocking === "function""#));
+        assert!(DESKTOP_GIT_UI_JS.contains(r#"typeof hideBlocking === "function""#));
+    }
+
+    #[test]
+    fn file_browser_js_wraps_actions_with_blocking() {
+        assert!(DESKTOP_FILE_BROWSER_JS.contains("showBlocking"));
+        assert!(DESKTOP_FILE_BROWSER_JS.contains("hideBlocking"));
+        assert!(DESKTOP_FILE_BROWSER_JS.contains(r#"showBlocking("Saving file"#));
+        assert!(DESKTOP_FILE_BROWSER_JS.contains(r#"showBlocking("Renaming"#));
+        assert!(DESKTOP_FILE_BROWSER_JS.contains(r#"showBlocking("Deleting"#));
+        // Defensive guards for test compatibility
+        assert!(DESKTOP_FILE_BROWSER_JS.contains(r#"typeof showBlocking === "function""#));
+        assert!(DESKTOP_FILE_BROWSER_JS.contains(r#"typeof hideBlocking === "function""#));
+    }
+
+    #[test]
+    fn modals_css_has_blocking_overlay_above_modals() {
+        // The blocking overlay must sit above the question modal (z-index 1100)
+        // and the command palette (z-index 1200) to prevent interaction.
+        assert!(DESKTOP_CSS.contains("z-index: 1300"));
+        assert!(DESKTOP_CSS.contains(".blocking-overlay"));
+        assert!(DESKTOP_CSS.contains("blocking-overlay-label"));
+    }
 }

--- a/src/assets/app.html
+++ b/src/assets/app.html
@@ -61,6 +61,12 @@
         <div class="search-help">Enter opens selection · ↑/↓ moves · Alt+F files · Alt+D folders · Esc closes</div>
       </div>
     </div>
+    <div class="blocking-overlay" id="blockingOverlay" aria-hidden="true">
+      <div class="blocking-overlay-card">
+        <span class="blocking-overlay-spinner"></span>
+        <span class="blocking-overlay-label" id="blockingOverlayLabel">Working...</span>
+      </div>
+    </div>
     <div class="modal-backdrop" id="settingsModal">
       <div class="modal">
         <h2>Settings</h2>

--- a/src/assets/app_core.test.mjs
+++ b/src/assets/app_core.test.mjs
@@ -799,6 +799,16 @@ describe("desktop file browser editor integration", () => {
       this.parentNode = null;
       this.className = "";
       this.style = {};
+      this.classList = {
+        _classes: new Set(),
+        add(...tokens) { for (const t of tokens) this._classes.add(t); },
+        remove(...tokens) { for (const t of tokens) this._classes.delete(t); },
+        contains(token) { return this._classes.has(token); },
+        toggle(token, force) {
+          if (force === true || (force === undefined && !this._classes.has(token))) this._classes.add(token);
+          else this._classes.delete(token);
+        },
+      };
       this.scrollTop = 0;
       this.value = "";
       this._id = "";

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -9,6 +9,7 @@ function element(id = "") {
     id,
     classList: {
       add() {},
+      remove() {},
       contains() {
         return false;
       },

--- a/src/assets/blocking_overlay.test.mjs
+++ b/src/assets/blocking_overlay.test.mjs
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+// Test the blocking overlay depth-counting logic from core.js.
+// The showBlocking/hideBlocking/resetBlocking functions manage a ref-counted
+// overlay so that nested async operations work correctly.
+
+function context() {
+  const elements = new Map();
+
+  function makeElement(id) {
+    const el = {
+      id: id || "",
+      _classes: new Set(),
+      _aria: "true",
+      _textContent: "",
+      classList: {
+        add(token) { el._classes.add(token); },
+        remove(token) { el._classes.delete(token); },
+        contains(token) { return el._classes.has(token); },
+      },
+      set textContent(v) { el._textContent = String(v); },
+      get textContent() { return el._textContent; },
+      setAttribute(name, value) {
+        if (name === "aria-hidden") el._aria = String(value);
+      },
+      getAttribute(name) {
+        if (name === "aria-hidden") return el._aria;
+        return null;
+      },
+      style: {},
+    };
+    return el;
+  }
+
+  function getElement(id) {
+    if (!elements.has(id)) elements.set(id, makeElement(id));
+    return elements.get(id);
+  }
+
+  // Pre-create the blocking overlay elements so tests can access them
+  getElement("blockingOverlay");
+  getElement("blockingOverlayLabel");
+
+  const ctx = {
+    console,
+    TextEncoder,
+    TextDecoder,
+    URLSearchParams,
+    clearTimeout,
+    setInterval() {},
+    setTimeout(fn) { return 1; },
+    requestAnimationFrame(fn) { fn(); },
+    document: {
+      body: getElement("body"),
+      createElement: () => makeElement(""),
+      getElementById: getElement,
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      addEventListener() {},
+    },
+    localStorage: {
+      _store: new Map(),
+      getItem(key) { return this._store.get(key) || null; },
+      setItem(key, value) { this._store.set(key, String(value)); },
+      removeItem(key) { this._store.delete(key); },
+    },
+    history: { pushState() {}, replaceState() {} },
+    location: { pathname: "/", href: "" },
+    navigator: { clipboard: {} },
+    window: null,
+    globalThis: null,
+    WebSocket: class { constructor() { this.readyState = 1; } send() {} close() {} addEventListener() {} },
+    fetch: async () => ({ status: 200, ok: true, json: async () => ({}) }),
+    addEventListener() {},
+    encodeURIComponent,
+    decodeURIComponent,
+    JSON,
+    Error,
+    Math,
+    String,
+    Object,
+    Array,
+    Promise,
+    Symbol,
+    Map,
+    Set,
+    Date,
+    RegExp,
+    Number,
+    Boolean,
+  };
+  ctx.window = ctx;
+  ctx.globalThis = ctx;
+  return { ctx: vm.createContext(ctx), elements };
+}
+
+function loadCore(ctx) {
+  const source = readFileSync(
+    new URL("./desktop/app_js/core.js", import.meta.url),
+    "utf8",
+  );
+  try {
+    vm.runInContext(source, ctx);
+  } catch (e) {
+    // Some init code may fail without full DOM; the functions we test
+    // are declared at top level and should be available.
+  }
+}
+
+function getOverlay(elements) {
+  return elements.get("blockingOverlay");
+}
+function getLabel(elements) {
+  return elements.get("blockingOverlayLabel");
+}
+
+describe("blocking overlay", () => {
+  it("showBlocking adds 'show' class and sets aria-hidden to false", () => {
+    const { ctx, elements } = context();
+    loadCore(ctx);
+
+    ctx.showBlocking("Loading...");
+    const overlay = getOverlay(elements);
+    assert.ok(overlay, "blockingOverlay element should exist");
+    assert.ok(overlay.classList.contains("show"), "should have 'show' class");
+    assert.equal(overlay.getAttribute("aria-hidden"), "false");
+    assert.equal(getLabel(elements).textContent, "Loading...");
+  });
+
+  it("hideBlocking removes 'show' class and sets aria-hidden to true when depth reaches 0", () => {
+    const { ctx, elements } = context();
+    loadCore(ctx);
+
+    ctx.showBlocking("Working...");
+    ctx.hideBlocking();
+    const overlay = getOverlay(elements);
+    assert.ok(!overlay.classList.contains("show"), "should not have 'show' class");
+    assert.equal(overlay.getAttribute("aria-hidden"), "true");
+  });
+
+  it("nested showBlocking calls require matching hideBlocking calls", () => {
+    const { ctx, elements } = context();
+    loadCore(ctx);
+
+    const overlay = getOverlay(elements);
+
+    // First level
+    ctx.showBlocking("Outer...");
+    assert.ok(overlay.classList.contains("show"));
+    assert.equal(getLabel(elements).textContent, "Outer...");
+
+    // Second level (nested) - should update the message
+    ctx.showBlocking("Inner...");
+    assert.ok(overlay.classList.contains("show"), "overlay still visible after nested show");
+    assert.equal(getLabel(elements).textContent, "Inner...");
+
+    // First hide - depth goes 2 -> 1, overlay should stay visible
+    ctx.hideBlocking();
+    assert.ok(overlay.classList.contains("show"), "overlay stays visible when depth > 0");
+
+    // Second hide - depth goes 1 -> 0, overlay should be hidden
+    ctx.hideBlocking();
+    assert.ok(!overlay.classList.contains("show"), "overlay hidden when depth reaches 0");
+    assert.equal(overlay.getAttribute("aria-hidden"), "true");
+  });
+
+  it("hideBlocking does nothing when depth is already 0", () => {
+    const { ctx, elements } = context();
+    loadCore(ctx);
+
+    const overlay = getOverlay(elements);
+
+    // Call hideBlocking without any prior showBlocking
+    ctx.hideBlocking();
+    assert.ok(!overlay.classList.contains("show"), "overlay should remain hidden");
+    assert.equal(overlay.getAttribute("aria-hidden"), "true");
+  });
+
+  it("showBlocking uses default message when none provided", () => {
+    const { ctx, elements } = context();
+    loadCore(ctx);
+
+    ctx.showBlocking();
+    assert.equal(getLabel(elements).textContent, "Working...");
+  });
+
+  it("resetBlocking clears the overlay regardless of depth", () => {
+    const { ctx, elements } = context();
+    loadCore(ctx);
+
+    const overlay = getOverlay(elements);
+
+    // Build up depth to 3
+    ctx.showBlocking("A");
+    ctx.showBlocking("B");
+    ctx.showBlocking("C");
+    assert.ok(overlay.classList.contains("show"));
+
+    // Reset should clear everything
+    ctx.resetBlocking();
+    assert.ok(!overlay.classList.contains("show"), "reset clears 'show' class");
+    assert.equal(overlay.getAttribute("aria-hidden"), "true");
+
+    // Subsequent hideBlocking should be a no-op
+    ctx.hideBlocking();
+    assert.ok(!overlay.classList.contains("show"));
+  });
+
+  it("resetBlocking is exposed globally on window", () => {
+    const { ctx } = context();
+    loadCore(ctx);
+
+    assert.equal(typeof ctx.window.resetBlocking, "function");
+    assert.equal(typeof ctx.window.showBlocking, "function");
+    assert.equal(typeof ctx.window.hideBlocking, "function");
+  });
+
+  it("resetBlocking recovers from stuck overlay (simulating unhandledrejection)", () => {
+    const { ctx, elements } = context();
+    loadCore(ctx);
+
+    const overlay = getOverlay(elements);
+
+    // Simulate an active overlay
+    ctx.showBlocking("Working...");
+    assert.ok(overlay.classList.contains("show"));
+
+    // Simulate what the unhandledrejection handler does: call resetBlocking
+    ctx.window.resetBlocking();
+    assert.ok(!overlay.classList.contains("show"), "reset clears stuck overlay");
+    assert.equal(overlay.getAttribute("aria-hidden"), "true");
+
+    // Depth should be 0 now, so hideBlocking is a no-op
+    ctx.hideBlocking();
+    assert.ok(!overlay.classList.contains("show"));
+  });
+});

--- a/src/assets/desktop/app_css/modals.css
+++ b/src/assets/desktop/app_css/modals.css
@@ -143,6 +143,47 @@
   background: var(--border);
 }
 
+/* Global blocking overlay for async actions */
+.blocking-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  place-items: center;
+  background: #0006;
+  z-index: 1300;
+}
+
+.blocking-overlay.show {
+  display: grid;
+}
+
+.blocking-overlay-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--panel);
+  border: 1px solid var(--border2);
+  border-radius: 12px;
+  padding: 16px 24px;
+  box-shadow: 0 14px 40px #000a;
+}
+
+.blocking-overlay-spinner {
+  width: 20px;
+  height: 20px;
+  border: 2.5px solid var(--border2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+.blocking-overlay-label {
+  color: var(--fg);
+  font-size: 14px;
+  font-weight: 500;
+}
+
 /* Ephemeral temporary terminal overlay */
 .temp-terminal-backdrop {
   position: fixed;

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -142,6 +142,33 @@ const FAST_REFRESH_EVENTS = new Set([
   "worktree.removed",
 ]);
 let sidebarCollapsed = storedFlag(SIDEBAR_COLLAPSED_KEY);
+let blockingOverlayDepth = 0;
+function showBlocking(message) {
+  const overlay = document.getElementById("blockingOverlay");
+  if (!overlay) return;
+  const label = document.getElementById("blockingOverlayLabel");
+  if (label) label.textContent = message || "Working...";
+  blockingOverlayDepth = Math.max(0, blockingOverlayDepth) + 1;
+  overlay.classList.add("show");
+  overlay.setAttribute("aria-hidden", "false");
+}
+function hideBlocking() {
+  blockingOverlayDepth = Math.max(0, blockingOverlayDepth - 1);
+  if (blockingOverlayDepth > 0) return;
+  const overlay = document.getElementById("blockingOverlay");
+  if (!overlay) return;
+  overlay.classList.remove("show");
+  overlay.setAttribute("aria-hidden", "true");
+}
+function resetBlocking() {
+  blockingOverlayDepth = 0;
+  const overlay = document.getElementById("blockingOverlay");
+  if (!overlay) return;
+  overlay.classList.remove("show");
+  overlay.setAttribute("aria-hidden", "true");
+}
+window.showBlocking = showBlocking;
+window.hideBlocking = hideBlocking;
 // Tracks the workspace id whose shell mode (terminal/git/files) was last
 // applied to the DOM. When refreshOnline finishes for a *different* workspace
 // than the one currently shown, the shell surfaces (terminal/git/file panels)
@@ -2316,6 +2343,7 @@ function hideSessionManager() {
 async function launchBackend(session = state.session, backend = currentSessionBackend()) {
   const textEl = el("sessionManagerText");
   if (textEl) textEl.textContent = `Launching ${sessionBackendLabel(backend)} session...`;
+  showBlocking("Launching session...");
   try {
     const r = await api("/api/session/launch", {
       method: "POST",
@@ -2331,10 +2359,13 @@ async function launchBackend(session = state.session, backend = currentSessionBa
     setTimeout(refresh, 1200);
   } catch (e) {
     if (textEl) textEl.textContent = e.message || String(e);
+  } finally {
+    hideBlocking();
   }
 }
 async function closeCurrentSession() {
   if (!confirm(`Close current ${sessionBackendLabel(currentSessionBackend())} session?`)) return;
+  showBlocking("Closing session...");
   try {
     await api("/api/session/close", {
       method: "POST",
@@ -2348,21 +2379,28 @@ async function closeCurrentSession() {
     setTimeout(refresh, 800);
   } catch (e) {
     showSessionManager("Close failed", e.message || String(e));
+  } finally {
+    hideBlocking();
   }
 }
 async function resetSession() {
   if (!confirm("Close all workspaces in this session?")) return;
-  for (const w of [...state.workspaces]) {
-    try {
-      await api(`/api/workspaces/${encodeURIComponent(w.workspace_id)}/close`, {
-        method: "POST",
-      });
-    } catch (e) {}
+  showBlocking("Closing workspaces...");
+  try {
+    for (const w of [...state.workspaces]) {
+      try {
+        await api(`/api/workspaces/${encodeURIComponent(w.workspace_id)}/close`, {
+          method: "POST",
+        });
+      } catch (e) {}
+    }
+    state.ws = null;
+    state.tab = null;
+    state.pane = null;
+    refresh();
+  } finally {
+    hideBlocking();
   }
-  state.ws = null;
-  state.tab = null;
-  state.pane = null;
-  refresh();
 }
 const statusClass = (s) => (s === "done" ? "done" : s || "unknown");
 function statusMark(status, withText = false) {
@@ -2473,6 +2511,7 @@ async function applyServerSettings() {
     return;
   }
   submit.disabled = true;
+  showBlocking("Saving settings...");
   try {
     const updatedSettings = await api("/api/server-settings", {
       method: "POST",
@@ -2500,6 +2539,7 @@ async function applyServerSettings() {
     if (err) err.textContent = ex.message || String(ex);
   } finally {
     submit.disabled = false;
+    hideBlocking();
   }
 }
 async function loadVersions() {

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -169,6 +169,8 @@ function resetBlocking() {
 }
 window.showBlocking = showBlocking;
 window.hideBlocking = hideBlocking;
+window.resetBlocking = resetBlocking;
+window.addEventListener("unhandledrejection", () => resetBlocking());
 // Tracks the workspace id whose shell mode (terminal/git/files) was last
 // applied to the DOM. When refreshOnline finishes for a *different* workspace
 // than the one currently shown, the shell surfaces (terminal/git/file panels)

--- a/src/assets/desktop/app_js/workspace_create.js
+++ b/src/assets/desktop/app_js/workspace_create.js
@@ -41,6 +41,7 @@ async function createWorkspaceFromModal() {
     return;
   }
   submit.disabled = true;
+  showBlocking("Creating workspace...");
   try {
     const r = await api("/api/workspaces", {
       method: "POST",
@@ -54,6 +55,7 @@ async function createWorkspaceFromModal() {
     err.textContent = ex.message || String(ex);
   } finally {
     submit.disabled = false;
+    hideBlocking();
   }
 }
 el("workspaceCreateClose").onclick = closeWorkspaceCreateModal;

--- a/src/assets/desktop/app_js/workspace_create.js
+++ b/src/assets/desktop/app_js/workspace_create.js
@@ -41,7 +41,7 @@ async function createWorkspaceFromModal() {
     return;
   }
   submit.disabled = true;
-  showBlocking("Creating workspace...");
+  if (typeof showBlocking === "function") showBlocking("Creating workspace...");
   try {
     const r = await api("/api/workspaces", {
       method: "POST",
@@ -55,7 +55,7 @@ async function createWorkspaceFromModal() {
     err.textContent = ex.message || String(ex);
   } finally {
     submit.disabled = false;
-    hideBlocking();
+    if (typeof hideBlocking === "function") hideBlocking();
   }
 }
 el("workspaceCreateClose").onclick = closeWorkspaceCreateModal;

--- a/src/assets/desktop/app_js/worktrees.js
+++ b/src/assets/desktop/app_js/worktrees.js
@@ -489,7 +489,9 @@ async function submitWorktreeCreate(input) {
     );
   } catch (ex) {
     const message = ex.message || String(ex);
+    hideBlocking();
     if (pullBase && await confirmContinueWithoutPull(message)) {
+      showBlocking("Creating worktree...");
       await submitWorktreeCreate(Object.assign({}, input, { pullBase: false }));
       return;
     }
@@ -780,7 +782,9 @@ async function removeDiscoveredWorktree(index) {
     refresh();
   } catch (ex) {
     const message = ex.message || String(ex);
+    hideBlocking();
     if (await confirmForceWorktreeRemove(message)) {
+      showBlocking("Removing worktree...");
       await forceRemoveDiscoveredWorktree(row);
       await discoverWorktrees();
       refresh();
@@ -871,8 +875,10 @@ async function createDiscoveredWorktree() {
     );
   } catch (ex) {
     const message = ex.message || String(ex);
+    hideBlocking();
     if (pullBase && await confirmContinueWithoutPull(message)) {
       el("worktreeNewPullBase").checked = false;
+      showBlocking("Creating worktree...");
       await createDiscoveredWorktree();
       return;
     }
@@ -1012,7 +1018,9 @@ async function removeWorktree(id) {
       });
     } catch (ex) {
       const message = ex.message || String(ex);
+      hideBlocking();
       if (!(await confirmForceWorktreeRemove(message))) return;
+      showBlocking("Removing worktree...");
       await api(`/api/workspaces/${encodeURIComponent(id)}/worktree-remove`, {
         method: "POST",
         headers: { "content-type": "application/json" },

--- a/src/assets/desktop/app_js/worktrees.js
+++ b/src/assets/desktop/app_js/worktrees.js
@@ -471,6 +471,7 @@ async function submitWorktreeCreate(input) {
   }
   submitEl.disabled = true;
   setCreateWorktreeLoading(true, "Creating worktree...");
+  showBlocking("Creating worktree...");
   try {
     const r = await api("/api/worktrees", {
       method: "POST",
@@ -496,6 +497,7 @@ async function submitWorktreeCreate(input) {
   } finally {
     submitEl.disabled = false;
     setCreateWorktreeLoading(false);
+    hideBlocking();
   }
 }
 function pullFastForwardFailed(message) {
@@ -695,6 +697,7 @@ async function createWorkspaceFromSmartModal() {
   }
   submit.disabled = true;
   setWorktreeLoading(true, "Opening workspace...");
+  showBlocking("Opening workspace...");
   try {
     const r = await api("/api/workspaces", {
       method: "POST",
@@ -708,6 +711,7 @@ async function createWorkspaceFromSmartModal() {
   } finally {
     submit.disabled = false;
     setWorktreeLoading(false);
+    hideBlocking();
   }
 }
 async function openDiscoveredWorktree(index) {
@@ -716,6 +720,7 @@ async function openDiscoveredWorktree(index) {
   const err = el("worktreeOpenError");
   err.textContent = "";
   setOpenWorktreeOperation("open", index, "Opening worktree...");
+  showBlocking("Opening worktree...");
   try {
     const r = await api("/api/worktrees/open", {
       method: "POST",
@@ -738,6 +743,7 @@ async function openDiscoveredWorktree(index) {
     err.textContent = ex.message || String(ex);
   } finally {
     setOpenWorktreeOperation("", null);
+    hideBlocking();
   }
 }
 async function removeDiscoveredWorktree(index) {
@@ -753,6 +759,7 @@ async function removeDiscoveredWorktree(index) {
   const err = el("worktreeOpenError");
   err.textContent = "";
   setOpenWorktreeOperation("remove", index, "Removing worktree...");
+  showBlocking("Removing worktree...");
   try {
     if (row.open_workspace_id)
       await api(
@@ -782,6 +789,7 @@ async function removeDiscoveredWorktree(index) {
     err.textContent = message;
   } finally {
     setOpenWorktreeOperation("", null);
+    hideBlocking();
   }
 }
 async function confirmForceWorktreeRemove(message) {
@@ -830,6 +838,7 @@ async function createDiscoveredWorktree() {
   }
   submit.disabled = true;
   setOpenWorktreeOperation("create", null, "Creating worktree...");
+  showBlocking("Creating worktree...");
   try {
     if (sourcePath && !state.openWorktreeSource) await discoverWorktrees();
     const checkedOut = checkedOutWorktreeForBranch(branch);
@@ -871,6 +880,7 @@ async function createDiscoveredWorktree() {
   } finally {
     submit.disabled = false;
     setOpenWorktreeOperation("", null);
+    hideBlocking();
   }
 }
 async function closeWorkspace(id) {
@@ -901,25 +911,30 @@ async function closeWorkspace(id) {
       if (linkedToReopen.length)
         msg += `\n\nThis will close ${linkedToReopen.length} linked worktree(s) and stop their processes. They will be re-opened with fresh shells.`;
       if (!(await askQuestion({ title: "Close workspace?", message: msg, confirmText: "Close", danger: true }))) return;
-      await api(`/api/workspaces/${encodeURIComponent(id)}/close`, {
-        method: "POST",
-      });
-      if (state.ws === id) {
-        state.ws = null;
-        state.tab = null;
-        state.pane = null;
+      showBlocking("Closing workspace...");
+      try {
+        await api(`/api/workspaces/${encodeURIComponent(id)}/close`, {
+          method: "POST",
+        });
+        if (state.ws === id) {
+          state.ws = null;
+          state.tab = null;
+          state.pane = null;
+        }
+        await refresh();
+        for (const wt of linkedToReopen) {
+          try {
+            await api("/api/worktrees/open", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ path: wt.path, label: wt.label }),
+            });
+          } catch (e) {}
+        }
+        refresh();
+      } finally {
+        hideBlocking();
       }
-      await refresh();
-      for (const wt of linkedToReopen) {
-        try {
-          await api("/api/worktrees/open", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ path: wt.path, label: wt.label }),
-          });
-        } catch (e) {}
-      }
-      refresh();
       return;
     }
     if (!(await askQuestion({
@@ -929,8 +944,13 @@ async function closeWorkspace(id) {
       danger: true,
     })))
       return;
-    await closeWorkspaceById(id);
-    refresh();
+    showBlocking("Closing workspace...");
+    try {
+      await closeWorkspaceById(id);
+      refresh();
+    } finally {
+      hideBlocking();
+    }
     return;
   }
   if (!(await askQuestion({
@@ -939,8 +959,13 @@ async function closeWorkspace(id) {
     confirmText: "Close",
     danger: true,
   }))) return;
-  await closeWorkspaceById(id);
-  refresh();
+  showBlocking("Closing workspace...");
+  try {
+    await closeWorkspaceById(id);
+    refresh();
+  } finally {
+    hideBlocking();
+  }
 }
 function tabsForWorkspace(id) {
   return state.allTabs
@@ -979,35 +1004,45 @@ async function removeWorktree(id) {
     danger: true,
   })))
     return;
+  showBlocking("Removing worktree...");
   try {
-    await api(`/api/workspaces/${encodeURIComponent(id)}/worktree-remove`, {
-      method: "POST",
-    });
-  } catch (ex) {
-    const message = ex.message || String(ex);
-    if (!(await confirmForceWorktreeRemove(message))) return;
-    await api(`/api/workspaces/${encodeURIComponent(id)}/worktree-remove`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ force: true }),
-    });
+    try {
+      await api(`/api/workspaces/${encodeURIComponent(id)}/worktree-remove`, {
+        method: "POST",
+      });
+    } catch (ex) {
+      const message = ex.message || String(ex);
+      if (!(await confirmForceWorktreeRemove(message))) return;
+      await api(`/api/workspaces/${encodeURIComponent(id)}/worktree-remove`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ force: true }),
+      });
+    }
+    if (state.ws === id) {
+      state.ws = null;
+      state.tab = null;
+      state.pane = null;
+    }
+    refresh();
+  } finally {
+    hideBlocking();
   }
-  if (state.ws === id) {
-    state.ws = null;
-    state.tab = null;
-    state.pane = null;
-  }
-  refresh();
 }
 async function newTab() {
   if (!state.ws) return;
-  const r = await api("/api/tabs", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ workspace_id: state.ws }),
-  });
-  const tab = r.result.tab.tab_id;
-  go(state.ws, tab);
+  showBlocking("Creating panel...");
+  try {
+    const r = await api("/api/tabs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ workspace_id: state.ws }),
+    });
+    const tab = r.result.tab.tab_id;
+    go(state.ws, tab);
+  } finally {
+    hideBlocking();
+  }
 }
 function startWorkspaceRename(id, label) {
   state.editingWorkspace = id;
@@ -1080,28 +1115,33 @@ async function closeTab(id) {
   const tab = state.allTabs.concat(state.tabs).find((t) => t.tab_id === id),
     workspaceId = tab && tab.workspace_id,
     workspaceTabs = workspaceId ? tabsForWorkspace(workspaceId) : [];
-  if (workspaceTabs.length > 1) {
-    await api(`/api/tabs/${encodeURIComponent(id)}/close`, { method: "POST" });
-  } else if (workspaceId) {
-    // Close the tab; built-in backend auto-closes the empty workspace.
-    // External backends may keep it, so also close the workspace explicitly.
-    await api(`/api/tabs/${encodeURIComponent(id)}/close`, { method: "POST" });
-    await closeWorkspaceById(workspaceId);
-  } else {
-    const panes = panesForTab(id);
-    if (panes.length) await closePaneById(panes[0].pane_id);
+  showBlocking("Closing panel...");
+  try {
+    if (workspaceTabs.length > 1) {
+      await api(`/api/tabs/${encodeURIComponent(id)}/close`, { method: "POST" });
+    } else if (workspaceId) {
+      // Close the tab; built-in backend auto-closes the empty workspace.
+      // External backends may keep it, so also close the workspace explicitly.
+      await api(`/api/tabs/${encodeURIComponent(id)}/close`, { method: "POST" });
+      await closeWorkspaceById(workspaceId);
+    } else {
+      const panes = panesForTab(id);
+      if (panes.length) await closePaneById(panes[0].pane_id);
+    }
+    if (typeof removeClosedTabFromState === "function") removeClosedTabFromState(id);
+    if (state.tab === id && typeof selectFallbackTabAfterClosed === "function") {
+      resetTerminalConnection(true);
+      selectFallbackTabAfterClosed(id);
+      replaceSelectionHistory();
+      render();
+      if (window.HerdrTerminalRenderer) connectTerminal();
+    } else if (state.tab === id) {
+      state.tab = null;
+      state.pane = null;
+      render();
+    }
+    refresh();
+  } finally {
+    hideBlocking();
   }
-  if (typeof removeClosedTabFromState === "function") removeClosedTabFromState(id);
-  if (state.tab === id && typeof selectFallbackTabAfterClosed === "function") {
-    resetTerminalConnection(true);
-    selectFallbackTabAfterClosed(id);
-    replaceSelectionHistory();
-    render();
-    if (window.HerdrTerminalRenderer) connectTerminal();
-  } else if (state.tab === id) {
-    state.tab = null;
-    state.pane = null;
-    render();
-  }
-  refresh();
 }

--- a/src/assets/desktop/file_browser.js
+++ b/src/assets/desktop/file_browser.js
@@ -801,7 +801,7 @@
     file.saving = true;
     file.error = "";
     render();
-    showBlocking("Saving file...");
+    if (typeof showBlocking === "function") showBlocking("Saving file...");
     try {
       const result = await api("/api/file-browser/file", {
         method: "POST",
@@ -817,7 +817,7 @@
     }
     file.saving = false;
     render();
-    hideBlocking();
+    if (typeof hideBlocking === "function") hideBlocking();
   }
 
   function fileName(path) {
@@ -865,7 +865,7 @@
     const nextName = prompt("Rename to", fileName(path));
     if (!nextName || nextName === fileName(path)) return;
     if (!confirm(`Rename ${path} to ${nextName}?`)) return;
-    showBlocking("Renaming...");
+    if (typeof showBlocking === "function") showBlocking("Renaming...");
     try {
       await api("/api/file-browser/rename", {
         method: "POST",
@@ -877,13 +877,13 @@
       mutateTreeForRename(path, to, nextName);
       await refreshParentAfterMutation(to);
     } finally {
-      hideBlocking();
+      if (typeof hideBlocking === "function") hideBlocking();
     }
   }
 
   async function deletePath(path) {
     if (!confirm(`Delete ${path}? This cannot be undone.`)) return;
-    showBlocking("Deleting...");
+    if (typeof showBlocking === "function") showBlocking("Deleting...");
     try {
       await api("/api/file-browser/delete", {
         method: "POST",
@@ -893,7 +893,7 @@
       mutateTreeForDelete(path);
       await refreshParentAfterMutation(path);
     } finally {
-      hideBlocking();
+      if (typeof hideBlocking === "function") hideBlocking();
     }
   }
 

--- a/src/assets/desktop/file_browser.js
+++ b/src/assets/desktop/file_browser.js
@@ -801,6 +801,7 @@
     file.saving = true;
     file.error = "";
     render();
+    showBlocking("Saving file...");
     try {
       const result = await api("/api/file-browser/file", {
         method: "POST",
@@ -816,6 +817,7 @@
     }
     file.saving = false;
     render();
+    hideBlocking();
   }
 
   function fileName(path) {
@@ -863,26 +865,36 @@
     const nextName = prompt("Rename to", fileName(path));
     if (!nextName || nextName === fileName(path)) return;
     if (!confirm(`Rename ${path} to ${nextName}?`)) return;
-    await api("/api/file-browser/rename", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ cwd: state.cwd, path, new_name: nextName }),
-    });
-    const parent = Tree.parentPath(path);
-    const to = parent ? `${parent}/${nextName}` : nextName;
-    mutateTreeForRename(path, to, nextName);
-    await refreshParentAfterMutation(to);
+    showBlocking("Renaming...");
+    try {
+      await api("/api/file-browser/rename", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cwd: state.cwd, path, new_name: nextName }),
+      });
+      const parent = Tree.parentPath(path);
+      const to = parent ? `${parent}/${nextName}` : nextName;
+      mutateTreeForRename(path, to, nextName);
+      await refreshParentAfterMutation(to);
+    } finally {
+      hideBlocking();
+    }
   }
 
   async function deletePath(path) {
     if (!confirm(`Delete ${path}? This cannot be undone.`)) return;
-    await api("/api/file-browser/delete", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ cwd: state.cwd, path }),
-    });
-    mutateTreeForDelete(path);
-    await refreshParentAfterMutation(path);
+    showBlocking("Deleting...");
+    try {
+      await api("/api/file-browser/delete", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cwd: state.cwd, path }),
+      });
+      mutateTreeForDelete(path);
+      await refreshParentAfterMutation(path);
+    } finally {
+      hideBlocking();
+    }
   }
 
   async function copyPermalink(path) {

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -885,7 +885,7 @@
     view.mutating = true;
     view.mutatingLabel = label || "";
     if (state.visible) render();
-    showBlocking(label || "Working...");
+    if (typeof showBlocking === "function") showBlocking(label || "Working...");
     try {
       await api(path, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
       await refresh();
@@ -896,7 +896,7 @@
       view.mutating = false;
       view.mutatingLabel = "";
       if (state.visible) render();
-      hideBlocking();
+      if (typeof hideBlocking === "function") hideBlocking();
     }
   }
 
@@ -906,7 +906,7 @@
     view.mutating = true;
     view.mutatingLabel = label || "";
     if (state.visible) render();
-    showBlocking(label || "Working...");
+    if (typeof showBlocking === "function") showBlocking(label || "Working...");
     try {
       const result = await api(path, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
       await refresh();
@@ -919,7 +919,7 @@
       view.mutating = false;
       view.mutatingLabel = "";
       if (state.visible) render();
-      hideBlocking();
+      if (typeof hideBlocking === "function") hideBlocking();
     }
   }
 
@@ -3017,7 +3017,7 @@
       editor.saving = true;
       editor.error = "";
       render();
-      showBlocking("Saving file...");
+      if (typeof showBlocking === "function") showBlocking("Saving file...");
       try {
         await api("/api/git-ui/file", {
           method: "POST",
@@ -3031,7 +3031,7 @@
         editor.error = err.message || String(err);
         render();
       } finally {
-        hideBlocking();
+        if (typeof hideBlocking === "function") hideBlocking();
       }
     },
     resolveEditorConflictBlock(hunkIndex, blockIndex, mode) {
@@ -3279,7 +3279,7 @@
       view.cleanupLoading = true;
       view.cleanupError = "";
       render();
-      showBlocking("Deleting items...");
+      if (typeof showBlocking === "function") showBlocking("Deleting items...");
       const failures = [];
       try {
         for (const item of items) {
@@ -3299,7 +3299,7 @@
         }
       } finally {
         view.cleanupLoading = false;
-        hideBlocking();
+        if (typeof hideBlocking === "function") hideBlocking();
       }
       if (failures.length) view.cleanupError = failures.join("\n");
       await this.scanCleanup();
@@ -3319,7 +3319,7 @@
       view.cleanupLoading = true;
       view.cleanupError = "";
       render();
-      showBlocking("Deleting branch...");
+      if (typeof showBlocking === "function") showBlocking("Deleting branch...");
       try {
         await api("/api/git-ui/branch-delete", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ cwd: repo.path, branch, force, confirmed: true }) });
         await this.scanCleanup();
@@ -3330,7 +3330,7 @@
         const latest = active();
         if (latest) latest.cleanupLoading = false;
         render();
-        hideBlocking();
+        if (typeof hideBlocking === "function") hideBlocking();
       }
     },
     async deleteCleanupWorktree(repoIndex, worktreeIndex, force) {
@@ -3343,7 +3343,7 @@
       view.cleanupLoading = true;
       view.cleanupError = "";
       render();
-      showBlocking("Removing worktree...");
+      if (typeof showBlocking === "function") showBlocking("Removing worktree...");
       try {
         await api("/api/git-ui/worktree-remove", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ cwd: repo.path, path: worktree.path, force, confirmed: true }) });
         await this.scanCleanup();
@@ -3354,7 +3354,7 @@
         const latest = active();
         if (latest) latest.cleanupLoading = false;
         render();
-        hideBlocking();
+        if (typeof hideBlocking === "function") hideBlocking();
       }
     },
     saveDraft() {

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -885,6 +885,7 @@
     view.mutating = true;
     view.mutatingLabel = label || "";
     if (state.visible) render();
+    showBlocking(label || "Working...");
     try {
       await api(path, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
       await refresh();
@@ -895,6 +896,7 @@
       view.mutating = false;
       view.mutatingLabel = "";
       if (state.visible) render();
+      hideBlocking();
     }
   }
 
@@ -904,6 +906,7 @@
     view.mutating = true;
     view.mutatingLabel = label || "";
     if (state.visible) render();
+    showBlocking(label || "Working...");
     try {
       const result = await api(path, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
       await refresh();
@@ -916,6 +919,7 @@
       view.mutating = false;
       view.mutatingLabel = "";
       if (state.visible) render();
+      hideBlocking();
     }
   }
 
@@ -3013,6 +3017,7 @@
       editor.saving = true;
       editor.error = "";
       render();
+      showBlocking("Saving file...");
       try {
         await api("/api/git-ui/file", {
           method: "POST",
@@ -3025,6 +3030,8 @@
         editor.saving = false;
         editor.error = err.message || String(err);
         render();
+      } finally {
+        hideBlocking();
       }
     },
     resolveEditorConflictBlock(hunkIndex, blockIndex, mode) {
@@ -3272,23 +3279,28 @@
       view.cleanupLoading = true;
       view.cleanupError = "";
       render();
+      showBlocking("Deleting items...");
       const failures = [];
-      for (const item of items) {
-        try {
-          await deleteCleanupItem(item, false);
-        } catch (err) {
-          if (!cleanupForceRetryLikelyNeeded(err)) {
-            failures.push(`${cleanupItemLabel(item)}: ${(err && err.message) || err}`);
-            continue;
-          }
+      try {
+        for (const item of items) {
           try {
-            await deleteCleanupItem(item, true);
-          } catch (forceErr) {
-            failures.push(`${cleanupItemLabel(item)}: ${(forceErr && forceErr.message) || forceErr || err}`);
+            await deleteCleanupItem(item, false);
+          } catch (err) {
+            if (!cleanupForceRetryLikelyNeeded(err)) {
+              failures.push(`${cleanupItemLabel(item)}: ${(err && err.message) || err}`);
+              continue;
+            }
+            try {
+              await deleteCleanupItem(item, true);
+            } catch (forceErr) {
+              failures.push(`${cleanupItemLabel(item)}: ${(forceErr && forceErr.message) || forceErr || err}`);
+            }
           }
         }
+      } finally {
+        view.cleanupLoading = false;
+        hideBlocking();
       }
-      view.cleanupLoading = false;
       if (failures.length) view.cleanupError = failures.join("\n");
       await this.scanCleanup();
       if (failures.length) {
@@ -3307,6 +3319,7 @@
       view.cleanupLoading = true;
       view.cleanupError = "";
       render();
+      showBlocking("Deleting branch...");
       try {
         await api("/api/git-ui/branch-delete", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ cwd: repo.path, branch, force, confirmed: true }) });
         await this.scanCleanup();
@@ -3317,6 +3330,7 @@
         const latest = active();
         if (latest) latest.cleanupLoading = false;
         render();
+        hideBlocking();
       }
     },
     async deleteCleanupWorktree(repoIndex, worktreeIndex, force) {
@@ -3329,6 +3343,7 @@
       view.cleanupLoading = true;
       view.cleanupError = "";
       render();
+      showBlocking("Removing worktree...");
       try {
         await api("/api/git-ui/worktree-remove", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ cwd: repo.path, path: worktree.path, force, confirmed: true }) });
         await this.scanCleanup();
@@ -3339,6 +3354,7 @@
         const latest = active();
         if (latest) latest.cleanupLoading = false;
         render();
+        hideBlocking();
       }
     },
     saveDraft() {


### PR DESCRIPTION
## Summary

Adds a global blocking loading modal that prevents users from triggering multiple concurrent actions across the desktop UI.

### Infrastructure
- **HTML**: `#blockingOverlay` element with spinner and label (`app.html`)
- **CSS**: `.blocking-overlay` styles at z-index 1300, above all modals (`modals.css`)
- **JS**: `showBlocking(message)` / `hideBlocking()` / `resetBlocking()` functions with a ref-counted depth counter so nested operations work correctly (`core.js`)
- **Safety net**: `unhandledrejection` listener calls `resetBlocking()` so the overlay can never get permanently stuck

### Actions wrapped
- **Workspace/worktree**: create workspace, create/open/remove worktree, close workspace, close/open panel
- **Git UI**: integrated into `post`/`postJson` wrappers (covers stage, unstage, discard, commit, push, pull, rebase, switch branch, resolve conflict, tag, reset, apply hunk), plus save side editor and cleanup delete
- **File browser**: save file, rename, delete
- **Session/settings**: launch, close, reset session, apply server settings

### Bug fix: z-index conflict
When an async action fails and needs to show a confirmation dialog (force remove worktree, continue without pull), the blocking overlay at z-index 1300 would cover the question modal at z-index 1100. Fixed by calling `hideBlocking()` before showing the dialog and re-showing it if the user confirms.

### Test compatibility
Made `showBlocking`/`hideBlocking` calls defensive with `typeof` guards in standalone modules (`file_browser.js`, `git_ui.js`, `workspace_create.js`) so they work correctly even when `core.js` is not loaded (e.g. in isolated unit tests).

## Tests
- **7 new Rust tests** in `assets.rs` verifying HTML element presence, CSS z-index, JS function definitions, and action wrapping
- **8 new JS tests** in `blocking_overlay.test.mjs` covering depth-counter logic: show/hide basics, nesting, no-op at depth 0, default message, resetBlocking, global exposure, stuck-overlay recovery
- **Fixed 3 existing JS tests** broken by the changes (added `classList.remove` to mock elements)
- **Added JS test step to CI** (`webui-ci.yml`): `node --test src/assets/*.test.mjs`
- All 301 Rust tests + 298 JS tests pass locally