### PR TITLE
Redesign file browser context menus

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,7 @@
 - Unsaved edits mark the tab with a dirty dot, Save only appears in the tab menu for dirty editable files, and Cmd/Ctrl+S saves the focused file.
 - The dirty dot syncs live while editing without remounting editors; stale change flags clear after a lock.
 - Tab menu collapses Edit/Cancel into one state-driven Lock/Unlock entry; help modal documents the new behavior.
+- File-tab and tree-row context menus now use self-contained themed panels with grouped actions, icons, viewport clamping, and keyboard navigation.
 
 ### Git UI improvements
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -102,6 +102,13 @@ const ICON_SEARCH: &str = include_str!("assets/icons/search.svg");
 const ICON_REFRESH: &str = include_str!("assets/icons/refresh.svg");
 const ICON_LOCK: &str = include_str!("assets/icons/lock.svg");
 const ICON_LOCK_OPEN: &str = include_str!("assets/icons/lock-open.svg");
+const ICON_COLUMNS: &str = include_str!("assets/icons/columns.svg");
+const ICON_SAVE: &str = include_str!("assets/icons/save.svg");
+const ICON_CLOCK: &str = include_str!("assets/icons/clock.svg");
+const ICON_COPY: &str = include_str!("assets/icons/copy.svg");
+const ICON_X: &str = include_str!("assets/icons/x.svg");
+const ICON_LINK: &str = include_str!("assets/icons/link.svg");
+const ICON_PENCIL: &str = include_str!("assets/icons/pencil.svg");
 
 pub(crate) fn app_html() -> Response {
     Html(APP_HTML).into_response()
@@ -457,6 +464,34 @@ pub(crate) async fn icon_lock_svg() -> Response {
 
 pub(crate) async fn icon_lock_open_svg() -> Response {
     static_svg(ICON_LOCK_OPEN)
+}
+
+pub(crate) async fn icon_columns_svg() -> Response {
+    static_svg(ICON_COLUMNS)
+}
+
+pub(crate) async fn icon_save_svg() -> Response {
+    static_svg(ICON_SAVE)
+}
+
+pub(crate) async fn icon_clock_svg() -> Response {
+    static_svg(ICON_CLOCK)
+}
+
+pub(crate) async fn icon_copy_svg() -> Response {
+    static_svg(ICON_COPY)
+}
+
+pub(crate) async fn icon_x_svg() -> Response {
+    static_svg(ICON_X)
+}
+
+pub(crate) async fn icon_link_svg() -> Response {
+    static_svg(ICON_LINK)
+}
+
+pub(crate) async fn icon_pencil_svg() -> Response {
+    static_svg(ICON_PENCIL)
 }
 
 #[cfg(test)]

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -763,7 +763,7 @@ describe("app bundle load", () => {
 
   it("offers copy permalink actions in file explorer and Git file menus", () => {
     match(fileBrowserSource, /Copy permalink/);
-    match(fileBrowserSource, /data-file-menu-action="copyPermalink"/);
+    match(fileBrowserSource, /menuIcon\("copyPermalink"/);
     match(fileBrowserSource, /\.file-browser-menu \[data-file-menu-action\]/);
     match(fileBrowserSource, /\/api\/git-ui\/permalink\?cwd=/);
     match(fileBrowserSource, /navigator\.clipboard\.writeText\(url\)/);
@@ -1093,9 +1093,10 @@ describe("app bundle load", () => {
     ok(!fileBrowserCss.includes(".file-browser-side.previewing"), "file tree must stay visible while previewing files");
     match(fileBrowserSource, /function renderTabMenu/);
     match(fileBrowserSource, /HerdrFileBrowser\.tabMenu/);
-    match(fileBrowserSource, /data-file-menu-action="copyPathTab"/);
-    match(fileBrowserSource, /data-file-menu-action="focus"/);
-    match(fileBrowserSource, /data-file-menu-action="close"/);
+    match(fileBrowserSource, /data-file-menu-action="\$\{action\}"/);
+    match(fileBrowserSource, /menuIcon\("copyPathTab"/);
+    match(fileBrowserSource, /menuIcon\("focus"/);
+    match(fileBrowserSource, /menuIcon\("close"/);
     match(fileBrowserCss, /\.file-browser-menu-label/);
     match(fileBrowserCss, /\.file-browser-menu-sep/);
     match(fileBrowserCss, /\.cm-foldGutter/);
@@ -3079,10 +3080,10 @@ describe("app bundle load", () => {
     match(gitUiSource, /const GIT_LOG_PAGE_SIZE = 80;/);
     match(gitUiSource, /const GIT_LOG_MAX_LIMIT = 2000;/);
     match(fileBrowserSource, /showHistory\(encodedPath\)/);
-    match(fileBrowserSource, />Show history<\/button>/);
-    match(fileBrowserSource, /menu\.kind === "file" \? `<button type="button" data-file-menu-action="history">Show history<\/button>` : ""/);
+    match(fileBrowserSource, /menuIcon\("history", "Show history"\)/);
+    match(fileBrowserSource, /menu\.kind === "file" \? menuIcon\("history", "Show history"\) : ""/);
     match(fileBrowserSource, /if \(action === "history"\) \{ showHistoryPath\(menu\.path\); return; \}/);
-    match(fileBrowserSource, /data-file-menu-action="history">Show history<\/button>/);
+    match(fileBrowserSource, /role="menuitem"/);
     match(fileBrowserSource, /hide\(\);\n\s+window\.HerdrGitUi\.openFileHistory/);
     match(fileBrowserSource, /openFileHistory\(encodeURIComponent\(state\.cwd\), encodeURIComponent\(path\)\)/);
     match(gitUiSource, /\/api\/git-ui\/path-info\?cwd=\$\{encodeURIComponent\(cwd\)\}&path=\$\{encodeURIComponent\(path\)\}/);

--- a/src/assets/desktop/file_browser.css
+++ b/src/assets/desktop/file_browser.css
@@ -358,6 +358,89 @@
   flex: 0 0 auto;
   font-size: 10px;
 }
+.file-browser-menu {
+  background: var(--panel);
+  border: 1px solid var(--border2);
+  border-radius: 10px;
+  box-shadow: 0 12px 28px #0006, 0 2px 8px #0003;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 210px;
+  max-width: min(320px, calc(100vw - 16px));
+  padding: 5px;
+  position: fixed;
+  z-index: 1000;
+}
+.file-browser-menu-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.file-browser-menu button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  color: var(--fg);
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: 12px;
+  gap: 8px;
+  min-height: 28px;
+  padding: 5px 8px;
+  text-align: left;
+  white-space: nowrap;
+}
+.file-browser-menu button:hover,
+.file-browser-menu button:focus-visible {
+  background: var(--accent-2, color-mix(in srgb, var(--accent), transparent 84%));
+  color: var(--accent-1, var(--accent));
+  outline: 0;
+}
+.file-browser-menu button:focus-visible {
+  box-shadow: 0 0 0 2px var(--herdr-focus-ring, color-mix(in srgb, var(--accent), transparent 45%)) inset;
+}
+.file-browser-menu button.danger {
+  color: #f38ba8;
+}
+.file-browser-menu button.danger:hover,
+.file-browser-menu button.danger:focus-visible {
+  background: color-mix(in srgb, #f38ba8, transparent 84%);
+  color: #f38ba8;
+}
+.file-browser-menu-icon {
+  background: currentColor;
+  display: inline-block;
+  flex: none;
+  height: 14px;
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  width: 14px;
+}
+.file-browser-menu-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.file-browser-menu-hint {
+  color: var(--muted);
+  display: inline-block;
+  font-size: 10px;
+  flex: none;
+  padding-left: 12px;
+}
+.file-browser-menu button:hover .file-browser-menu-hint,
+.file-browser-menu button:focus-visible .file-browser-menu-hint {
+  color: inherit;
+  opacity: 0.75;
+}
 .file-browser-menu .file-browser-menu-sep {
   border: 0;
   border-top: 1px solid var(--border);
@@ -366,13 +449,18 @@
   padding: 0;
 }
 .file-browser-menu .file-browser-menu-label {
-  color: var(--muted);
+  color: var(--fg);
   cursor: default;
-  font-size: 10px;
-  font-weight: 700;
-  padding: 4px 8px 2px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  font-size: 12px;
+  font-weight: 800;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 6px 8px 7px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.file-browser-menu .file-browser-menu-label + .file-browser-menu-sep {
+  margin: 0 2px 4px;
 }
 .file-browser-pane {
   border: 1px solid var(--border);

--- a/src/assets/desktop/file_browser.js
+++ b/src/assets/desktop/file_browser.js
@@ -146,6 +146,24 @@
     render();
   }, true);
   window.addEventListener("keydown", (event) => {
+    if (!state.open || !state.contextMenu || !event || event.defaultPrevented) return;
+    const key = event.key;
+    if (key !== "ArrowDown" && key !== "ArrowUp" && key !== "Home" && key !== "End") return;
+    const items = Array.from(document.querySelectorAll('.file-browser-menu [role="menuitem"]') || []);
+    if (!items.length) return;
+    event.preventDefault();
+    const active = items.find((b) => b === document.activeElement);
+    const delta = key === "ArrowDown" ? 1 : -1;
+    const activeIndex = items.indexOf(active);
+    let index;
+    if (key === "Home") index = 0;
+    else if (key === "End") index = items.length - 1;
+    else if (activeIndex < 0) index = key === "ArrowDown" ? 0 : items.length - 1;
+    else index = (activeIndex + delta + items.length) % items.length;
+    const target = items[index];
+    if (target && typeof target.focus === "function") target.focus();
+  }, true);
+  window.addEventListener("keydown", (event) => {
     if (!state.open || !event || event.defaultPrevented || event.altKey || event.shiftKey) return;
     const key = String(event.key || "").toLowerCase();
     if (key !== "s" || !(event.metaKey || event.ctrlKey)) return;
@@ -695,16 +713,57 @@
 
   }
 
+  function menuIcon(action, label, extra = "") {
+    const icons = {
+      open: "/assets/icons/file.svg",
+      enter: "/assets/icons/folder-up.svg",
+      split: "/assets/icons/columns.svg",
+      focus: "/assets/icons/chevron-right.svg",
+      find: "/assets/icons/search.svg",
+      edit: "/assets/icons/pencil.svg",
+      cancelEdit: "/assets/icons/lock.svg",
+      save: "/assets/icons/save.svg",
+      history: "/assets/icons/clock.svg",
+      reload: "/assets/icons/refresh.svg",
+      copyPath: "/assets/icons/copy.svg",
+      copyPathTab: "/assets/icons/copy.svg",
+      copyPermalink: "/assets/icons/link.svg",
+      rename: "/assets/icons/pencil.svg",
+      delete: "/assets/icons/trash.svg",
+      close: "/assets/icons/x.svg",
+    };
+    const src = icons[action];
+    const icon = src ? ` style="mask-image:url('${src}');-webkit-mask-image:url('${src}')"` : "";
+    const attrs = extra ? ` ${extra.trim()}` : "";
+    return `<button type="button" role="menuitem"${attrs} data-file-menu-action="${action}"><span class="file-browser-menu-icon"${icon} aria-hidden="true"></span><span class="file-browser-menu-text">${esc(label)}</span></button>`;
+  }
+
+  function menuPos(menu) {
+    const x = Math.max(0, Number(menu.x) || 0);
+    const y = Math.max(0, Number(menu.y) || 0);
+    const vw = (typeof window !== "undefined" && window.innerWidth) || 0;
+    const vh = (typeof window !== "undefined" && window.innerHeight) || 0;
+    const width = 240;
+    const height = 320;
+    let left = x;
+    let top = y;
+    if (vw && x + width > vw - 8) left = Math.max(8, vw - width - 8);
+    if (vh && y + height > vh - 8) top = Math.max(8, vh - height - 8);
+    return `left:${left}px;top:${top}px`;
+  }
+
   function renderContextMenu() {
     const menu = state.contextMenu;
     if (!menu) return "";
     if (menu.type === "tab") return renderTabMenu(menu);
+    const name = Tree.basename(menu.path) || menu.path;
+    const title = `<span class="file-browser-menu-label" title="${arg(menu.path)}">${esc(name)}</span><span class="file-browser-menu-sep"></span>`;
     const primary = menu.kind === "dir"
-      ? `<button type="button" data-file-menu-action="enter">Enter folder</button>`
-      : `<button type="button" data-file-menu-action="open">Open</button><button type="button" data-file-menu-action="split">Open in split</button>`;
-    const history = menu.kind === "file" ? `<button type="button" data-file-menu-action="history">Show history</button>` : "";
-    const permalink = menu.kind === "file" ? `<button type="button" data-file-menu-action="copyPermalink">Copy permalink</button>` : "";
-    return `<div class="git-ui-menu file-browser-menu" style="left:${Math.max(0, menu.x)}px;top:${Math.max(0, menu.y)}px" onclick="event.stopPropagation()">${primary}${history}${permalink}<button type="button" data-file-menu-action="rename">Rename</button><button type="button" class="danger" data-file-menu-action="delete">Delete</button><button type="button" data-file-menu-action="copyPath">Copy path</button></div>`;
+      ? menuIcon("enter", "Enter folder")
+      : `${menuIcon("open", "Open")}${menuIcon("split", "Open in split")}`;
+    const history = menu.kind === "file" ? menuIcon("history", "Show history") : "";
+    const permalink = menu.kind === "file" ? menuIcon("copyPermalink", "Copy permalink") : "";
+    return `<div class="file-browser-menu" role="menu" style="${menuPos(menu)}" onclick="event.stopPropagation()">${title}<div class="file-browser-menu-section">${primary}${history}${permalink}</div><span class="file-browser-menu-sep"></span><div class="file-browser-menu-section">${menuIcon("rename", "Rename")}${menuIcon("copyPath", "Copy path")}</div><span class="file-browser-menu-sep"></span><div class="file-browser-menu-section">${menuIcon("delete", "Delete", ' class="danger"')}</div></div>`;
   }
 
   function renderTabMenu(menu) {
@@ -714,18 +773,19 @@
     const isActive = file.path === state.selected;
     const editing = !!file.editing;
     const hasMultiple = state.files.length > 1;
-    const sep = `<span class="file-browser-menu-sep"></span>`;
-    const labelHtml = `<span class="file-browser-menu-label">${esc(Tree.basename(file.path))}</span>`;
-    const focus = !isActive ? `<button type="button" data-file-menu-action="focus">Focus</button>` : "";
-    const split = hasMultiple ? `<button type="button" data-file-menu-action="split">Open in split</button>` : "";
-    const find = canEdit ? `<button type="button" data-file-menu-action="find">Find in file</button>` : "";
-    const lock = canEdit ? `<button type="button" data-file-menu-action="${editing ? "cancelEdit" : "edit"}">${editing ? "Lock (read-only)" : "Unlock to edit"}</button>` : "";
-    const save = canEdit && editing && file.dirty ? `<button type="button" data-file-menu-action="save">Save</button>` : "";
-    const history = `<button type="button" data-file-menu-action="history">Show history</button>`;
-    const reload = `<button type="button" data-file-menu-action="reload">Reload</button>`;
-    const copyPath = `<button type="button" data-file-menu-action="copyPathTab">Copy path</button>`;
-    const close = `<button type="button" class="danger" data-file-menu-action="close">Close file</button>`;
-    return `<div class="git-ui-menu file-browser-menu" style="left:${Math.max(0, menu.x)}px;top:${Math.max(0, menu.y)}px" onclick="event.stopPropagation()">${labelHtml}${focus}${split}${find}${lock}${save}${history}${reload}${copyPath}${sep}${close}</div>`;
+    const label = `<span class="file-browser-menu-label" title="${arg(file.path)}">${esc(Tree.basename(file.path))}</span><span class="file-browser-menu-sep"></span>`;
+    const focus = !isActive ? menuIcon("focus", "Focus") : "";
+    const split = hasMultiple ? menuIcon("split", "Open in split") : "";
+    const find = canEdit ? menuIcon("find", "Find in file", ' title="Cmd/Ctrl-F"') : "";
+    const lock = canEdit ? menuIcon(editing ? "cancelEdit" : "edit", editing ? "Lock (read-only)" : "Unlock to edit") : "";
+    const save = canEdit && editing && file.dirty ? menuIcon("save", "Save", ' title="Cmd/Ctrl-S"') : "";
+    const history = menuIcon("history", "Show history");
+    const reload = menuIcon("reload", "Reload");
+    const copyPath = menuIcon("copyPathTab", "Copy path");
+    const close = menuIcon("close", "Close file", ' class="danger"');
+    const fileSection = `${focus}${split}${find}${lock}${save}`;
+    const viewSection = `${history}${reload}${copyPath}`;
+    return `<div class="file-browser-menu" role="menu" style="${menuPos(menu)}" onclick="event.stopPropagation()">${label}<div class="file-browser-menu-section">${fileSection}</div>${fileSection ? `<span class="file-browser-menu-sep"></span>` : ""}<div class="file-browser-menu-section">${viewSection}</div><span class="file-browser-menu-sep"></span><div class="file-browser-menu-section">${close}</div></div>`;
   }
 
   function syncDirtyDots() {

--- a/src/assets/icons/clock.svg
+++ b/src/assets/icons/clock.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>

--- a/src/assets/icons/columns.svg
+++ b/src/assets/icons/columns.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M12 3v18"/><path d="M3 12h18"/></svg>

--- a/src/assets/icons/copy.svg
+++ b/src/assets/icons/copy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>

--- a/src/assets/icons/link.svg
+++ b/src/assets/icons/link.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>

--- a/src/assets/icons/pencil.svg
+++ b/src/assets/icons/pencil.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>

--- a/src/assets/icons/save.svg
+++ b/src/assets/icons/save.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"/><path d="M17 21v-8H7v8"/><path d="M7 3v5h8"/></svg>

--- a/src/assets/icons/x.svg
+++ b/src/assets/icons/x.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18"/><path d="M6 6l12 12"/></svg>

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,18 +37,20 @@ use assets::{
     desktop_file_browser_css, desktop_file_browser_js, desktop_git_ui_css, desktop_git_ui_js,
     desktop_js, desktop_search_css, desktop_search_js, desktop_shortcuts_css,
     favicon_attention_svg, favicon_error_svg, favicon_svg, icon_chevron_down_svg,
-    icon_chevron_right_svg, icon_file_svg, icon_folder_svg, icon_folder_up_svg, icon_git_svg,
-    icon_help_svg, icon_lock_open_svg, icon_lock_svg, icon_refresh_svg, icon_search_svg,
-    icon_settings_svg, icon_terminal_svg, icon_theme_auto_svg, icon_trash_svg,
-    jetbrains_mono_nerd_font, login_css, login_html, login_js, mobile_attention_js, mobile_core_js,
-    mobile_css, mobile_file_browser_js, mobile_js, mobile_settings_js, mobile_terminal_js,
-    mobile_worktrees_js, shared_actions_js, shared_colors_css, shared_content_search_css,
-    shared_core_js, shared_editor_js, shared_file_content_search_js, shared_file_icons_css,
-    shared_file_icons_js, shared_file_tree_css, shared_file_tree_js, shared_line_context_js,
-    shared_markdown_preview_css, shared_markdown_preview_js, shared_temp_terminal_js,
-    shared_terminal_adapter_js, shared_terminal_fit_js, shared_terminal_scroll_js,
-    shared_workspace_search_js, vendor_codemirror_js, vendor_dompurify_js, vendor_ghostty_wasm,
-    vendor_marked_js, vendor_mermaid_js, vendor_wterm_css, vendor_wterm_js,
+    icon_chevron_right_svg, icon_clock_svg, icon_columns_svg, icon_copy_svg, icon_file_svg,
+    icon_folder_svg, icon_folder_up_svg, icon_git_svg, icon_help_svg, icon_link_svg,
+    icon_lock_open_svg, icon_lock_svg, icon_pencil_svg, icon_refresh_svg, icon_save_svg,
+    icon_search_svg, icon_settings_svg, icon_terminal_svg, icon_theme_auto_svg, icon_trash_svg,
+    icon_x_svg, jetbrains_mono_nerd_font, login_css, login_html, login_js, mobile_attention_js,
+    mobile_core_js, mobile_css, mobile_file_browser_js, mobile_js, mobile_settings_js,
+    mobile_terminal_js, mobile_worktrees_js, shared_actions_js, shared_colors_css,
+    shared_content_search_css, shared_core_js, shared_editor_js, shared_file_content_search_js,
+    shared_file_icons_css, shared_file_icons_js, shared_file_tree_css, shared_file_tree_js,
+    shared_line_context_js, shared_markdown_preview_css, shared_markdown_preview_js,
+    shared_temp_terminal_js, shared_terminal_adapter_js, shared_terminal_fit_js,
+    shared_terminal_scroll_js, shared_workspace_search_js, vendor_codemirror_js,
+    vendor_dompurify_js, vendor_ghostty_wasm, vendor_marked_js, vendor_mermaid_js,
+    vendor_wterm_css, vendor_wterm_js,
 };
 #[cfg(test)]
 use compat::SimpleVersion;
@@ -1388,6 +1390,13 @@ fn app_router(state: WebState) -> Router {
         .route("/assets/icons/lock-open.svg", get(icon_lock_open_svg))
         .route("/assets/icons/search.svg", get(icon_search_svg))
         .route("/assets/icons/refresh.svg", get(icon_refresh_svg))
+        .route("/assets/icons/columns.svg", get(icon_columns_svg))
+        .route("/assets/icons/save.svg", get(icon_save_svg))
+        .route("/assets/icons/clock.svg", get(icon_clock_svg))
+        .route("/assets/icons/copy.svg", get(icon_copy_svg))
+        .route("/assets/icons/x.svg", get(icon_x_svg))
+        .route("/assets/icons/link.svg", get(icon_link_svg))
+        .route("/assets/icons/pencil.svg", get(icon_pencil_svg))
         .route("/favicon.svg", get(favicon_svg))
         .route("/favicon-attention.svg", get(favicon_attention_svg))
         .route("/favicon-error.svg", get(favicon_error_svg))


### PR DESCRIPTION
## Summary
- Replace the unstyled file-explorer context menu with a self-contained themed menu.
- Add grouped actions, icons, viewport clamping, ARIA roles, and keyboard navigation.
- Apply the same menu treatment to tree-row context menus.
- Add release notes and update source-pattern tests.

## Validation
- 226 JavaScript asset/load tests passed.
- `cargo check` passed.
- `cargo fmt -- --check` and `git diff --check` passed.
- Real-browser CDP verification passed for tab and tree-row menus.