### PR TITLE
docs: document v0.4.2 in release notes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,19 @@
 # Release notes
 
+## 0.4.2 Release Notes
+
+### Language server crash recovery
+
+- Found by a SIGKILL failure-mode probe against the real UI: killing the json language server mid-session left the frontend stuck forever. The backend detected the death and dropped the entry, but the frontend kept its cached capabilities, so `ensureServer` short-circuited and every later `didOpen` skipped `/api/lsp/start`; diagnostics never came back until a full page reload.
+- The backend answers 404 (not running) or 410 (exited) once a server is gone. Those responses now invalidate the cached server state, and a failed `didOpen` notification respawns the server and retries once, so diagnostics return on the same open.
+- Verified end to end in the real browser: page main thread stays responsive after the crash, the backend drops the dead entry, a fresh server spawns on reopen, and diagnostics reappear (10/10 probe checks).
+
+### Acceptance suite hardening
+
+- The CDP driver auto-accepts native `confirm()`/`prompt()` dialogs; an unanswered dialog in headless Chrome blocks the page main thread forever, which wedged the suite on dirty-tab close flows. The suite grew to 17 checks including a close-tab/reopen/version-reset check, and `HERDR_BIN` lets it run against any prebuilt binary (verified against the downloaded v0.4.1 tarball).
+- Widened the editor-mount wait to 30s: the first suite run after `cargo build --release` competes with the compiler and the language server for CPU/disk and can exceed the old 10s window (reproduced once in five runs, verified fixed with a clean rebuild + immediate run).
+- Failure-mode probes added to the validation record: missing language server binary (clean 502 with an install hint, editor still usable, 9/9), malformed settings config (400/422 rejection, page responsive, 6/6), and double-open/external-delete edge cases (single tab, sane state, 9/9).
+
 ## 0.4.1 Release Notes
 
 ### LSP diagnostics fixes found by real-UI acceptance testing


### PR DESCRIPTION
## Summary

Documents v0.4.2 in `docs/release-notes.md`, following the same format as the v0.4.0/v0.4.1 entries (PR #149).

### v0.4.2 contents

- **Language server crash recovery** (product fix from #151): a SIGKILL probe against the real UI found that a killed language server left the frontend stuck forever (cached capabilities made `ensureServer` skip the respawn on every later open). The backend's 404/410 responses now invalidate the cached state and a failed `didOpen` respawns and retries once, so diagnostics return on the same open. Verified 10/10 in the real browser.
- **Acceptance suite hardening** (from #150 and #151): native dialog auto-accept in the CDP driver, close/reopen/version-reset check (17 checks), `HERDR_BIN` override verified against the downloaded v0.4.1 tarball, cold-start mount wait widened to 30s, and the failure-mode validation record (missing binary 9/9, malformed config 6/6, double-open/external-delete 9/9).

Docs only. The tag `v0.4.2` will be pushed after this merges.