### PR TITLE
test: harden LSP acceptance suite with dialog handling and reopen edge case

### DIFF
--- a/scripts/e2e/cdp-driver.mjs
+++ b/scripts/e2e/cdp-driver.mjs
@@ -32,6 +32,15 @@ export async function connectToPage() {
       pending.get(msg.id)(msg);
       pending.delete(msg.id);
     }
+    // The app's desktop UI uses native confirm()/prompt() for destructive
+    // actions (dirty tab close, discard, delete). In headless Chrome those
+    // dialogs block the page main thread until answered, which would hang
+    // every later eval. Auto-accept them: acceptance flows treat "yes" as
+    // the expected user choice, and the dialog text is visible in the trace.
+    if (msg.method === 'Page.javascriptDialogOpening') {
+      const mid = ++id;
+      ws.send(JSON.stringify({ id: mid, method: 'Page.handleJavaScriptDialog', params: { accept: true } }));
+    }
   };
   const send = (method, params = {}) =>
     new Promise((res, rej) => {
@@ -41,6 +50,11 @@ export async function connectToPage() {
       );
       ws.send(JSON.stringify({ id: mid, method, params }));
     });
+  // Required to receive Page.javascriptDialogOpening events. Best effort:
+  // every page target supports the Page domain.
+  try {
+    await send('Page.enable');
+  } catch (_) {}
   const evalExpr = async (expression, awaitPromise = false) => {
     const r = await send('Runtime.evaluate', { expression, returnByValue: true, awaitPromise });
     if (r.exceptionDetails)

--- a/scripts/e2e/lsp-acceptance.mjs
+++ b/scripts/e2e/lsp-acceptance.mjs
@@ -262,7 +262,59 @@ try {
   })()`);
   record(goodBadge === '', 'valid json file shows no diagnostics badge', JSON.stringify(goodBadge));
 
-  // 12. Close the file: didClose must reach the server (no crash, state sane).
+  // 12. Version-reset edge case: close the broken.json tab (didClose),
+  //     reopen it from disk (fresh didOpen resets the version to 1), and
+  //     require the FIRST edit to clear diagnostics again. Guards the fix
+  //     where a stale didChange version made servers ignore edits.
+  await evalExpr(`(async () => {
+    // Close every open tab so the next tree click reopens from disk.
+    for (let i = 0; i < 5; i++) {
+      const closeBtn = document.querySelector('.file-browser-open-tab-close');
+      if (!closeBtn) break;
+      // A dirty tab may prompt; accept the discard when asked.
+      closeBtn.click();
+      for (let j = 0; j < 10; j++) {
+        const q = document.getElementById('questionModal');
+        if (q && getComputedStyle(q).display === 'grid') {
+          const confirmBtn = document.getElementById('questionConfirm');
+          if (confirmBtn) confirmBtn.click();
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 150));
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    return true;
+  })()`, true);
+  const reopenedBadge = await evalExpr(`(async () => {
+    const broken = [...document.querySelectorAll('.herdr-tree-row')].find((r) => (r.textContent || '').trim().startsWith('broken.json'));
+    if (!broken) return 'no-broken-row';
+    broken.click();
+    await new Promise((r) => setTimeout(r, 3500));
+    const badge = document.querySelector('.file-browser-lsp-badge');
+    return badge ? badge.textContent : 'absent';
+  })()`, true);
+  record(/error/.test(String(reopenedBadge)), 'diagnostics reappear after close and reopen', String(reopenedBadge));
+  if (/error/.test(String(reopenedBadge))) {
+    await evalExpr(`(() => {
+      const mount = document.querySelector('[id^="fileBrowserEditor-"]');
+      const api = mount && mount._herdrEditorApi;
+      if (api && typeof api.setValue === 'function') {
+        api.setValue('{\\n  "name": "lsp-ui-accept",\\n  "version": "1.0.0"\\n}\\n');
+        return true;
+      }
+      return false;
+    })()`, true);
+    const recleared = await waitFor('diagnostics recleared after reopen', `(() => {
+      const badge = document.querySelector('.file-browser-lsp-badge');
+      return !badge || badge.textContent === '' ? 'cleared' : '';
+    })()`, 80, 250);
+    record(recleared === 'cleared', 'first edit after reopen clears diagnostics (version reset)', String(recleared));
+  } else {
+    record(false, 'first edit after reopen clears diagnostics (version reset)', 'skipped: no badge after reopen');
+  }
+
+  // 13. Close the file: didClose must reach the server (no crash, state sane).
   await evalExpr(`window.HerdrFileBrowser.close()`);
   await sleep(500);
   record(true, 'file browser closes cleanly');

--- a/scripts/e2e/run-lsp-e2e.sh
+++ b/scripts/e2e/run-lsp-e2e.sh
@@ -15,6 +15,7 @@
 #   E2E_PORT     server port (default 8899)
 #   CDP_PORT     Chrome remote debugging port (default 9222)
 #   CHROME_BIN   path to Chrome/Chromium if not auto-detected
+#   HERDR_BIN    server binary to test; defaults to building $ROOT (release)
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -66,8 +67,14 @@ trap cleanup EXIT
 ORPHAN_EXIT=0
 echo "==> workdir: $WORK"
 
-echo "==> building herdr-webui (release)"
-(cd "$ROOT" && cargo build --release --target-dir target --quiet)
+if [[ -n "${HERDR_BIN:-}" ]]; then
+  echo "==> using provided binary: $HERDR_BIN"
+  [[ -x "$HERDR_BIN" ]] || { echo "error: HERDR_BIN not executable: $HERDR_BIN" >&2; exit 2; }
+else
+  echo "==> building herdr-webui (release)"
+  (cd "$ROOT" && cargo build --release --target-dir target --quiet)
+  HERDR_BIN="$ROOT/target/release/herdr-webui"
+fi
 
 echo "==> creating fixture repo with src/broken.json and src/good.json"
 REPO="$WORK/lsp-accept-repo"
@@ -90,7 +97,7 @@ wait_for() {
 }
 
 echo "==> starting isolated server on https://127.0.0.1:$PORT"
-XDG_CONFIG_HOME="$WORK/xdg" "$ROOT/target/release/herdr-webui" \
+XDG_CONFIG_HOME="$WORK/xdg" "$HERDR_BIN" \
   --bind "127.0.0.1:$PORT" --session "$(session_id)" &
 SERVER_PID=$!
 


### PR DESCRIPTION
## Summary

Deeper post-release validation of the v0.4.1 LSP fixes surfaced two suite-level gaps. This PR hardens the acceptance suite and proves the fixes against the actual downloadable release artifact.

### Found while validating deeper

Closing a dirty tab uses the app native `confirm()` (correct for interactive users). In headless Chrome an unanswered native dialog blocks the page main thread forever, which wedged the entire suite when the new close-reopen check first ran. The CDP driver now auto-accepts native dialogs (`Page.javascriptDialogOpening` + `handleJavaScriptDialog`).

### Changes

- **CDP driver**: auto-accept native `confirm()`/`prompt()` dialogs so destructive flows (dirty tab close, discard, delete) can be driven in headless Chrome.
- **New checks (15 to 17)**: close the broken.json tab (dirty, discard confirmed), reopen it from disk, require diagnostics to reappear (fresh `didOpen`), then require the **first** edit to clear them again. This guards the per-document version reset from the v0.4.1 fix: `didOpen` resets the version to 1, so the next `didChange` must be 2, never a stale repeat.
- **HERDR_BIN override**: `run-lsp-e2e.sh` can now run the same acceptance suite against any prebuilt binary, for example a downloaded release tarball. Default behavior unchanged.

### Validation

- Downloaded the actual v0.4.1 release artifact, verified its sha256, and ran the suite against it: **17/17 PASS**, no orphan language servers, no leaked workdirs.
- Editor UX acceptance: **18/18 PASS** with the shared driver change.
- Mutation test: reverting the version fix makes the synthetic regression test fail with `first didChange version must be strictly greater than the didOpen version`; restoring the fix makes it pass (file verified byte-identical to the merged state afterward).

No app code changes; test tooling only.