### PR TITLE
test+fix: cold-start suite robustness and language server crash recovery

### DIFF
--- a/scripts/e2e/lsp-acceptance.mjs
+++ b/scripts/e2e/lsp-acceptance.mjs
@@ -181,7 +181,7 @@ try {
     if (btn) btn.click();
     return true;
   })()`);
-  const treeReady = await waitFor('file tree rendered', `!!document.querySelector('.herdr-file-tree .herdr-tree-row')`, 100, 250);
+  const treeReady = await waitFor('file tree rendered', `!!document.querySelector('.herdr-file-tree .herdr-tree-row')`, 100, 250); // 25s; cold start after cargo build
   record(!!treeReady, 'file tree renders after switching to files mode');
 
   const fileClicked = await evalExpr(`(async () => {
@@ -204,11 +204,13 @@ try {
   })()`, true);
   record(fileClicked === 'clicked', 'broken.json opened by clicking the real tree row', String(fileClicked));
 
-  // 7. Wait for the editor to mount.
+  // 7. Wait for the editor to mount. Generous window: the first run after
+  // cargo build competes with the compiler for CPU and the language server
+  // for disk, which can push mount past the old 10s and flake the suite.
   const editorUp = await waitFor('editor mounted', `(() => {
     const mount = document.querySelector('[id^="fileBrowserEditor-"]');
     return !!(mount && mount._herdrEditorApi);
-  })()`);
+  })()`, 120, 250);
   record(!!editorUp, 'broken.json opens in the real editor');
 
   // 8. Wait for diagnostics to arrive and the badge + list to render.

--- a/src/assets/shared/lsp.js
+++ b/src/assets/shared/lsp.js
@@ -116,6 +116,16 @@
     return !!(ws.capabilities && ws.language === language);
   }
 
+  // The backend answers 404 (not running) or 410 (exited) once a server is
+  // gone. Clear the cached server state so the next didOpen respawns it;
+  // otherwise ensureServer trusts stale capabilities forever and a crashed
+  // server never comes back until the page is reloaded.
+  function invalidateServer(ws, err) {
+    if (!err || (err.status !== 404 && err.status !== 410)) return;
+    ws.capabilities = null;
+    ws.language = "";
+  }
+
   // Start the language server for a workspace and initialize it.
   async function ensureServer(ws, language) {
     if (!language || serverRunning(ws, language)) return ws.capabilities;
@@ -180,19 +190,35 @@
     const uri = fileUri(ws, path);
     ws.documents.set(uri, path);
     ws.docVersions.set(uri, 1); // didOpen starts every document at version 1
-    await post("/api/lsp/notify", {
-      language: languageId,
-      cwd: ws.cwd,
-      method: "textDocument/didOpen",
-      params: {
-        textDocument: {
-          uri,
-          languageId: language,
-          version: 1,
-          text: String(content == null ? "" : content),
+    const notify = () =>
+      post("/api/lsp/notify", {
+        language: languageId,
+        cwd: ws.cwd,
+        method: "textDocument/didOpen",
+        params: {
+          textDocument: {
+            uri,
+            languageId: language,
+            version: 1,
+            text: String(content == null ? "" : content),
+          },
         },
-      },
-    }).catch(() => {});
+      });
+    try {
+      await notify();
+    } catch (err) {
+      // A crashed server answers 404/410 here (stale capabilities passed the
+      // ensureServer check). Drop the cache, respawn, and retry once so the
+      // user sees diagnostics again on the very same open, not the next one.
+      invalidateServer(ws, err);
+      if (err && (err.status === 404 || err.status === 410)) {
+        try {
+          await ensureServer(ws, language);
+          ws.docVersions.set(uri, 1);
+          await notify();
+        } catch (_) {}
+      }
+    }
     startDiagnosticsPolling();
   }
 
@@ -219,7 +245,7 @@
             textDocument: { uri, version },
             contentChanges: [{ text: String(content == null ? "" : content) }],
           },
-        }).catch(() => {});
+        }).catch((err) => invalidateServer(ws, err));
       }, DID_CHANGE_DEBOUNCE_MS),
     );
   }
@@ -239,7 +265,7 @@
       cwd: ws.cwd,
       method: "textDocument/didClose",
       params: { textDocument: { uri } },
-    }).catch(() => {});
+    }).catch((err) => invalidateServer(ws, err));
   }
 
   async function request(ws, path, method, params) {
@@ -253,7 +279,8 @@
         method,
       }, params ? { params } : {}));
       return body && body.result !== undefined ? body.result : null;
-    } catch (_) {
+    } catch (err) {
+      invalidateServer(ws, err);
       return null;
     }
   }


### PR DESCRIPTION
## Summary

Two hardening changes from deeper validation, both found by driving the real UI:

### 1. Cold-start flake fix (test tooling)

The LSP acceptance suite flaked once in five runs: `timeout waiting for: editor mounted`, empty LSP trace (no `didOpen` ever fired), on the first run immediately after `cargo build --release`. Three warm runs never reproduce. The editor-mount wait was 10s; post-build load can exceed it. Widened to 30s with a comment.

### 2. Crash recovery fix (product fix, `src/assets/shared/lsp.js`)

A SIGKILL failure-mode probe (real browser, real language server) found a genuine defect: killing the server mid-session left the frontend stuck forever. The backend correctly detected the death and dropped the entry, but the frontend kept cached capabilities, so `ensureServer` short-circuited and every later `didOpen` skipped `/api/lsp/start`. Diagnostics never came back until a full page reload.

Fix: the backend answers 404/410 once a server is gone; those now invalidate the cached state, and a failed `didOpen` notify respawns the server and retries once, so diagnostics return on the same open.

### Verification

- Cold-start: `cargo clean --release` + rebuild + immediate suite run (the exact failing condition) passes **17/17 exit 0**; three warm runs 17/17 each.
- Crash probe (SIGKILL out-of-band, like an OOM kill): **10/10** — page main thread responsive, backend drops the dead entry, fresh server spawns on reopen, diagnostics reappear.
- Malformed config probe: **6/6** — malformed JSON 400, structurally wrong 422, page responsive, sane config re-applies.
- Happy-path acceptance suite unchanged: **17/17**. Frontend tests **360/360**.