### PR TITLE
fix: make editor caret visible and UX friendly in dark theme

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## 0.4.5 Release Notes
+
+### Editor caret visibility in dark theme
+
+- Fixed the code/file editor caret (cursor) being practically invisible in dark theme. CodeMirror injects its theme with a generated class prefix (`.ͼN .cm-cursor`, specificity 0,2,0) and defaults the caret to 1.2px solid black; our previous override (`.cm-cursor`, specificity 0,1,0) lost the CSS cascade, so the caret stayed black on the `#1e1e2e` editor background (contrast 1.3:1).
+- Caret rules are now scoped with `.cm-editor` in both desktop and mobile CSS so they win the cascade, and the caret is 2px wide with `margin-left: -1px` so it stays centered on the character cell.
+- New theme variables drive caret colors: `--editor-caret` (bright, used while the editor is focused and for the content `caret-color`) and `--editor-caret-dim` (dimmed but still contrasted while unfocused). Dark uses `#f2f5ff` / `#a6adc8` (15.06:1 / 7.37:1 against the editor background), light uses `#1e2a50` / `#6c6f85` (10.56:1 / 3.73:1).
+- Verified end to end in headless Chrome over CDP: caret visible through the blink cycle, 2px, theme-colored, focused and dim variants, both themes; 360 frontend tests and 325 Rust tests pass.
+
 ## 0.4.4 Release Notes
 
 ### Settings modal fixes

--- a/src/assets/desktop/app_css/base.css
+++ b/src/assets/desktop/app_css/base.css
@@ -28,6 +28,8 @@ body {
   --border2: #45475a;
   --muted: #a6adc8;
   --accent: #89b4fa;
+  --editor-caret: #f2f5ff;
+  --editor-caret-dim: #a6adc8;
   --git-modified-color: #e9d07a;
   --git-added-color: #a6e3a1;
   --git-deleted-color: #f38ba8;
@@ -67,6 +69,8 @@ body.light {
   --border2: #9ca0b0;
   --muted: #6c6f85;
   --accent: #1e66f5;
+  --editor-caret: #1e2a50;
+  --editor-caret-dim: #6c6f85;
   --git-modified-color: #8a6d00;
   --git-added-color: #2a8c2f;
   --git-deleted-color: #cc2b3e;

--- a/src/assets/desktop/file_browser.css
+++ b/src/assets/desktop/file_browser.css
@@ -727,15 +727,27 @@
   line-height: 1.5;
 }
 .cm-content {
-  caret-color: var(--accent);
+  caret-color: var(--editor-caret);
   padding: 8px 0;
 }
 .cm-line {
   padding: 0 8px;
 }
-.cm-cursor {
-  border-left-color: var(--accent);
-  border-left-width: 2px;
+/* CodeMirror's injected theme styles the caret with a generated class prefix
+   (".ͼN .cm-cursor", specificity 0,2,0) and defaults it to black, which is
+   invisible on the dark editor background. Scope our rules with .cm-editor so
+   they win the cascade and stay theme-aware: bright while focused, dimmed but
+   still contrasted while unfocused. */
+.cm-editor .cm-cursor,
+.cm-editor .cm-dropCursor {
+  border-left: 2px solid var(--editor-caret);
+  margin-left: -1px;
+}
+.cm-editor.cm-focused .cm-cursor {
+  border-left-color: var(--editor-caret);
+}
+.cm-editor:not(.cm-focused) .cm-cursor {
+  border-left-color: var(--editor-caret-dim);
 }
 .cm-selectionBackground {
   background: color-mix(in srgb, var(--accent), transparent 72%) !important;

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -27,6 +27,8 @@ body {
   --border2: #45475a;
   --muted: #a6adc8;
   --accent: #89b4fa;
+  --editor-caret: #f2f5ff;
+  --editor-caret-dim: #a6adc8;
   --git-modified-color: #e9d07a;
   --git-added-color: #a6e3a1;
   --git-deleted-color: #f38ba8;
@@ -71,6 +73,8 @@ body.light {
   --border2: #9ca0b0;
   --muted: #6c6f85;
   --accent: #1e66f5;
+  --editor-caret: #1e2a50;
+  --editor-caret-dim: #6c6f85;
   --git-modified-color: #8a6d00;
   --git-added-color: #2a8c2f;
   --git-deleted-color: #cc2b3e;
@@ -869,15 +873,27 @@ body.mobile-keyboard-open .mobile-screen.terminal-active .mobile-tabs {
   line-height: 1.5;
 }
 .cm-content {
-  caret-color: var(--accent);
+  caret-color: var(--editor-caret);
   padding: 8px 0;
 }
 .cm-line {
   padding: 0 8px;
 }
-.cm-cursor {
-  border-left-color: var(--accent);
-  border-left-width: 2px;
+/* CodeMirror's injected theme styles the caret with a generated class prefix
+   (".ͼN .cm-cursor", specificity 0,2,0) and defaults it to black, which is
+   invisible on the dark editor background. Scope our rules with .cm-editor so
+   they win the cascade and stay theme-aware: bright while focused, dimmed but
+   still contrasted while unfocused. */
+.cm-editor .cm-cursor,
+.cm-editor .cm-dropCursor {
+  border-left: 2px solid var(--editor-caret);
+  margin-left: -1px;
+}
+.cm-editor.cm-focused .cm-cursor {
+  border-left-color: var(--editor-caret);
+}
+.cm-editor:not(.cm-focused) .cm-cursor {
+  border-left-color: var(--editor-caret-dim);
 }
 .cm-selectionBackground {
   background: color-mix(in srgb, var(--accent), transparent 72%) !important;

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -379,7 +379,9 @@ describe("mobile bundle load", () => {
     match(mobileCss, /\.cm-activeLineGutter/);
     match(mobileCss, /\.cm-matchingBracket/);
     match(mobileCss, /\.cm-nonmatchingBracket/);
-    match(mobileCss, /\.cm-cursor \{[\s\S]*?border-left-color: var\(--accent\)/);
+    match(mobileCss, /\.cm-editor \.cm-cursor,[\s\S]*?border-left: 2px solid var\(--editor-caret\)/);
+    match(mobileCss, /--editor-caret:/);
+    match(mobileCss, /--editor-caret-dim:/);
     match(mobileCss, /\.cm-selectionBackground/);
     match(mobileCss, /--accent-1:/);
     match(mobileCss, /--accent-2:/);


### PR DESCRIPTION
## Summary

- The code/file editor caret was practically invisible in the dark theme. CodeMirror injects its theme with a generated class prefix (`.ͼN .cm-cursor`, specificity 0,2,0) and defaults the caret to 1.2px solid black. Our previous override (`.cm-cursor`, specificity 0,1,0) lost the CSS cascade, so the caret stayed black on the `#1e1e2e` editor background (contrast 1.3:1).
- Caret rules are now scoped with `.cm-editor` in both desktop and mobile CSS so they win the cascade. The caret is 2px wide with `margin-left: -1px` so it stays centered on the character cell.
- New theme variables drive caret colors: `--editor-caret` (bright, focused) and `--editor-caret-dim` (dimmed but still contrasted while unfocused), also used for the content `caret-color`. Dark: `#f2f5ff` / `#a6adc8` (15.06:1 / 7.37:1). Light: `#1e2a50` / `#6c6f85` (10.56:1 / 3.73:1).
- Documents the fix in release notes under 0.4.5, and updates the mobile CSS parity test to the new theme-aware rules.

## Verification

- End to end in headless Chrome over CDP: caret visible through the blink cycle, 2px wide, theme-colored, focused and dim variants, in both dark and light themes. Cascade source confirmed by toggling CodeMirror's injected stylesheet.
- Frontend suite: 360/360 pass. Rust suite: 325/325 pass.

## Notes

Fixes the user-reported "pointer not shown in the code/file editor" with dark theme, with UX-friendly coloring (WCAG contrast) in both themes.