### PR TITLE
Make terminal_output_publishes_agent_status_changes deterministic on CI

### DIFF
--- a/src/builtin_backend.rs
+++ b/src/builtin_backend.rs
@@ -1573,6 +1573,18 @@ impl TerminalRuntime {
         }
     }
 
+    /// Resets the status-detection throttle so the next output-driven
+    /// `publish_agent_status_if_changed` run is guaranteed to execute.
+    /// Only used by tests to avoid racing the spawned shell's prompt output,
+    /// which can consume the 500ms throttle window before the synthetic
+    /// append_output call lands.
+    #[cfg(test)]
+    fn reset_status_throttle(&self) {
+        if let Ok(mut last_check) = self.last_status_check.lock() {
+            *last_check = None;
+        }
+    }
+
     fn publish_agent_status_if_changed(&self) {
         // Throttle status detection to max once per 500ms per terminal
         // This prevents CPU burn during heavy terminal output
@@ -4421,6 +4433,11 @@ mod tests {
             data.terminals.get(&pane.terminal_id).unwrap().clone()
         };
 
+        // The spawned shell's prompt output may have already consumed the
+        // 500ms status-check throttle window. Reset it so our synthetic
+        // output is guaranteed to trigger the status-change publish instead
+        // of racing the reader thread on a loaded CI runner.
+        terminal.reset_status_throttle();
         terminal.append_output("●·· batch ··● · 2/5 done".as_bytes());
 
         let event = rx.recv_timeout(Duration::from_secs(1)).unwrap();


### PR DESCRIPTION
## Problem

The v0.2.98 release workflow failed on the macOS aarch64 job (after one run hung on a slow runner and was rerun):

`builtin_backend::tests::terminal_output_publishes_agent_status_changes` panicked with `called Result::unwrap() on an Err value: Timeout`.

## Root cause

The test spawns a real shell PTY. The shell's prompt output (reader thread) and the test's synthetic `append_output` both race into `publish_agent_status_if_changed`, which throttles status detection to once per 500ms. On a loaded CI runner the shell prompt usually wins the race, consuming the throttle window; the test's append then lands inside the window and publishes no event, so `rx.recv_timeout(1s)` fails.

This is the same class of CI-environment flake fixed earlier in 482e288 (done-after-exit test).

## Fix

Adds a `#[cfg(test)] fn reset_status_throttle` helper on `TerminalRuntime` that clears `last_status_check`, and calls it right before the synthetic append so the publish path is guaranteed to run regardless of the shell's racing output.

## Verification

- 20 consecutive runs of the test: 0 failures.
- 5 full-suite runs (301 tests): 0 failures.
- cargo fmt clean.