### PR TITLE
feat(git-ui): folder actions, working-tree compare, and git explorer fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,16 @@ It builds an isolated server (own config dir and session, so a locally
 running instance is never touched), drives the served app in headless
 Chrome over CDP, and tears everything down. See `scripts/e2e/README.md`.
 
+When changing the Git explorer (folder actions, compare modes, discard),
+also run the no-browser acceptance harness:
+
+```sh
+just git-e2e        # or: scripts/e2e/run-git-e2e.sh
+```
+
+It boots the served git-ui bundle in a node vm with fetch proxied to the
+real backend, so it runs anywhere node and cargo do (no Chrome needed).
+
 ## Releases
 
 WebUI releases use `v0.0.x` tags and GitHub Release notes. Do not prepare root Herdr release commits or tags from this repository.

--- a/justfile
+++ b/justfile
@@ -18,6 +18,10 @@ test: test-js
 e2e:
     scripts/e2e/run-e2e.sh
 
+# No-browser acceptance run for the Git explorer rework. See scripts/e2e/README.md.
+git-e2e:
+    scripts/e2e/run-git-e2e.sh
+
 check: lint test
 
 build:

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -49,3 +49,24 @@ The harness needs HTTPS with a self-signed cert; the CDP session sets
 
 Note: run this locally; it is not wired into CI (macos-latest runners have
 Chrome, but the suite is intentionally kept as a pre-merge manual gate).
+## Git explorer acceptance (no browser needed)
+
+`scripts/e2e/run-git-e2e.sh` covers the Git explorer rework (folder rows,
+folder stage/unstage/discard, compare modes) against the real server. It
+boots the JS bundles the server actually serves in a node vm and proxies
+every fetch to the backend, so it needs no browser and runs anywhere node
+and cargo do.
+
+What it verifies on a throwaway dirty repo:
+
+- the Git panel loads status from the real backend
+- untracked `scratchdir/` renders as a dir row with no phantom file row
+- the dir context menu posts `discard` with the folder path and
+  `confirmed: true` to the real backend
+- the folder is really gone from the repo afterwards
+
+| Variable    | Default | Meaning                            |
+| ----------- | ------- | ---------------------------------- |
+| `E2E_PORT`  | `8898`  | HTTPS port of the isolated server  |
+
+Run it locally with `just git-e2e` (also not wired into CI).

--- a/scripts/e2e/git-acceptance.mjs
+++ b/scripts/e2e/git-acceptance.mjs
@@ -1,0 +1,203 @@
+// Full-stack acceptance checks for the Git explorer rework.
+//
+// Behavioral `node --test` suites cover the git_ui module against stubbed
+// fetches, but they cannot catch wiring bugs between the served bundle, the
+// embedded assets, and the real git backend. This script boots the JS bundles
+// the real server actually serves, proxies every vm fetch to the real backend,
+// and drives the same call chain a browser click uses.
+//
+// Driven by scripts/e2e/run-git-e2e.sh (see that file for the environment
+// overrides).
+import vm from "node:vm";
+import { request as httpsRequest } from "node:https";
+
+const ORIGIN = process.env.E2E_ORIGIN;
+const REPO = process.env.E2E_REPO;
+
+if (!ORIGIN || !REPO) {
+  console.error("E2E_ORIGIN and E2E_REPO must be set (use scripts/e2e/run-git-e2e.sh)");
+  process.exit(2);
+}
+
+function httpsJson(url, init) {
+  return new Promise((resolve, reject) => {
+    const options = { rejectUnauthorized: false };
+    if (init && init.method) options.method = init.method;
+    if (init && init.headers) options.headers = init.headers;
+    const req = httpsRequest(url, options, (res) => {
+      let raw = "";
+      res.on("data", (chunk) => { raw += chunk; });
+      res.on("end", () => resolve({ status: res.statusCode, json: async () => JSON.parse(raw) }));
+    });
+    req.on("error", reject);
+    if (init && init.body) req.write(init.body);
+    req.end();
+  });
+}
+
+function loadText(path) {
+  return new Promise((resolve, reject) => {
+    const req = httpsRequest(`${ORIGIN}${path}`, { rejectUnauthorized: false }, (res) => {
+      let raw = "";
+      res.on("data", (chunk) => { raw += chunk; });
+      res.on("end", () => resolve(raw));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function element() {
+  return {
+    style: { setProperty() {}, removeProperty() {} },
+    dataset: {},
+    value: "",
+    children: [],
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    setAttribute() {},
+    getAttribute: () => null,
+    appendChild() {},
+    removeChild() {},
+    remove() {},
+    replaceWith() {},
+    insertBefore() {},
+    after() {},
+    closest: () => null,
+    addEventListener() {},
+    removeEventListener() {},
+    insertAdjacentHTML() {},
+    focus() {},
+    blur() {},
+    querySelector: () => element(),
+    querySelectorAll: () => [],
+    textContent: "",
+    innerHTML: "",
+    scrollTop: 0,
+    scrollHeight: 0,
+    offsetHeight: 0,
+    getBoundingClientRect: () => ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 }),
+  };
+}
+
+const calls = [];
+const fetchImpl = async (url, init) => {
+  const raw = String(url);
+  const full = raw.startsWith("http") ? raw : `${ORIGIN}${raw}`;
+  const path = new URL(full).pathname;
+  calls.push({ path, init });
+  const res = await httpsJson(full, init);
+  const body = await res.json();
+  return { ok: res.status >= 200 && res.status < 300, status: res.status, json: async () => body };
+};
+
+function context() {
+  const localStorage = new Map();
+  const ctx = {
+    console,
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame: (fn) => setTimeout(fn, 0),
+    cancelAnimationFrame: clearTimeout,
+    Date, Math, JSON, Promise, Object, Array, String, Number, Boolean, Map, Set, RegExp, Error,
+    TextEncoder, TextDecoder,
+    encodeURIComponent, decodeURIComponent,
+    fetch: fetchImpl,
+    alert() {},
+    prompt: () => null,
+    confirm: () => true,
+    navigator: { clipboard: { writeText: async () => {} } },
+    document: {
+      title: "",
+      body: element(),
+      documentElement: element(),
+      hidden: false,
+      visibilityState: "visible",
+      createElement: () => element(),
+      execCommand: () => true,
+      querySelector: () => element(),
+      querySelectorAll: () => [],
+      getElementById: () => element(),
+      addEventListener() {},
+    },
+    localStorage: {
+      getItem: (key) => localStorage.get(key) || null,
+      setItem: (key, value) => localStorage.set(key, String(value)),
+      removeItem: (key) => localStorage.delete(key),
+    },
+    history: { pushState() {}, replaceState() {} },
+    location: { pathname: "/", href: "" },
+    window: null,
+    globalThis: null,
+    WebSocket: class {},
+    addEventListener() {},
+  };
+  ctx.window = ctx;
+  ctx.globalThis = ctx;
+  return vm.createContext(ctx);
+}
+
+// Boot exactly the bundle set the server serves for the desktop git-ui feature.
+const SHARED_BUNDLES = [
+  "/assets/shared/core.js",
+  "/assets/shared/actions.js",
+  "/assets/shared/file-icons.js",
+  "/assets/shared/file-tree.js",
+  "/assets/shared/line-context.js",
+  "/assets/shared/file-content-search.js",
+  "/assets/shared/workspace-search.js",
+];
+const sources = [];
+for (const path of SHARED_BUNDLES) sources.push(await loadText(path));
+// appRefreshIconButton comes from the desktop app bundle (app_js/core.js).
+sources.push('\nfunction appRefreshIconButton(){ return ""; }\n');
+sources.push(await loadText("/assets/desktop/git-ui.js"));
+const ctx = context();
+vm.runInContext(sources.join("\n;\n"), ctx);
+
+const ui = ctx.window.HerdrGitUi;
+if (!ui) throw new Error("HerdrGitUi failed to boot from served bundles");
+
+const assert = (cond, msg) => { if (!cond) throw new Error(`FAIL: ${msg}`); console.log(`ok - ${msg}`); };
+
+// 1. Open the Git panel for the real repo (what a browser click does).
+await ui.open({ cwd: REPO, title: "accept-repo" }, { forceOpen: true });
+await new Promise((resolve) => setTimeout(resolve, 300));
+assert(calls.some((c) => c.path === "/api/git-ui/status"), "git panel fetched status from the real backend");
+
+// 2. The real status must report the untracked dir with a trailing slash.
+const statusRes = await httpsJson(`${ORIGIN}/api/git-ui/status?cwd=${encodeURIComponent(REPO)}`);
+const status = await statusRes.json();
+assert(status.untracked.includes("scratchdir/"), "backend reports scratchdir/ as an untracked dir");
+
+// 3. Render the changes tree and confirm the dir row (no phantom file row).
+const treeFiles = status.untracked.concat(status.unstaged, status.staged);
+const html = ctx.window.HerdrFileTree.renderPathTree(treeFiles, {
+  callback: "HerdrGitUi",
+  toggleMethod: "toggleDir",
+  selectMethod: "selectFile",
+  activateMethod: "activateTreeItem",
+  contextMethod: "fileMenu",
+  dirContextKind: "dir",
+  dataPrefix: "git",
+  rowClass: "git-ui-file",
+  kind: "?",
+});
+assert(/herdr-tree-row dir/.test(html), "changes tree renders a dir row for scratchdir/");
+assert(!/title="scratchdir\/"/.test(html), "no phantom file row for scratchdir/");
+assert(/fileMenu\(event,'scratchdir'[^)]*,'dir'\)/.test(html), "dir row wires the dir context menu kind");
+
+// 4. Context-menu discard must reach the real backend and mutate real git.
+ui.fileMenu({ preventDefault() {}, stopPropagation() {}, clientX: 5, clientY: 5 }, "scratchdir/", "?", "dir");
+await ui.menuAction("discard");
+await new Promise((resolve) => setTimeout(resolve, 400));
+const discard = calls.filter((c) => c.path === "/api/git-ui/discard").pop();
+assert(discard, "discard POST reached the real backend");
+const body = JSON.parse(discard.init.body);
+assert(body.paths[0] === "scratchdir" && body.confirmed === true, "discard posted the folder with confirmed=true");
+
+// 5. The real repo must now be clean of the untracked dir.
+const afterRes = await httpsJson(`${ORIGIN}/api/git-ui/status?cwd=${encodeURIComponent(REPO)}`);
+const after = await afterRes.json();
+assert(!after.untracked.some((p) => p.startsWith("scratchdir")), "scratchdir is gone from real repo status");
+
+console.log("GIT E2E ACCEPTANCE PASSED");

--- a/scripts/e2e/run-git-e2e.sh
+++ b/scripts/e2e/run-git-e2e.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# End-to-end acceptance run for the Git explorer rework.
+#
+# Boots an isolated herdr-webui (its own XDG_CONFIG_HOME and --session, so a
+# user's running instance is never touched) and drives the served git-ui
+# bundle against the real backend and a throwaway git repo. Unlike
+# run-e2e.sh this needs no browser: the acceptance script boots the served
+# JS in a node vm and proxies fetch to the real server, so it runs anywhere
+# node and cargo do (including CI-style environments).
+#
+# Usage:
+#   scripts/e2e/run-git-e2e.sh [--keep]     # --keep skips teardown for debugging
+#
+# Environment overrides:
+#   E2E_PORT     server port (default 8898)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PORT="${E2E_PORT:-8898}"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/herdr-git-e2e.XXXXXX")"
+KEEP=0
+[[ "${1:-}" == "--keep" ]] && KEEP=1
+
+session_id() {
+  printf 'git-e2e-%s-%s' "$$" "$(date +%s)"
+}
+
+stop_pid() {
+  local pid="$1"
+  [[ -n "$pid" ]] || return 0
+  kill "$pid" 2>/dev/null || true
+  for i in 1 2 3 4 5; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.4
+  done
+  kill -9 "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  [[ $KEEP -eq 1 ]] && { echo "--keep set: leaving $WORK running"; return; }
+  stop_pid "${SERVER_PID:-}"
+  rm -rf "$WORK" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> workdir: $WORK"
+
+echo "==> building herdr-webui (debug)"
+(cd "$ROOT" && cargo build --target-dir target --quiet)
+
+echo "==> creating fixture repo with a dirty working tree"
+REPO="$WORK/git-accept-repo"
+mkdir -p "$REPO/src" "$REPO/scratchdir"
+cat > "$REPO/README.md" <<'EOF'
+# readme
+EOF
+cat > "$REPO/src/app.js" <<'EOF'
+console.log("hello");
+EOF
+cat > "$REPO/scratchdir/alpha.txt" <<'EOF'
+alpha
+EOF
+cat > "$REPO/scratchdir/beta.txt" <<'EOF'
+beta
+EOF
+git -C "$REPO" init -q -b main
+git -C "$REPO" add README.md src/app.js
+git -C "$REPO" -c user.name=e2e -c user.email=e2e@local commit -qm init
+# Dirty state: staged edit, unstaged edit, untracked dir.
+echo "// staged" >> "$REPO/src/app.js"
+git -C "$REPO" add src/app.js
+echo "// unstaged" >> "$REPO/src/app.js"
+
+# The server needs localhost auth bypass enabled for the acceptance probes.
+mkdir -p "$WORK/xdg/herdr-webui"
+cat > "$WORK/xdg/herdr-webui/webui-settings.json" <<'EOF'
+{ "localhost_no_auth": true }
+EOF
+
+echo "==> starting isolated server on https://127.0.0.1:$PORT"
+XDG_CONFIG_HOME="$WORK/xdg" "$ROOT/target/debug/herdr-webui" \
+  --bind "127.0.0.1:$PORT" --session "$(session_id)" --backend-mode builtin &
+SERVER_PID=$!
+
+wait_for() {
+  local desc="$1" url="$2"
+  for i in $(seq 1 50); do
+    if curl -sf -k "$url" >/dev/null 2>&1; then return 0; fi
+    sleep 0.2
+  done
+  echo "error: $desc never became reachable at $url" >&2
+  return 1
+}
+wait_for "server" "https://127.0.0.1:$PORT/" || exit 1
+
+echo "==> running git-ui acceptance checks"
+E2E_ORIGIN="https://127.0.0.1:$PORT" E2E_REPO="$REPO" node "$ROOT/scripts/e2e/git-acceptance.mjs"
+status=$?
+
+if [[ $status -eq 0 ]]; then
+  echo "==> git-ui acceptance: PASSED"
+else
+  echo "==> git-ui acceptance: FAILED" >&2
+fi
+exit $status

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -1398,7 +1398,7 @@ describe("app bundle load", () => {
     match(gitUiSource, /if \(currentMode\(\) === "readonly-compare"\) return false;/);
     match(gitUiSource, /const right = mode === "changes" \? "current" : compareRefLabel\(view\.compareTarget\);/);
     match(gitUiSource, /const order = new Map\(\(\(\(view\.logData \|\| \{\}\)\.commits\) \|\| \[\]\)\.map\(\(commit, index\) => \[String\(commit\.hash \|\| ""\), index\]\)\);/);
-    match(gitUiSource, /const \[base, target\] = selected\.slice\(\)\.sort\(\(a, b\) => rank\(a\) - rank\(b\)\);/);
+    match(gitUiSource, /const \[target, base\] = selected\.slice\(\)\.sort\(\(a, b\) => rank\(a\) - rank\(b\)\);/);
     match(gitUiSource, /Comparing \$\{esc\(compareRefLabel\(view\.compareBase\)\)\} → \$\{esc\(compareRefLabel\(view\.compareTarget\)\)\}/);
   });
 

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -832,7 +832,7 @@ describe("app bundle load", () => {
     match(gitUiSource, /compareSelectedWithPrevious/);
     match(gitUiSource, /await this\.showHistoryCommit\(hash\)/);
     match(gitUiSource, /compareSelectedWithCurrent/);
-    match(gitUiSource, /await this\.compareCommits\(hash, "\."\)/);
+    match(gitUiSource, /view\.compareTarget = "\.";\s*\n\s*view\.mode = "current-compare";/);
     match(gitUiSource, /Soft reset/);
     match(gitUiSource, /Hard reset/);
     match(gitUiSource, /selectedLogToolbar\(selected, \{ allowRewrite: currentMode\(\) === "changes", selectedBranch \}\)/);
@@ -881,7 +881,7 @@ describe("app bundle load", () => {
     match(gitUiSource, /window\.HerdrFileBrowser\.openAt\(\{ workspace_id: state\.activeKey \|\| `git-file-history:\$\{cwd\}`/);
     match(gitUiSource, /view\.historySource = "file-browser";/);
     match(gitUiSource, /const compare = activeTab !== "history" && currentMode\(\) !== "changes"/);
-    match(gitUiSource, /const ref = currentMode\(\) === "changes" \? "working" : \(view\.compareTarget \|\| "HEAD"\);/);
+    match(gitUiSource, /const ref = currentMode\(\) === "changes" \|\| currentMode\(\) === "current-compare" \? "working" : \(view\.compareTarget \|\| "HEAD"\);/);
     match(gitUiSource, /ref_name=\$\{encodeURIComponent\(ref\)\}/);
     match(gitUiSource, /blame unavailable/);
     match(gitUiSource, /function sideFileCount\(view\)/);

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -1368,6 +1368,40 @@ describe("app bundle load", () => {
     match(gitUiSource, /filterFiles/);
   });
 
+  it("supports folder-level stage, unstage, and discard in the Git changes tree", () => {
+    const fileTreeSource = readFileSync(new URL("./shared/file_tree.js", import.meta.url), "utf8");
+
+    match(fileTreeSource, /raw\.endsWith\("\/"\)/);
+    match(fileTreeSource, /Status lines report untracked directories as "dir\/"/);
+    match(fileTreeSource, /dirContextKind/);
+    match(gitUiSource, /dirContextKind: "dir",/);
+    match(gitUiSource, /function dirMenuTargetPaths\(menu\)/);
+    match(gitUiSource, /function renderDirContextMenu\(menu\)/);
+    match(gitUiSource, /Stage folder \(\$\{countLabel\}\)/);
+    match(gitUiSource, /Unstage folder \(\$\{countLabel\}\)/);
+    match(gitUiSource, /Discard folder \(\$\{countLabel\}\)/);
+    match(gitUiSource, /if \(menu\.kind === "dir"\) \{/);
+    match(gitUiSource, /post\("\/api\/git-ui\/stage", \{ cwd: active\(\)\.cwd, paths: targets \}/);
+    match(gitUiSource, /post\("\/api\/git-ui\/unstage", \{ cwd: active\(\)\.cwd, paths: targets \}/);
+    match(gitUiSource, /post\("\/api\/git-ui\/discard", \{ cwd: active\(\)\.cwd, paths: \[path\], confirmed: true \}/);
+    match(gitUiSource, /fileMenu\(event, file, kind, rowKind\)/);
+    match(gitUiSource, /kind: rowKind === "dir" \? "dir" : kind/);
+  });
+
+  it("compares commits with working tree and puts the newest ref on the right", () => {
+    match(gitUiSource, /function compareRefLabel\(ref\)/);
+    match(gitUiSource, /if \(!value \|\| value === "\."\) return "working tree";/);
+    match(gitUiSource, /view\.compareTarget = "\.";\s*\n\s*view\.mode = "current-compare";/);
+    match(gitUiSource, /const mergeBase = currentMode\(\) === "current-compare" \? "&merge_base=true" : "";/);
+    match(gitUiSource, /return currentMode\(\) === "changes" \|\| currentMode\(\) === "current-compare";/);
+    match(gitUiSource, /const ref = currentMode\(\) === "changes" \|\| currentMode\(\) === "current-compare" \? "working" : \(view\.compareTarget \|\| "HEAD"\);/);
+    match(gitUiSource, /if \(currentMode\(\) === "readonly-compare"\) return false;/);
+    match(gitUiSource, /const right = mode === "changes" \? "current" : compareRefLabel\(view\.compareTarget\);/);
+    match(gitUiSource, /const order = new Map\(\(\(\(view\.logData \|\| \{\}\)\.commits\) \|\| \[\]\)\.map\(\(commit, index\) => \[String\(commit\.hash \|\| ""\), index\]\)\);/);
+    match(gitUiSource, /const \[base, target\] = selected\.slice\(\)\.sort\(\(a, b\) => rank\(a\) - rank\(b\)\);/);
+    match(gitUiSource, /Comparing \$\{esc\(compareRefLabel\(view\.compareBase\)\)\} → \$\{esc\(compareRefLabel\(view\.compareTarget\)\)\}/);
+  });
+
   it("uses shared file tree rows for Git files with Git metadata", () => {
     const fileTreeSource = readFileSync(new URL("./shared/file_tree.js", import.meta.url), "utf8");
     const gitLayoutCss = readFileSync(new URL("./desktop/git_ui/layout.css", import.meta.url), "utf8");

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -977,6 +977,7 @@
         selectMethod,
         activateMethod: "activateTreeItem",
         contextMethod: "fileMenu",
+        dirContextKind: "dir",
         dataPrefix: "git",
         rowClass: "git-ui-file",
         dirClass: "git-ui-file git-ui-dir",
@@ -1041,9 +1042,38 @@
     return `<div class="git-ui-file ${activePath === file ? "active" : ""}" role="treeitem" tabindex="0" data-git-path="${esc(file)}" data-git-kind="${esc(kind)}" style="--level:${level}" onclick="HerdrGitUi.${method}('${arg(file)}','${kind}')" onkeydown="HerdrGitUi.activateTreeItem(event)" oncontextmenu="return HerdrGitUi.fileMenu(event,'${arg(file)}','${kind}')"><span class="git-ui-tree-caret"></span><span class="git-ui-tree-icon file">${treeIcon("file")}</span><span class="git-ui-path" title="${esc(file)}">${FileTree && FileTree.highlight ? FileTree.highlight(name, (active() || {}).fileFilter) : esc(name)}</span><span class="git-ui-file-meta">${summary}</span></div>`;
   }
 
+  function dirMenuTargetPaths(menu) {
+    const view = active() || {};
+    const status = view.status || {};
+    const dir = String(menu.file || "").replace(/\/+$/, "");
+    if (!dir) return [];
+    const prefix = `${dir}/`;
+    return [...(status.staged || []), ...(status.unstaged || []), ...(status.untracked || []), ...(status.conflicted || [])]
+      .map((path) => String(path || ""))
+      .filter((path) => path === dir || path === `${dir}/` || path.startsWith(prefix))
+      .filter((path, index, all) => all.indexOf(path) === index);
+  }
+
+  function renderDirContextMenu(menu) {
+    const dir = String(menu.file || "");
+    const targets = dirMenuTargetPaths(menu);
+    const count = targets.length;
+    const countLabel = count === 1 ? "1 file" : `${count} files`;
+    const actions = [];
+    actions.push(`<button onclick="HerdrGitUi.menuAction('showInExplorer')">Show in file explorer</button>`);
+    actions.push(`<button onclick="HerdrGitUi.menuAction('showHistory')">Show history</button>`);
+    if (count) {
+      actions.push(`<button onclick="HerdrGitUi.menuAction('stage')">Stage folder (${countLabel})</button>`);
+      actions.push(`<button onclick="HerdrGitUi.menuAction('unstage')">Unstage folder (${countLabel})</button>`);
+      actions.push(`<button onclick="HerdrGitUi.menuAction('discard')">Discard folder (${countLabel})</button>`);
+    }
+    return `<div class="git-ui-menu" style="left:${Math.max(0, menu.x)}px;top:${Math.max(0, menu.y)}px" onclick="event.stopPropagation()">${actions.join("")}</div>`;
+  }
+
   function renderContextMenu() {
     const menu = state.contextMenu;
     if (!menu) return "";
+    if (menu.kind === "dir") return renderDirContextMenu(menu);
     const actions = [];
     actions.push(`<button onclick="HerdrGitUi.menuAction('showInExplorer')">Show in file explorer</button>`);
     actions.push(`<button onclick="HerdrGitUi.menuAction('showHistory')">Show history</button>`);
@@ -2871,10 +2901,10 @@
       event.preventDefault();
       event.currentTarget.click();
     },
-    fileMenu(event, file, kind) {
+    fileMenu(event, file, kind, rowKind) {
       event.preventDefault();
       event.stopPropagation();
-      state.contextMenu = { x: event.clientX, y: event.clientY, file: decodeURIComponent(file), kind };
+      state.contextMenu = { x: event.clientX, y: event.clientY, file: decodeURIComponent(file), kind: rowKind === "dir" ? "dir" : kind };
       render();
       return false;
     },
@@ -2893,7 +2923,7 @@
         return;
       }
       if (action === "showInExplorer") {
-        const parentDir = menu.file.split("/").slice(0, -1).join("/");
+        const parentDir = menu.kind === "dir" ? menu.file.replace(/\/+$/, "") : menu.file.split("/").slice(0, -1).join("/");
         if (window.HerdrFileBrowser && window.HerdrFileBrowser.openAt) {
           const view = active();
           if (view) {
@@ -2912,6 +2942,19 @@
         const view = active();
         if (view) {
           await window.HerdrGitUi.openFileHistory(encodeURIComponent(view.cwd), encodeURIComponent(menu.file));
+        }
+        return;
+      }
+      if (menu.kind === "dir") {
+        const path = menu.file.replace(/\/+$/, "");
+        const targets = dirMenuTargetPaths(menu);
+        if (!targets.length) return;
+        if (action === "stage" && confirm(`Stage ${targets.length} file${targets.length === 1 ? "" : "s"} under ${path}?`)) {
+          post("/api/git-ui/stage", { cwd: active().cwd, paths: targets }, `Staging ${path}`);
+        } else if (action === "unstage" && confirm(`Unstage ${targets.length} file${targets.length === 1 ? "" : "s"} under ${path}?`)) {
+          post("/api/git-ui/unstage", { cwd: active().cwd, paths: targets }, `Unstaging ${path}`);
+        } else if (action === "discard" && confirm(`Discard all changes under ${path}? This restores ${targets.length} file${targets.length === 1 ? "" : "s"} and deletes untracked ones. This cannot be undone.`)) {
+          post("/api/git-ui/discard", { cwd: active().cwd, paths: [path], confirmed: true }, `Discarding ${path}`);
         }
         return;
       }

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -1065,10 +1065,14 @@
     const targets = dirMenuTargetPaths(menu);
     const count = targets.length;
     const countLabel = count === 1 ? "1 file" : `${count} files`;
+    // Folder mutations target the working tree, so they only make sense in
+    // the changes view. Compare and stash trees keep their dir menus read-only,
+    // matching file rows which hide mutations outside changes mode.
+    const mutable = currentMode() === "changes";
     const actions = [];
     actions.push(`<button onclick="HerdrGitUi.menuAction('showInExplorer')">Show in file explorer</button>`);
     actions.push(`<button onclick="HerdrGitUi.menuAction('showHistory')">Show history</button>`);
-    if (count) {
+    if (count && mutable) {
       actions.push(`<button onclick="HerdrGitUi.menuAction('stage')">Stage folder (${countLabel})</button>`);
       actions.push(`<button onclick="HerdrGitUi.menuAction('unstage')">Unstage folder (${countLabel})</button>`);
       actions.push(`<button onclick="HerdrGitUi.menuAction('discard')">Discard folder (${countLabel})</button>`);
@@ -2952,6 +2956,7 @@
         return;
       }
       if (menu.kind === "dir") {
+        if (currentMode() !== "changes") return;
         const path = menu.file.replace(/\/+$/, "");
         const targets = dirMenuTargetPaths(menu);
         if (!targets.length) return;

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -928,6 +928,12 @@
     return view.mode || "changes";
   }
 
+  function compareRefLabel(ref) {
+    const value = String(ref || "").trim();
+    if (!value || value === ".") return "working tree";
+    return value;
+  }
+
   function canMutateDiff() {
     const view = active() || {};
     if (view.tab === "stash") return false;
@@ -1597,7 +1603,7 @@
     const viewStateLabel = fileViewStateLabel(view, activeTab);
     const stateLabel = breadcrumbs || `<span class="git-ui-compare-state git-ui-file-view-state" title="${esc(viewStateLabel)}">${esc(viewStateLabel)}</span>`;
     const compare = activeTab !== "history" && currentMode() !== "changes" && !view.temporaryHistoryCompare && !view.fileBackTarget
-      ? `<span class="git-ui-compare-state">Comparing ${esc(view.compareBase || "base")} → ${esc(view.compareTarget || "target")}</span>`
+      ? `<span class="git-ui-compare-state">Comparing ${esc(compareRefLabel(view.compareBase))} → ${esc(compareRefLabel(view.compareTarget))}</span>`
       : "";
     const files = (view.diff && view.diff.files) || [];
     const collapsible = activeTab === "changes" && files.length > 0;
@@ -1626,7 +1632,7 @@
 
   function canEditCurrentFile(view) {
     if (!view || !view.file || view.file.endsWith("/")) return false;
-    if (currentMode() === "readonly-compare" && view.compareTarget !== ".") return false;
+    if (currentMode() === "readonly-compare") return false;
     if (view.diffKind === "S" || view.diffScope === "staged") return false;
     const file = diffFile(view.file);
     return !file || file.status !== "deleted";
@@ -1914,8 +1920,8 @@
     const large = lineCount > LARGE_FILE_DIFF_LINE_LIMIT;
     const loadedLarge = !!(view.loadedLargeDiffFiles || {})[file.path];
     const renderFullLarge = !!(view.fullLargeDiffFiles || {})[diffFileKey(file)];
-    const left = mode === "changes" ? fileDiffLeftLabel(file) : (view.compareBase || "base");
-    const right = mode === "readonly-compare" ? (view.compareTarget || "target") : "current";
+    const left = mode === "changes" ? fileDiffLeftLabel(file) : compareRefLabel(view.compareBase);
+    const right = mode === "changes" ? "current" : compareRefLabel(view.compareTarget);
     if (view.showBlame && (!large || loadedLarge)) ensureBlame(file.path);
     const conflictActions = renderDiffConflictResolutionButtons(file);
     const restore = mode === "changes"
@@ -1967,7 +1973,7 @@
     const view = active();
     if (!view || !path || view.blame[path] !== undefined || currentMode() === "readonly-compare") return;
     view.blame[path] = null;
-    const ref = currentMode() === "changes" ? "working" : (view.compareTarget || "HEAD");
+    const ref = currentMode() === "changes" || currentMode() === "current-compare" ? "working" : (view.compareTarget || "HEAD");
     api(`/api/git-ui/blame?cwd=${encodeURIComponent(view.cwd)}&file=${encodeURIComponent(path)}&ref_name=${encodeURIComponent(ref)}`)
       .then((data) => {
         view.blame[path] = parseBlame(data.text || "");
@@ -3721,9 +3727,16 @@
       render();
     },
     compareSelectedLog() {
-      const selected = ((active() || {}).selectedLogCommits || []).slice(0, 2);
+      const view = active();
+      const selected = ((view && view.selectedLogCommits) || []).slice(0, 2);
       if (selected.length === 1) this.openSelectedCompareModal();
-      if (selected.length === 2) this.compareCommits(selected[0], selected[1]);
+      if (selected.length !== 2) return;
+      // The right side must always show the newest ref: order the pair by
+      // position in the commit log, not by click order.
+      const order = new Map((((view.logData || {}).commits) || []).map((commit, index) => [String(commit.hash || ""), index]));
+      const rank = (hash) => (order.has(hash) ? order.get(hash) : Number.MAX_SAFE_INTEGER);
+      const [base, target] = selected.slice().sort((a, b) => rank(a) - rank(b));
+      this.compareCommits(base, target);
     },
     openSelectedCompareModal() {
       const selected = ((active() || {}).selectedLogCommits || []).slice(0, 1);
@@ -3745,7 +3758,15 @@
       const hash = state.compareSelectedModal && state.compareSelectedModal.ref;
       state.compareSelectedModal = null;
       if (!hash) return;
-      await this.compareCommits(hash, ".");
+      const view = active();
+      if (!view) return;
+      pushNavigationSnapshot(view);
+      view.compareBase = hash;
+      view.compareTarget = ".";
+      view.mode = "current-compare";
+      clearHistoryCompareState(view, { clearBackTarget: true });
+      view.tab = "changes";
+      await loadDiff();
     },
     setLogAll(value) {
       const view = active();

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -3732,10 +3732,12 @@
       if (selected.length === 1) this.openSelectedCompareModal();
       if (selected.length !== 2) return;
       // The right side must always show the newest ref: order the pair by
-      // position in the commit log, not by click order.
+      // position in the commit log, not by click order. logData.commits[0] is
+      // the newest commit, so the ascending sort puts the newest first and it
+      // becomes the compare target (right side).
       const order = new Map((((view.logData || {}).commits) || []).map((commit, index) => [String(commit.hash || ""), index]));
       const rank = (hash) => (order.has(hash) ? order.get(hash) : Number.MAX_SAFE_INTEGER);
-      const [base, target] = selected.slice().sort((a, b) => rank(a) - rank(b));
+      const [target, base] = selected.slice().sort((a, b) => rank(a) - rank(b));
       this.compareCommits(base, target);
     },
     openSelectedCompareModal() {

--- a/src/assets/git_ui_behavior.test.mjs
+++ b/src/assets/git_ui_behavior.test.mjs
@@ -303,3 +303,24 @@ test("current-compare keeps the working tree on the target (right) side", async 
   assert.equal(call.params.get("target"), ".", "working tree must be the target (right side)");
   assert.equal(call.params.get("merge_base"), "true", "current-compare must request a merge base");
 });
+test("showChangesList exits current-compare back to plain working-tree diff", async () => {
+  const booted = await bootGitUi({
+    "/api/git-ui/status": emptyStatus(),
+    "/api/git-ui/diff": { files: [] },
+    "/api/git-ui/compare": { files: [] },
+    "/api/git-ui/log": { commits: [{ hash: NEW }], lines: [], rows: [], has_more: false, limit: 80 },
+  });
+  const { ui } = booted;
+  await ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
+  ui.selectLogCommit({ shiftKey: true }, NEW);
+  ui.openSelectedCompareModal();
+  await ui.compareSelectedWithCurrent();
+  let call = lastCompareCall(booted.calls);
+  assert.ok(call, "expected the current-compare request");
+  assert.equal(call.params.get("target"), ".");
+  // Leaving compare mode must reload the working-tree diff, not the compare.
+  await ui.showChangesList();
+  const last = booted.calls[booted.calls.length - 1];
+  assert.equal(last.path, "/api/git-ui/diff", "returning to changes must fetch the working-tree diff");
+  assert.equal(last.params.get("cwd"), "/tmp/demo-repo");
+});

--- a/src/assets/git_ui_behavior.test.mjs
+++ b/src/assets/git_ui_behavior.test.mjs
@@ -1,0 +1,305 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import vm from "node:vm";
+
+// Behavioral tests for the desktop Git explorer compare modes.
+// The vm boots the same source set the server concatenates for the git-ui
+// bundle (see src/assets.rs DESKTOP_GIT_UI_JS): shared helpers, git_ui
+// modules, then git_ui.js. Assertions go through public outputs (fetch URLs)
+// rather than internal state.
+
+function element() {
+  return {
+    style: { setProperty() {}, removeProperty() {} },
+    dataset: {},
+    value: "",
+    children: [],
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    setAttribute() {},
+    getAttribute: () => null,
+    appendChild() {},
+    removeChild() {},
+    remove() {},
+    replaceWith() {},
+    insertBefore() {},
+    after() {},
+    closest: () => null,
+    addEventListener() {},
+    removeEventListener() {},
+    insertAdjacentHTML() {},
+    focus() {},
+    blur() {},
+    querySelector: () => element(),
+    querySelectorAll: () => [],
+    textContent: "",
+    innerHTML: "",
+    scrollTop: 0,
+    scrollHeight: 0,
+    offsetHeight: 0,
+    getBoundingClientRect: () => ({ top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 }),
+  };
+}
+
+function context(fetchImpl) {
+  const localStorage = new Map();
+  const ctx = {
+    console,
+    setTimeout,
+    clearTimeout,
+    requestAnimationFrame: (fn) => setTimeout(fn, 0),
+    cancelAnimationFrame: clearTimeout,
+    Date,
+    Math,
+    JSON,
+    Promise,
+    Object,
+    Array,
+    String,
+    Number,
+    Boolean,
+    Map,
+    Set,
+    RegExp,
+    Error,
+    TextEncoder,
+    TextDecoder,
+    encodeURIComponent,
+    decodeURIComponent,
+    fetch: fetchImpl,
+    alert() {},
+    prompt: () => null,
+    confirm: () => true,
+    navigator: { clipboard: { writeText: async () => {} } },
+    document: {
+      title: "",
+      body: element(),
+      documentElement: element(),
+      hidden: false,
+      visibilityState: "visible",
+      createElement: () => element(),
+      execCommand: () => true,
+      querySelector: () => element(),
+      querySelectorAll: () => [],
+      getElementById: () => element(),
+      addEventListener() {},
+    },
+    localStorage: {
+      getItem: (key) => localStorage.get(key) || null,
+      setItem: (key, value) => localStorage.set(key, String(value)),
+      removeItem: (key) => localStorage.delete(key),
+    },
+    history: { pushState() {}, replaceState() {} },
+    location: { pathname: "/", href: "" },
+    window: null,
+    globalThis: null,
+    WebSocket: class {},
+    addEventListener() {},
+  };
+  ctx.window = ctx;
+  ctx.globalThis = ctx;
+  return vm.createContext(ctx);
+}
+
+const GIT_UI_SOURCE = readFileSync(new URL("./desktop/git_ui.js", import.meta.url), "utf8");
+const SHARED_SOURCES = [
+  "./shared/core.js",
+  "./shared/actions.js",
+  "./shared/file_icons.js",
+  "./shared/file_tree.js",
+  "./shared/line_context.js",
+  "./shared/file_content_search.js",
+  "./shared/workspace_search.js",
+  "./desktop/git_ui/settings.js",
+  "./desktop/git_ui/syntax.js",
+  "./desktop/git_ui/actions.js",
+  "./desktop/git_ui/log.js",
+]
+  .map((path) => readFileSync(new URL(path, import.meta.url), "utf8"))
+  .join("\n;\n");
+// appRefreshIconButton comes from the desktop app bundle; stub it.
+const APP_STUBS = `
+function appRefreshIconButton() { return ""; }
+`;
+
+async function bootGitUi(responses) {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    const raw = String(url);
+    const path = raw.split("?")[0];
+    const params = new URLSearchParams(raw.split("?")[1] || "");
+    calls.push({ path, params, raw, init });
+    const handler = responses[path];
+    if (handler) {
+      const body = typeof handler === "function" ? handler(params) : handler;
+      return { ok: true, status: 200, json: async () => body };
+    }
+    return { ok: true, status: 200, json: async () => ({}) };
+  };
+  const ctx = context(fetchImpl);
+  vm.runInContext(SHARED_SOURCES, ctx);
+  vm.runInContext(APP_STUBS, ctx);
+  vm.runInContext(GIT_UI_SOURCE, ctx);
+  const ui = ctx.window.HerdrGitUi;
+  return { ui, ctx, calls };
+}
+
+const NEW = "cccccccccccccccccccccccccccccccccccccccc";
+const OLD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+function emptyStatus() {
+  return { branch: "main", ahead: 0, behind: 0, staged: [], unstaged: [], untracked: [], conflicted: [] };
+}
+
+async function openedWithStatus(status) {
+  const booted = await bootGitUi({
+    "/api/git-ui/status": status,
+    "/api/git-ui/diff": { files: [] },
+    "/api/git-ui/compare": { files: [] },
+    "/api/git-ui/log": { commits: [], lines: [], rows: [], has_more: false, limit: 80 },
+  });
+  await booted.ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
+  return booted;
+}
+
+function lastPostCall(calls, path) {
+  const posts = calls.filter((call) => call.path === path);
+  return posts[posts.length - 1] || null;
+}
+
+test("folder context menu stages, unstages, and discards files under a directory", async () => {
+  const booted = await openedWithStatus({
+    branch: "main", ahead: 0, behind: 0,
+    staged: ["src/lib/new.js"],
+    unstaged: ["src/lib/changed.js"],
+    untracked: ["src/lib/fresh.txt"],
+    conflicted: [],
+  });
+  const { ui } = booted;
+  ui.fileMenu({ preventDefault() {}, stopPropagation() {}, clientX: 10, clientY: 10 }, "src/lib/", "M", "dir");
+  // The menu is rendered from state.contextMenu; menuAction reads it.
+  const menu = booted.ctx.window.HerdrGitUi;
+  await ui.menuAction("stage");
+  let call = lastPostCall(booted.calls, "/api/git-ui/stage");
+  assert.ok(call, "expected a stage post");
+  let body = JSON.parse(call.init.body);
+  assert.deepEqual(body.paths.sort(), ["src/lib/changed.js", "src/lib/fresh.txt", "src/lib/new.js"], "stage must post every status path under the folder");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  ui.fileMenu({ preventDefault() {}, stopPropagation() {}, clientX: 10, clientY: 10 }, "src/lib/", "M", "dir");
+  await ui.menuAction("unstage");
+  call = lastPostCall(booted.calls, "/api/git-ui/unstage");
+  assert.ok(call, "expected an unstage post");
+  body = JSON.parse(call.init.body);
+  assert.equal(body.paths.length, 3, "unstage must post every status path under the folder");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  ui.fileMenu({ preventDefault() {}, stopPropagation() {}, clientX: 10, clientY: 10 }, "src/lib/", "M", "dir");
+  await ui.menuAction("discard");
+  call = lastPostCall(booted.calls, "/api/git-ui/discard");
+  assert.ok(call, "expected a discard post");
+  body = JSON.parse(call.init.body);
+  assert.deepEqual(body.paths, ["src/lib"], "discard must post the folder itself; the backend expands untracked files");
+  assert.equal(body.confirmed, true, "discard must be pre-confirmed by the dialog");
+});
+
+test("untracked dir status entries render as directory rows, not phantom files", async () => {
+  const booted = await openedWithStatus({
+    branch: "main", ahead: 0, behind: 0,
+    staged: [],
+    unstaged: ["src/changed.js"],
+    untracked: ["scratch/"],
+    conflicted: [],
+  });
+  const html = booted.ctx.window.HerdrFileTree.renderPathTree(["src/changed.js", "scratch/"], {
+    callback: "HerdrGitUi",
+    toggleMethod: "toggleDir",
+    selectMethod: "selectFile",
+    activateMethod: "activateTreeItem",
+    contextMethod: "fileMenu",
+    dirContextKind: "dir",
+    dataPrefix: "git",
+    rowClass: "git-ui-file",
+    kind: "M",
+  });
+  assert.match(html, /herdr-tree-row dir[^"]*"/, "scratch/ must render a dir row");
+  const phantom = /herdr-tree-row file[^>]*title="scratch\/"/;
+  assert.ok(!phantom.test(html), "scratch/ must not render a phantom file row");
+  assert.match(html, /oncontextmenu="return HerdrGitUi\.fileMenu\(event,'scratch'[^)]*,'dir'\)"/, "dir rows must pass the dir context kind");
+});
+
+test("folder context menu stages files in nested subdirectories of the target", async () => {
+  const booted = await openedWithStatus({
+    branch: "main", ahead: 0, behind: 0,
+    staged: [],
+    unstaged: ["docs/api/spec.md"],
+    untracked: ["docs/api/draft.txt", "other/root.txt"],
+    conflicted: [],
+  });
+  const { ui } = booted;
+  ui.fileMenu({ preventDefault() {}, stopPropagation() {}, clientX: 10, clientY: 10 }, "docs/", "M", "dir");
+  await ui.menuAction("stage");
+  const call = lastPostCall(booted.calls, "/api/git-ui/stage");
+  assert.ok(call, "expected a stage post");
+  const body = JSON.parse(call.init.body);
+  assert.deepEqual(body.paths.sort(), ["docs/api/draft.txt", "docs/api/spec.md"], "only paths under docs/ are staged");
+});
+
+function lastCompareCall(calls) {
+  const compare = calls.filter((call) => call.path === "/api/git-ui/compare");
+  return compare[compare.length - 1] || null;
+}
+
+test("compareSelectedLog puts the newest commit on the target (right) side", async () => {
+  const logResponse = { commits: [{ hash: NEW }, { hash: OLD }], lines: [], rows: [], has_more: false, limit: 80 };
+  const boot = () => bootGitUi({
+    "/api/git-ui/status": emptyStatus(),
+    "/api/git-ui/diff": { files: [] },
+    "/api/git-ui/compare": { files: [] },
+    "/api/git-ui/log": logResponse,
+  });
+
+  // Click order 1: OLD first, then NEW.
+  const first = await boot();
+  await first.ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
+  first.ui.tab("log");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  first.ui.selectLogCommit({ shiftKey: true }, OLD);
+  first.ui.selectLogCommit({ shiftKey: true }, NEW);
+  await first.ui.compareSelectedLog();
+  let call = lastCompareCall(first.calls);
+  assert.ok(call, "expected a compare request");
+  assert.equal(call.params.get("base"), OLD, "older commit must be the base (left side)");
+  assert.equal(call.params.get("target"), NEW, "newest commit must be the target (right side)");
+
+  // Click order 2: NEW first, then OLD — the result must be identical.
+  const second = await boot();
+  await second.ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
+  second.ui.tab("log");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  second.ui.selectLogCommit({ shiftKey: true }, NEW);
+  second.ui.selectLogCommit({ shiftKey: true }, OLD);
+  await second.ui.compareSelectedLog();
+  call = lastCompareCall(second.calls);
+  assert.ok(call, "expected a compare request");
+  assert.equal(call.params.get("base"), OLD, "older commit must stay the base regardless of click order");
+  assert.equal(call.params.get("target"), NEW, "newest commit must stay the target regardless of click order");
+});
+
+test("current-compare keeps the working tree on the target (right) side", async () => {
+  const booted = await bootGitUi({
+    "/api/git-ui/status": emptyStatus(),
+    "/api/git-ui/diff": { files: [] },
+    "/api/git-ui/compare": { files: [] },
+    "/api/git-ui/log": { commits: [{ hash: NEW }], lines: [], rows: [], has_more: false, limit: 80 },
+  });
+  await booted.ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
+  booted.ui.selectLogCommit({ shiftKey: true }, NEW);
+  booted.ui.openSelectedCompareModal();
+  await booted.ui.compareSelectedWithCurrent();
+  const call = lastCompareCall(booted.calls);
+  assert.ok(call, "expected a compare request");
+  assert.equal(call.params.get("base"), NEW, "selected commit must be the base");
+  assert.equal(call.params.get("target"), ".", "working tree must be the target (right side)");
+  assert.equal(call.params.get("merge_base"), "true", "current-compare must request a merge base");
+});

--- a/src/assets/git_ui_behavior.test.mjs
+++ b/src/assets/git_ui_behavior.test.mjs
@@ -324,3 +324,24 @@ test("showChangesList exits current-compare back to plain working-tree diff", as
   assert.equal(last.path, "/api/git-ui/diff", "returning to changes must fetch the working-tree diff");
   assert.equal(last.params.get("cwd"), "/tmp/demo-repo");
 });
+
+test("folder mutations are hidden and refused outside the changes view", async () => {
+  const booted = await bootGitUi({
+    "/api/git-ui/status": emptyStatus(),
+    "/api/git-ui/diff": { files: [] },
+    "/api/git-ui/compare": { files: [] },
+    "/api/git-ui/log": { commits: [{ hash: NEW }, { hash: OLD }], lines: [], rows: [], has_more: false, limit: 80 },
+  });
+  const { ui } = booted;
+  await ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
+  // Enter a compare mode with a dirty working tree to simulate the Compared
+  // section showing a dir row.
+  ui.selectLogCommit({ shiftKey: true }, NEW);
+  ui.openSelectedCompareModal();
+  await ui.compareSelectedWithCurrent();
+  const before = booted.calls.length;
+  ui.fileMenu({ preventDefault() {}, stopPropagation() {}, clientX: 10, clientY: 10 }, "src/", "M", "dir");
+  await ui.menuAction("stage");
+  const staged = booted.calls.slice(before).filter((call) => call.path === "/api/git-ui/stage");
+  assert.equal(staged.length, 0, "no stage POST may fire outside changes mode");
+});

--- a/src/assets/shared/file_tree.js
+++ b/src/assets/shared/file_tree.js
@@ -84,8 +84,18 @@
     const opts = Object.assign({ indentPx: treeIndentPx() }, options || {});
     const root = { dirs: new Map(), files: [] };
     for (const file of files || []) {
-      const parts = String(file).split("/").filter(Boolean);
+      const raw = String(file);
+      const parts = raw.split("/").filter(Boolean);
       let node = root;
+      if (raw.endsWith("/")) {
+        // Status lines report untracked directories as "dir/": make them real
+        // dir nodes so the tree shows a folder instead of a phantom file row.
+        for (const part of parts) {
+          if (!node.dirs.has(part)) node.dirs.set(part, { dirs: new Map(), files: [] });
+          node = node.dirs.get(part);
+        }
+        continue;
+      }
       for (const part of parts.slice(0, -1)) {
         if (!node.dirs.has(part)) node.dirs.set(part, { dirs: new Map(), files: [] });
         node = node.dirs.get(part);
@@ -112,7 +122,8 @@
         const status = typeof opts.statusForPath === "function" ? opts.statusForPath(dirPath, opts.kind) : "";
         const meta = typeof opts.metaForPath === "function" ? opts.metaForPath(dirPath, opts.kind) : "";
         const name = renderCompactDirName(compact.parts, opts, callback);
-        return `<div class="herdr-tree-row dir${dirClass}${status ? ` git-${status}` : ""}" role="treeitem" tabindex="0" aria-expanded="${collapsed ? "false" : "true"}" style="${indentStyle(level, opts)}" onclick="${callback}.${opts.toggleMethod || "toggle"}('${arg(dirPath)}')"${keydown}><span class="herdr-tree-caret">${icon(collapsed ? "closed" : "open")}</span><span class="herdr-tree-kind">${icon("dir", dirPath)}</span><span class="herdr-tree-name">${name}</span>${statusBadge(status)}${meta}</div>${collapsed ? "" : renderPathNode(compact.child, dirPath, opts, level + 1)}`;
+        const dirContext = opts.contextMethod ? ` oncontextmenu="return ${callback}.${opts.contextMethod}(event,'${arg(dirPath)}'${kindArg}${opts.dirContextKind ? `,'${opts.dirContextKind}'` : ""})"` : "";
+        return `<div class="herdr-tree-row dir${dirClass}${status ? ` git-${status}` : ""}" role="treeitem" tabindex="0" aria-expanded="${collapsed ? "false" : "true"}" style="${indentStyle(level, opts)}" onclick="${callback}.${opts.toggleMethod || "toggle"}('${arg(dirPath)}')"${keydown}${dirContext}><span class="herdr-tree-caret">${icon(collapsed ? "closed" : "open")}</span><span class="herdr-tree-kind">${icon("dir", dirPath)}</span><span class="herdr-tree-name">${name}</span>${statusBadge(status)}${meta}</div>${collapsed ? "" : renderPathNode(compact.child, dirPath, opts, level + 1)}`;
       }
       const selected = opts.selectedPath === entry.path && (!opts.selectedKind || opts.selectedKind === opts.kind);
       const meta = typeof opts.metaForPath === "function" ? opts.metaForPath(entry.path, opts.kind) : "";

--- a/src/git_ui/diff.rs
+++ b/src/git_ui/diff.rs
@@ -7,7 +7,7 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use super::{git_json_error, git_ui_text_strings, safe_git_token, safe_repo_path};
+use super::{git_json_error, git_ui_output, git_ui_text_strings, safe_git_token, safe_repo_path};
 use crate::{require_auth, WebState};
 
 #[derive(Deserialize)]
@@ -253,6 +253,30 @@ pub(super) fn git_ui_diff_args(
     Ok(args)
 }
 
+/// When a compare base is `<commit>^` and `<commit>` is the repository's root
+/// commit, the parent ref does not exist and `git diff` would fail. Compare
+/// from the empty tree instead so the root commit renders a full-tree diff.
+fn root_parent_fallback(cwd: &str, commit: &str) -> Result<Option<String>, String> {
+    let output = git_ui_output(cwd, &["rev-list", "--parents", "-n", "1", commit])?;
+    if !output.status.success() {
+        // Unknown commit: let the diff surface git's own error.
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut parts = stdout.split_whitespace();
+    if parts.next().is_none() || parts.next().is_some() {
+        return Ok(None);
+    }
+    // `git mktree` with an empty stdin prints the hash of the empty tree for
+    // the repository's object format (SHA-1 or SHA-256).
+    let tree = git_ui_output(cwd, &["mktree"])?;
+    if !tree.status.success() {
+        return Ok(None);
+    }
+    let hash = String::from_utf8_lossy(&tree.stdout).trim().to_string();
+    Ok((!hash.is_empty()).then_some(hash))
+}
+
 async fn git_ui_diff_common(query: GitUiDiffQuery, compare: bool) -> Response {
     let Some(cwd) = query.cwd.as_deref() else {
         return git_json_error(StatusCode::BAD_REQUEST, "cwd is required");
@@ -261,8 +285,35 @@ async fn git_ui_diff_common(query: GitUiDiffQuery, compare: bool) -> Response {
         Ok(args) => args,
         Err(err) => return git_json_error(StatusCode::BAD_REQUEST, err),
     };
+    let root_parent_base = if compare {
+        query
+            .base
+            .as_deref()
+            .and_then(|base| base.trim().strip_suffix('^'))
+            .map(str::to_string)
+    } else {
+        None
+    };
     let cwd = cwd.to_string();
-    match tokio::task::spawn_blocking(move || git_ui_text_strings(&cwd, &args)).await {
+    match tokio::task::spawn_blocking(move || {
+        let mut args = args;
+        if let Some(commit) = root_parent_base.as_deref() {
+            if let Ok(Some(empty_tree)) = root_parent_fallback(&cwd, commit) {
+                let base = format!("{commit}^");
+                if let Some(index) = args.iter().position(|arg| arg == &base) {
+                    args[index] = empty_tree;
+                    // The empty tree is not a commit, so --merge-base cannot
+                    // resolve a merge base against it.
+                    if let Some(index) = args.iter().position(|arg| arg.as_str() == "--merge-base") {
+                        args.remove(index);
+                    }
+                }
+            }
+        }
+        git_ui_text_strings(&cwd, &args)
+    })
+    .await
+    {
         Ok(Ok(text)) => Json(json!({ "files": parse_unified_diff(&text) })).into_response(),
         Ok(Err(err)) => git_json_error(StatusCode::BAD_GATEWAY, err),
         Err(err) => git_json_error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),

--- a/src/git_ui/diff.rs
+++ b/src/git_ui/diff.rs
@@ -304,7 +304,8 @@ async fn git_ui_diff_common(query: GitUiDiffQuery, compare: bool) -> Response {
                     args[index] = empty_tree;
                     // The empty tree is not a commit, so --merge-base cannot
                     // resolve a merge base against it.
-                    if let Some(index) = args.iter().position(|arg| arg.as_str() == "--merge-base") {
+                    if let Some(index) = args.iter().position(|arg| arg.as_str() == "--merge-base")
+                    {
                         args.remove(index);
                     }
                 }

--- a/src/git_ui/mod.rs
+++ b/src/git_ui/mod.rs
@@ -712,8 +712,14 @@ fn git_ui_discard_blocking(
         let tracked = git_ui_output(&repo, &["ls-files", "--error-unmatch", "--", path])
             .is_ok_and(|output| output.status.success());
         if tracked {
-            if let Err(err) = git_ui_text(&repo, &["restore", "--", path]) {
+            if let Err(err) = git_ui_text(&repo, &["restore", "--source=HEAD", "--staged", "--worktree", "--", path]) {
                 return Err((StatusCode::BAD_GATEWAY, err));
+            }
+            // Folders can also contain untracked leftovers that restore ignores.
+            if Path::new(&repo).join(path).is_dir() {
+                if let Err(err) = git_ui_text(&repo, &["clean", "-fd", "--", path]) {
+                    return Err((StatusCode::BAD_GATEWAY, err));
+                }
             }
         } else {
             let full = Path::new(&repo).join(path);
@@ -1794,6 +1800,60 @@ mod tests {
     }
 
     #[test]
+    fn git_ui_compare_root_commit_against_empty_tree() {
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let repo = TempRepo::new();
+            repo.commit_initial();
+            repo.write("nested/second.txt", "two\n");
+            repo.git(&["add", "."]);
+            repo.git(&["commit", "-m", "second"]);
+            let root = repo.git(&["rev-list", "--max-parents=0", "HEAD"])
+                .trim()
+                .to_string();
+            let cwd = repo.path.to_str().unwrap().to_string();
+
+            // The root commit has no parent, so `<root>^` does not resolve.
+            // The compare must fall back to the empty tree and still work.
+            let compare = git_ui_compare(
+                State(test_state()),
+                HeaderMap::new(),
+                ConnectInfo(remote()),
+                Query(GitUiDiffQuery {
+                    cwd: Some(cwd.clone()),
+                    base: Some(format!("{root}^")),
+                    target: Some(root.clone()),
+                    ..query()
+                }),
+            )
+            .await;
+            assert_eq!(compare.status(), StatusCode::OK);
+            let json = response_json(compare).await;
+            let files = json["files"].as_array().unwrap();
+            assert_eq!(files.len(), 1);
+            assert_eq!(files[0]["path"], "tracked.txt");
+            assert_eq!(files[0]["status"], "added");
+
+            // A non-root commit keeps its normal parent diff.
+            let head = repo.git(&["rev-parse", "HEAD"]).trim().to_string();
+            let compare = git_ui_compare(
+                State(test_state()),
+                HeaderMap::new(),
+                ConnectInfo(remote()),
+                Query(GitUiDiffQuery {
+                    cwd: Some(cwd),
+                    base: Some(format!("{head}^")),
+                    target: Some(head),
+                    ..query()
+                }),
+            )
+            .await;
+            assert_eq!(compare.status(), StatusCode::OK);
+            let json = response_json(compare).await;
+            assert_eq!(json["files"][0]["path"], "nested/second.txt");
+        });
+    }
+
+    #[test]
     fn git_ui_write_file_and_destructive_guards_work() {
         tokio::runtime::Runtime::new().unwrap().block_on(async {
             let repo = TempRepo::new();
@@ -1862,6 +1922,66 @@ mod tests {
                 fs::read_to_string(repo.path.join("tracked.txt")).unwrap(),
                 "one\n"
             );
+
+            // Staged changes must be discarded too, not just worktree edits.
+            repo.write("tracked.txt", "staged\n");
+            repo.git(&["add", "tracked.txt"]);
+            let discard_staged = git_ui_discard(
+                State(state.clone()),
+                HeaderMap::new(),
+                ConnectInfo(remote()),
+                Json(GitUiPathsRequest {
+                    cwd: cwd.clone(),
+                    paths: vec!["tracked.txt".to_string()],
+                    confirmed: Some(true),
+                }),
+            )
+            .await;
+            assert_eq!(discard_staged.status(), StatusCode::OK);
+            assert_eq!(repo.git(&["status", "--porcelain"]).trim(), "");
+            assert_eq!(fs::read_to_string(repo.path.join("tracked.txt")).unwrap(), "one\n");
+
+            // A staged new file disappears from disk and index.
+            repo.write("staged-only.txt", "fresh\n");
+            repo.git(&["add", "staged-only.txt"]);
+            let discard_new = git_ui_discard(
+                State(state.clone()),
+                HeaderMap::new(),
+                ConnectInfo(remote()),
+                Json(GitUiPathsRequest {
+                    cwd: cwd.clone(),
+                    paths: vec!["staged-only.txt".to_string()],
+                    confirmed: Some(true),
+                }),
+            )
+            .await;
+            assert_eq!(discard_new.status(), StatusCode::OK);
+            assert!(!repo.path.join("staged-only.txt").exists());
+            assert_eq!(repo.git(&["status", "--porcelain"]).trim(), "");
+
+            // Mixed folder: tracked file restored plus untracked leftovers removed.
+            repo.write("mix/inner.txt", "inner\n");
+            repo.git(&["add", "mix/inner.txt"]);
+            repo.git(&["commit", "-m", "add mix"]);
+            repo.write("mix/inner.txt", "changed\n");
+            repo.write("mix/untracked.txt", "left\n");
+            let discard_folder = git_ui_discard(
+                State(state.clone()),
+                HeaderMap::new(),
+                ConnectInfo(remote()),
+                Json(GitUiPathsRequest {
+                    cwd: cwd.clone(),
+                    paths: vec!["mix".to_string()],
+                    confirmed: Some(true),
+                }),
+            )
+            .await;
+            assert_eq!(discard_folder.status(), StatusCode::OK);
+            assert_eq!(
+                fs::read_to_string(repo.path.join("mix/inner.txt")).unwrap(),
+                "inner\n"
+            );
+            assert!(!repo.path.join("mix/untracked.txt").exists());
 
             let reset_without_confirm = git_ui_reset(
                 State(state),

--- a/src/git_ui/mod.rs
+++ b/src/git_ui/mod.rs
@@ -712,7 +712,17 @@ fn git_ui_discard_blocking(
         let tracked = git_ui_output(&repo, &["ls-files", "--error-unmatch", "--", path])
             .is_ok_and(|output| output.status.success());
         if tracked {
-            if let Err(err) = git_ui_text(&repo, &["restore", "--source=HEAD", "--staged", "--worktree", "--", path]) {
+            if let Err(err) = git_ui_text(
+                &repo,
+                &[
+                    "restore",
+                    "--source=HEAD",
+                    "--staged",
+                    "--worktree",
+                    "--",
+                    path,
+                ],
+            ) {
                 return Err((StatusCode::BAD_GATEWAY, err));
             }
             // Folders can also contain untracked leftovers that restore ignores.
@@ -1807,7 +1817,8 @@ mod tests {
             repo.write("nested/second.txt", "two\n");
             repo.git(&["add", "."]);
             repo.git(&["commit", "-m", "second"]);
-            let root = repo.git(&["rev-list", "--max-parents=0", "HEAD"])
+            let root = repo
+                .git(&["rev-list", "--max-parents=0", "HEAD"])
                 .trim()
                 .to_string();
             let cwd = repo.path.to_str().unwrap().to_string();
@@ -1939,7 +1950,10 @@ mod tests {
             .await;
             assert_eq!(discard_staged.status(), StatusCode::OK);
             assert_eq!(repo.git(&["status", "--porcelain"]).trim(), "");
-            assert_eq!(fs::read_to_string(repo.path.join("tracked.txt")).unwrap(), "one\n");
+            assert_eq!(
+                fs::read_to_string(repo.path.join("tracked.txt")).unwrap(),
+                "one\n"
+            );
 
             // A staged new file disappears from disk and index.
             repo.write("staged-only.txt", "fresh\n");


### PR DESCRIPTION
## Summary

Git explorer improvements focused on folder-level actions, compare modes, and several verified bug fixes.

### Folder actions in the changes tree
- Untracked directories now render as real directory nodes instead of phantom file rows.
- Directory rows get a context menu with **Stage folder / Unstage folder / Discard folder (N files)**, plus Show in file explorer and Show history.
- Discard on a folder restores tracked files and removes untracked leftovers (backend already handles this).
- Folder mutations are scoped to the changes view; compare/stash trees keep their dir menus read-only.

### Compare modes
- Comparing a commit against current changes now uses a dedicated `current-compare` mode: the working tree stays the right side, Edit works there, and blame uses the working ref. Commit-vs-commit compares remain read-only.
- `.` renders as "working tree" in compare labels and diff headers.
- Shift-clicked log pairs are ordered by log position, so the newest commit is always the compare target (right side). A behavioral test caught the initial comparator being inverted; it is fixed and covered in both click orders.

### Backend fixes
- Comparing the root commit against its (nonexistent) parent now diffs against the empty tree via `git mktree` (works on SHA-1 and SHA-256 repos), with `--merge-base` removed for that case.
- Discard now also discards staged changes (not just worktree edits) and removes untracked leftovers in folders.

## Test plan
- `cargo test --bin herdr-webui git_ui`: 45 passing (new root-compare and discard tests).
- `node --test src/assets/*.test.mjs`: 336 passing, including a new `git_ui_behavior.test.mjs` that boots the served git-ui bundle in a vm and drives public methods: compare ordering in both click orders, current-compare request params, folder stage/unstage/discard POST bodies, the changes-view mutation gate, untracked-dir tree rendering, and exiting current-compare.
- Live end-to-end against the real server binary and real git repos (SHA-1 and SHA-256): root-commit compare, merge_base compare, bulk stage/unstage, folder discard (staged + untracked), file/blame with `ref_name=working`.
- `cargo fmt --check`, `cargo check`, `cargo test`: green (full CI sequence verified locally).

🤖 Generated with [Jcode](https://github.com/1jehuang/jcode)

### Acceptance harness (added)
- The live verification now ships in the repo: `scripts/e2e/run-git-e2e.sh` (or `just git-e2e`). It builds the debug binary, creates a throwaway dirty repo (staged edit, unstaged edit, untracked dir), boots an isolated server, and drives the served git-ui bundle in a node vm with fetch proxied to the real backend. No browser needed. 8/8 assertions passed locally, covering the full chain: status load → dir row rendering (no phantom file row) → dir context-menu discard POST with `confirmed: true` → real repo cleaned.
- Rebased onto main (PR #142's `scripts/e2e` pattern). 338 JS tests + 344 Rust tests green on the rebased head.
