### PR TITLE
GitHub flow: rebase fresh base, Update pull, and Git header rework

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -83,6 +83,18 @@
 - Mobile: the Git screen now covers the core desktop flow — stage, unstage,
   discard (with confirmation), branch list and checkout. Heavy actions
   (rebase, stash, conflicts) remain desktop-only and are labeled as such.
+- GitHub-style Git flow: the desktop Git header now puts branch info and
+  actions in one place. A right-justified branch chip shows the current
+  branch with live sync state (↓N/↑N counts when diverged from upstream,
+  ✓ when in sync); clicking the branch name opens a filterable branch list
+  (local then remote) where every entry shows the tip author and relative
+  time, with the exact time and commit subject on hover. The action row
+  keeps Commit, ↓ Update (fetch + fast-forward, never merge), Rebase and
+  Reset, and the Pull button became a split button whose dropdown offers
+  Fetch, Fetch from…, Pull, Pull (Rebase), Push, Push to… and Force Push.
+  Rebase with fetch now also refreshes the default base branch, and a new
+  /api/git-ui/fetch endpoint backs the standalone fetch actions. Branch
+  payloads from the backend now include tip author/date/subject.
 
 ### Mobile file editing (IDE review)
 

--- a/scripts/e2e/git-acceptance.mjs
+++ b/scripts/e2e/git-acceptance.mjs
@@ -13,6 +13,7 @@ import { request as httpsRequest } from "node:https";
 
 const ORIGIN = process.env.E2E_ORIGIN;
 const REPO = process.env.E2E_REPO;
+const CLEAN = process.env.E2E_CLEAN_REPO;
 
 if (!ORIGIN || !REPO) {
   console.error("E2E_ORIGIN and E2E_REPO must be set (use scripts/e2e/run-git-e2e.sh)");
@@ -112,11 +113,21 @@ function context() {
       documentElement: element(),
       hidden: false,
       visibilityState: "visible",
+      __panelHtml: "",
       createElement: () => element(),
       execCommand: () => true,
       querySelector: () => element(),
       querySelectorAll: () => [],
-      getElementById: () => element(),
+      getElementById(id) {
+        const el = element();
+        if (id === "gitUiPanel") {
+          Object.defineProperty(el, "innerHTML", {
+            get() { return ctx.document.__panelHtml; },
+            set(value) { ctx.document.__panelHtml = String(value); },
+          });
+        }
+        return el;
+      },
       addEventListener() {},
     },
     localStorage: {
@@ -187,7 +198,87 @@ assert(/herdr-tree-row dir/.test(html), "changes tree renders a dir row for scra
 assert(!/title="scratchdir\/"/.test(html), "no phantom file row for scratchdir/");
 assert(/fileMenu\(event,'scratchdir'[^)]*,'dir'\)/.test(html), "dir row wires the dir context menu kind");
 
+// 6. Header rework: the branch chip renders with the current branch and a
+// caret for the pull/fetch dropdown.
+const chipRes = await httpsJson(`${ORIGIN}/api/git-ui/status?cwd=${encodeURIComponent(REPO)}`);
+const chipStatus = await chipRes.json();
+const panelHtml = () => ctx.document.__panelHtml || "";
+let headerHtml = panelHtml();
+assert(/git-ui-branch-chip/.test(headerHtml), "branch chip rendered in header");
+assert(new RegExp(`git-ui-branch-chip-name">${chipStatus.branch}</span>`).test(headerHtml), `chip shows the real branch name (${chipStatus.branch})`);
+
+// 7. The dropdown menu exposes every git-flow action.
+ui.toggleHeaderMenu({ stopPropagation() {}, currentTarget: { getBoundingClientRect: () => ({ left: 12, bottom: 40 }) }, clientX: 12, clientY: 40 });
+headerHtml = panelHtml();
+for (const method of ["fetchOrigin", "openFetchFromModal", "openPullModal", "pullWithRebase", "openPushModal", "openPushToModal", "openForcePushModal"]) {
+  assert(new RegExp(`HerdrGitUi\\.${method}\\(\\)`).test(headerHtml), `header menu wires ${method}`);
+}
+ui.toggleHeaderMenu({ stopPropagation() {}, currentTarget: { getBoundingClientRect: () => ({ left: 12, bottom: 40 }) }, clientX: 12, clientY: 40 });
+
+// 8. Fetch from the menu reaches the real backend (fetch origin).
+await ui.fetchOrigin();
+await new Promise((resolve) => setTimeout(resolve, 400));
+const fetchCall = calls.filter((c) => c.path === "/api/git-ui/fetch").pop();
+assert(fetchCall, "fetch POST reached the real backend");
+assert(JSON.parse(fetchCall.init.body).cwd === REPO, "fetch posted the repo cwd");
+
+// 9. The branches endpoint returns author/date/subject for each branch.
+const branchesRes = await httpsJson(`${ORIGIN}/api/git-ui/branches?cwd=${encodeURIComponent(REPO)}`);
+const branches = await branchesRes.json();
+assert(branches.local.length >= 1, "branches endpoint lists local branches");
+const main = branches.local.find((b) => b.name === "main");
+assert(main && main.author === "e2e" && main.subject === "init", "branch payload carries author/subject from real git");
+assert(main && /\d{4}-\d{2}-\d{2}T/.test(String(main.date)), "branch payload carries an ISO date");
+
+// 10. The branch list popover renders local and remote sections from the
+// real payload, with author · relative time and hover details.
+await ui.openBranchList({ stopPropagation() {}, currentTarget: null, clientX: 0, clientY: 0 });
+await new Promise((resolve) => setTimeout(resolve, 400));
+const listHtml = panelHtml();
+assert(/git-ui-branch-list/.test(listHtml), "branch list popover opened");
+assert(/Local branches/.test(listHtml), "branch list shows the local section");
+assert(/e2e · /.test(listHtml), "branch rows show author · relative time");
+assert(/title="[^"]*init[^"]*"/.test(listHtml), "branch row hover title carries the commit subject");
+const switchCall = calls.filter((c) => c.path === "/api/git-ui/switch").pop();
+assert(!switchCall, "no switch fired yet");
+
+// 11. Filtering narrows rows. Switching runs on the clean clone (git refuses
+// checkout over the dirty fixture tree).
+ui.branchListFilter("no-such-branch");
+const filteredHtml = panelHtml();
+assert(!/git-ui-branch-row"/.test(filteredHtml), "filter hides all rows on no match");
+ui.branchListFilter("ma");
+ui.closeBranchList();
+await ui.open({ cwd: CLEAN, title: "clean-repo" }, { forceOpen: true });
+await new Promise((resolve) => setTimeout(resolve, 300));
+await ui.openBranchList({ stopPropagation() {}, currentTarget: null, clientX: 0, clientY: 0 });
+await new Promise((resolve) => setTimeout(resolve, 400));
+const cleanListHtml = panelHtml();
+
+assert(/feature-lane/.test(cleanListHtml), "clean repo branch list shows feature-lane");
+assert(/Remote branches/.test(cleanListHtml), "clone lists feature-lane under remote branches");
+// feature-lane exists only on the remote in the clone: switch from the
+// remote row; the UI strips origin/ and asks git to create the local branch.
+await ui.switchFromBranchList(encodeURIComponent("origin/feature-lane"), true);
+await new Promise((resolve) => setTimeout(resolve, 400));
+const switchPost = calls.filter((c) => c.path === "/api/git-ui/switch").pop();
+assert(switchPost, "switch POST reached the real backend after branch-list click");
+assert(JSON.parse(switchPost.init.body).branch === "feature-lane", "switch posted the bare branch name feature-lane");
+const laneStatusRes = await httpsJson(`${ORIGIN}/api/git-ui/status?cwd=${encodeURIComponent(CLEAN)}`);
+const laneStatus = await laneStatusRes.json();
+assert(laneStatus.branch === "feature-lane", "clean repo now sits on feature-lane after the switch");
+// And back to main: proves the list can switch both ways on a clean tree.
+await ui.switchFromBranchList(encodeURIComponent("main"), false);
+await new Promise((resolve) => setTimeout(resolve, 400));
+const backStatusRes = await httpsJson(`${ORIGIN}/api/git-ui/status?cwd=${encodeURIComponent(CLEAN)}`);
+const backStatus = await backStatusRes.json();
+assert(backStatus.branch === "main", "clean repo switched back to main via the branch list");
+
 // 4. Context-menu discard must reach the real backend and mutate real git.
+// The active view is still the clean clone from the switch checks: reopen
+// the dirty fixture repo first.
+await ui.open({ cwd: REPO, title: "accept-repo" }, { forceOpen: true });
+await new Promise((resolve) => setTimeout(resolve, 300));
 ui.fileMenu({ preventDefault() {}, stopPropagation() {}, clientX: 5, clientY: 5 }, "scratchdir/", "?", "dir");
 await ui.menuAction("discard");
 await new Promise((resolve) => setTimeout(resolve, 400));
@@ -200,5 +291,6 @@ assert(body.paths[0] === "scratchdir" && body.confirmed === true, "discard poste
 const afterRes = await httpsJson(`${ORIGIN}/api/git-ui/status?cwd=${encodeURIComponent(REPO)}`);
 const after = await afterRes.json();
 assert(!after.untracked.some((p) => p.startsWith("scratchdir")), "scratchdir is gone from real repo status");
+
 
 console.log("GIT E2E ACCEPTANCE PASSED");

--- a/scripts/e2e/run-git-e2e.sh
+++ b/scripts/e2e/run-git-e2e.sh
@@ -66,7 +66,26 @@ EOF
 git -C "$REPO" init -q -b main
 git -C "$REPO" add README.md src/app.js
 git -C "$REPO" -c user.name=e2e -c user.email=e2e@local commit -qm init
+# A bare "origin" so fetch/pull/upstream flows exercise a real remote.
+ORIGIN="$WORK/origin.git"
+git init -q --bare -b main "$ORIGIN"
+git -C "$REPO" remote add origin "$ORIGIN"
+git -C "$REPO" push -q -u origin main 2>/dev/null || git -C "$REPO" push -u origin main
+# A second branch so the branch list offers a real switch target.
+git -C "$REPO" checkout -q -b feature-lane
+echo "// lane" >> "$REPO/src/app.js"
+git -C "$REPO" add src/app.js
+git -C "$REPO" -c user.name=lane -c user.email=lane@local commit -qm "lane work"
+git -C "$REPO" push -q -u origin feature-lane 2>/dev/null || git -C "$REPO" push -u origin feature-lane
+git -C "$REPO" checkout -q main
+# A clean clone for the branch-switch checks (the main fixture keeps a dirty
+# tree for the staged/unstaged/untracked assertions; git refuses checkout
+# over conflicting local edits, so switching needs a clean worktree).
+CLEAN="$WORK/git-clean-repo"
+git clone -q "$ORIGIN" "$CLEAN"
 # Dirty state: staged edit, unstaged edit, untracked dir.
+# NOTE: the branch-list switch runs while the tree is still clean (before
+# this block), because git refuses checkout with conflicting local edits.
 echo "// staged" >> "$REPO/src/app.js"
 git -C "$REPO" add src/app.js
 echo "// unstaged" >> "$REPO/src/app.js"
@@ -94,7 +113,7 @@ wait_for() {
 wait_for "server" "https://127.0.0.1:$PORT/" || exit 1
 
 echo "==> running git-ui acceptance checks"
-E2E_ORIGIN="https://127.0.0.1:$PORT" E2E_REPO="$REPO" node "$ROOT/scripts/e2e/git-acceptance.mjs"
+E2E_ORIGIN="https://127.0.0.1:$PORT" E2E_REPO="$REPO" E2E_CLEAN_REPO="$CLEAN" node "$ROOT/scripts/e2e/git-acceptance.mjs"
 status=$?
 
 if [[ $status -eq 0 ]]; then

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -320,7 +320,7 @@ describe("app bundle load", () => {
   it("adds configured shortcut labels to Git tooltips", () => {
     match(gitUiSource, /function titleWithGitShortcut\(title, action\)/);
     match(gitUiSource, /titleWithGitShortcut\("Refresh", "refresh"\)/);
-    match(gitUiSource, /titleWithGitShortcut\("Change Git directory or switch branch", "branch"\)/);
+    match(gitUiSource, /titleWithGitShortcut\("Switch branch", "branch"\)/);
     match(gitUiSource, /titleWithGitShortcut\("File history", "history"\)/);
     match(gitUiSource, /titleWithGitShortcut\("Blame", "blame"\)/);
   });
@@ -733,7 +733,7 @@ describe("app bundle load", () => {
     match(gitUiSource, /isNotGitRepositoryMessage/);
     match(gitUiSource, /markNoGitRepository\(view\)/);
     match(gitUiSource, /not_git_repository: true/);
-    match(gitUiSource, /cleanupOnly \? "" : `<div class="git-ui-toolbar">/);
+    match(gitUiSource, /cleanupOnly \? "" : renderWorktreeActions/);
     match(gitUiSource, /const filterInput = sideFileCount\(view\)/);
     match(gitUiSource, /const fileList = cleanupOnly \? "" : `\$\{filterInput\}\$\{fileSections\}`;/);
     match(gitUiSource, /disabledReason = "Open a Git repository to use this view"/);
@@ -760,7 +760,7 @@ describe("app bundle load", () => {
     match(gitUiSource, /gitCommitIncludeBody/);
     match(gitUiSource, /gitUiPushTags/);
     match(gitUiSource, /Open PR/);
-    ok(!gitUiSource.includes("openForcePushModal"));
+    match(gitUiSource, /openForcePushModal/);
     ok(!gitUiSource.includes("HerdrGitUi.tab('commit')"));
     ok(!gitUiSource.includes('onclick="HerdrGitUi.toggleStageAll()'));
   });

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -892,7 +892,7 @@ describe("app bundle load", () => {
     match(gitUiSource, /const filterInput = sideFileCount\(view\)/);
     match(gitUiSource, /const fileList = cleanupOnly \? "" : `\$\{filterInput\}\$\{fileSections\}`;/);
     match(gitUiSource, /status\.conflicted, status\.staged, status\.unstaged, status\.untracked/);
-    match(gitUiSource, /Fetch selected branch before rebasing/);
+    match(gitUiSource, /Fetch selected branch \(and main\/master\) before rebasing onto origin/);
     match(gitUiSource, /pull_first: pullFirst/);
     ok(!gitUiSource.includes('/api/git-ui/pull", { cwd: view.cwd, mode: "ff-only", branch }'));
   });

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -1251,7 +1251,7 @@
     const loading = modal.loading ? `<div class="git-ui-muted">Loading branches...</div>` : "";
     const common = `${loading}${branchSelect}`;
     if (modal.type === "pull") {
-      return renderGitOpModalShell("Pull changes", `${common}${renderGitOpModeSelect("Pull option", [["regular", "Regular pull"], ["rebase", "Pull with rebase"], ["ff-only", "Fast-forward only"], ["no-ff", "No fast-forward"], ["force", "Force pull"]])}${error}`, "Pull", "primary", "runPullFromModal");
+      return renderGitOpModalShell("Pull changes", `${common}${renderGitOpModeSelect("Pull option", [["update", "Update (fetch + fast-forward)"], ["regular", "Regular pull"], ["rebase", "Pull with rebase"], ["ff-only", "Fast-forward only"], ["no-ff", "No fast-forward"], ["force", "Force pull"]], "update")}${error}`, "Pull", "primary", "runPullFromModal");
     }
     if (modal.type === "push" || modal.type === "force-push") {
       const force = modal.type === "force-push";
@@ -1264,7 +1264,7 @@
       return renderGitOpModalShell(force ? "Push failed" : "Push changes", body, force ? "Retry push" : "Push", force ? "danger" : "primary", "runPushFromModal");
     }
     if (modal.type === "rebase") {
-      const body = `${common}<label class="git-ui-branch-field"><span>Rebase commits after</span><input id="gitUiRebaseUpstream" value="HEAD" placeholder="HEAD"></label><label class="git-ui-check-row"><input id="gitUiRebasePullFirst" type="checkbox" checked><span>Fetch selected branch before rebasing</span></label>${error}`;
+      const body = `${common}<label class="git-ui-branch-field"><span>Rebase commits after</span><input id="gitUiRebaseUpstream" value="HEAD" placeholder="HEAD"></label><label class="git-ui-check-row"><input id="gitUiRebasePullFirst" type="checkbox" checked><span>Fetch selected branch (and main/master) before rebasing onto origin</span></label>${error}`;
       return renderGitOpModalShell("Rebase branch", body, "Rebase", "primary", "runRebaseFromModal");
     }
     return "";
@@ -1546,7 +1546,7 @@
     const commitDisabled = canCommit ? "" : " disabled";
     const branchLabel = `${view.titleKind || "Branch"}: ${s.branch || view.title || "No branch"}`;
     const error = view.error && !cleanupOnly ? `<div class="git-ui-error">${esc(view.error)}</div>` : "";
-    const actions = cleanupOnly ? "" : `<div class="git-ui-toolbar"><div class="git-ui-toolbar-title">Worktree actions</div><div class="git-ui-actions"><button class="git-ui-btn primary" title="${esc(commitHint)}" onclick="HerdrGitUi.openCommitModal()"${commitDisabled}>Commit</button><button class="git-ui-btn" onclick="HerdrGitUi.openPullModal()">↓ Pull</button><button class="git-ui-btn" onclick="HerdrGitUi.openPushModal()">↑ Push</button><button class="git-ui-btn" onclick="HerdrGitUi.rebase()">Rebase</button><button class="git-ui-btn danger" onclick="HerdrGitUi.reset()">Reset</button></div></div>`;
+    const actions = cleanupOnly ? "" : `<div class="git-ui-toolbar"><div class="git-ui-toolbar-title">Worktree actions</div><div class="git-ui-actions"><button class="git-ui-btn primary" title="${esc(commitHint)}" onclick="HerdrGitUi.openCommitModal()"${commitDisabled}>Commit</button><button class="git-ui-btn" title="Fetch and fast-forward from the upstream (never creates a merge commit)" onclick="HerdrGitUi.updateFromUpstream()">↓ Update</button><button class="git-ui-btn" onclick="HerdrGitUi.openPullModal()">↓ Pull</button><button class="git-ui-btn" onclick="HerdrGitUi.openPushModal()">↑ Push</button><button class="git-ui-btn" onclick="HerdrGitUi.rebase()">Rebase</button><button class="git-ui-btn danger" onclick="HerdrGitUi.reset()">Reset</button></div></div>`;
     const filterInput = sideFileCount(view)
       ? `<label class="git-ui-file-filter"><span class="git-ui-file-filter-icon" aria-hidden="true"></span><input value="${esc(view.fileFilter || "")}" id="gitUiFileFilter" name="git-ui-file-filter" autocomplete="off" placeholder="Filter files" oninput="HerdrGitUi.filterFiles(this.value)"></label>`
       : "";
@@ -3474,6 +3474,11 @@
       render();
     },
     openPullModal() { this.openGitOpModal("pull"); },
+    async updateFromUpstream() {
+      const view = active();
+      if (!view || view.mutating) return;
+      await postJson("/api/git-ui/pull", { cwd: view.cwd, mode: "update" }, "Updating from upstream");
+    },
     openPushModal() { this.openGitOpModal("push"); },
     closeGitOpModal() { state.gitOpModal = null; render(); },
     async runPullFromModal() {

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -43,10 +43,24 @@
   };
 
   document.addEventListener("click", () => {
-    if (!state.contextMenu) return;
+    const hadMenu = !!(state.contextMenu || state.headerMenu);
     state.contextMenu = null;
-    if (state.visible) render();
+    state.headerMenu = null;
+    if (state.branchList && !eventInsideBranchList(event)) {
+      state.branchList = null;
+      state.branchList.filter = "";
+      hadMenu = true;
+    }
+    if (hadMenu && state.visible) render();
   });
+  function eventInsideBranchList(event) {
+    const target = event && event.target;
+    while (target && target.classList) {
+      if (target.classList.contains("git-ui-branch-list") || target.classList.contains("git-ui-branch-chip")) return true;
+      target = target.parentNode;
+    }
+    return false;
+  }
   window.addEventListener("keydown", handleKeydown, true);
 
   function active() {
@@ -75,8 +89,14 @@
     }
     if (event.key !== "Escape") return;
     event.preventDefault();
-    if (state.contextMenu) {
+    if (state.contextMenu || state.headerMenu) {
       state.contextMenu = null;
+      state.headerMenu = null;
+      render();
+      return;
+    }
+    if (state.branchList) {
+      state.branchList = null;
       render();
       return;
     }
@@ -1263,6 +1283,13 @@
       const body = `${common}${modeSelect}${pushTags}${note}${error}`;
       return renderGitOpModalShell(force ? "Push failed" : "Push changes", body, force ? "Retry push" : "Push", force ? "danger" : "primary", "runPushFromModal");
     }
+    if (modal.type === "fetch-from") {
+      return renderGitOpModalShell("Fetch from", `${common}<div class="git-ui-muted">Fetches only the selected branch from origin.</div>${error}`, "Fetch", "primary", "runFetchFromFromModal");
+    }
+    if (modal.type === "push-to") {
+      const pushTags = `<label class="git-ui-check-row"><input id="gitUiPushTags" type="checkbox"><span>Push tags</span></label>`;
+      return renderGitOpModalShell("Push to branch", `${common}${pushTags}<div class="git-ui-muted">Pushes the current branch to the selected remote branch.</div>${error}`, "Push", "primary", "runPushToFromModal");
+    }
     if (modal.type === "rebase") {
       const body = `${common}<label class="git-ui-branch-field"><span>Rebase commits after</span><input id="gitUiRebaseUpstream" value="HEAD" placeholder="HEAD"></label><label class="git-ui-check-row"><input id="gitUiRebasePullFirst" type="checkbox" checked><span>Fetch selected branch (and main/master) before rebasing onto origin</span></label>${error}`;
       return renderGitOpModalShell("Rebase branch", body, "Rebase", "primary", "runRebaseFromModal");
@@ -1275,7 +1302,7 @@
     const currentBranch = status.branch || "";
     const branchNames = (modal.branches || []).map((branch) => branch.name || branch).concat([currentBranch, status.upstream || "", "main", "master"]);
     const branches = branchNames.filter((value, index, array) => value && array.indexOf(value) === index);
-    const defaultBranch = modal.type === "rebase" ? (branches.find((branch) => branch === "main" || branch === "master") || "") : modal.type && modal.type.includes("push") ? currentBranch : "";
+    const defaultBranch = modal.type === "rebase" ? (branches.find((branch) => branch === "main" || branch === "master") || "") : modal.type === "push-to" ? currentBranch : modal.type === "fetch-from" ? currentBranch : modal.type && modal.type.includes("push") ? currentBranch : "";
     const options = branches.map((branch) => `<option value="${esc(branch)}" ${branch === defaultBranch ? "selected" : ""}>${esc(branch)}${branch === currentBranch ? " (current)" : ""}</option>`).join("");
     return `<label class="git-ui-branch-field"><span>Branch</span><select id="gitUiOpBranch"><option value="" ${defaultBranch ? "" : "selected"}>Current upstream</option>${options}</select></label>`;
   }
@@ -1522,6 +1549,89 @@
     return `<span class="git-ui-ahead-behind-group" title="${esc(title)}">${badges.join("")}</span>`;
   }
 
+  // ── Worktree actions row (GitHub-flow header rework) ─────────────────
+  // Branch chip lives here, right-justified: name (opens the branch list),
+  // sync arrows with counts when diverged, Fetch when in sync, and a
+  // pull/fetch dropdown triangle.
+  function renderWorktreeActions(ctx) {
+    const s = ctx.s || {};
+    const esc = ctx.esc;
+    const commitHint = ctx.commitHint || "Commit";
+    const commitDisabled = ctx.commitDisabled || "";
+    const branch = String(s.branch || "");
+    const ahead = Number(s.ahead) || 0;
+    const behind = Number(s.behind) || 0;
+    const diverged = ahead > 0 || behind > 0;
+    const upstream = String(s.upstream || "").trim();
+    const syncBadge = upstream
+      ? diverged
+        ? `${behind > 0 ? `<b class="git-ui-chip-count behind" title="${esc(aheadBehindHint(s))}">↓${behind}</b>` : ""}${ahead > 0 ? `<b class="git-ui-chip-count ahead" title="${esc(aheadBehindHint(s))}">↑${ahead}</b>` : ""}`
+        : `<b class="git-ui-chip-count synced" title="In sync with ${esc(upstream)}">✓</b>`
+      : "";
+    const chip = branch
+      ? `<button class="git-ui-branch-chip" title="${esc(titleWithGitShortcut("Switch branch", "branch"))}" onclick="HerdrGitUi.openBranchList(event)"><span class="git-ui-branch-chip-name">${esc(branch)}</span>${syncBadge}<b class="git-ui-chip-caret">▾</b></button>`
+      : "";
+    return `<div class="git-ui-toolbar git-ui-worktree-row"><div class="git-ui-actions git-ui-worktree-left"><button class="git-ui-btn primary" title="${esc(commitHint)}" onclick="HerdrGitUi.openCommitModal()"${commitDisabled}>Commit</button><button class="git-ui-btn" title="Fetch and fast-forward from the upstream (never creates a merge commit)" onclick="HerdrGitUi.updateFromUpstream()">↓ Update</button><button class="git-ui-btn git-ui-split" title="Pull, fetch and push options" aria-haspopup="menu" aria-expanded="${state.headerMenu ? "true" : "false"}" onclick="HerdrGitUi.toggleHeaderMenu(event)"><span>↓ Pull</span><b class="git-ui-chip-caret">▾</b></button><button class="git-ui-btn" onclick="HerdrGitUi.rebase()">Rebase</button><button class="git-ui-btn danger" onclick="HerdrGitUi.reset()">Reset</button></div><div class="git-ui-worktree-right">${chip}</div></div>`;
+  }
+
+  // Dropdown next to Pull: Fetch / Fetch from / Pull / Pull (Rebase) /
+  // Push / Push to / Force Push.
+  function renderHeaderMenu() {
+    const menu = state.headerMenu;
+    if (!menu) return "";
+    const item = (label, method, hint) => `<button onclick="HerdrGitUi.${method}()">${esc(label)}${hint ? `<span class="git-ui-menu-hint">${esc(hint)}</span>` : ""}</button>`;
+    return `<div class="git-ui-menu git-ui-header-menu" style="left:${Math.max(0, menu.x)}px;top:${Math.max(0, menu.y)}px" onclick="event.stopPropagation()">${item("Fetch", "fetchOrigin", "git fetch origin")}${item("Fetch from…", "openFetchFromModal", "choose a branch")}${item("Pull", "openPullModal", "opens pull options")}${item("Pull (Rebase)", "pullWithRebase", "git pull --rebase")}${item("Push", "openPushModal", "opens push options")}${item("Push to…", "openPushToModal", "choose a branch")}${item("Force Push", "openForcePushModal", "force-with-lease first")}</div>`;
+  }
+
+  // Branch list popover: opens from the branch chip. Local section first,
+  // then remote; filterable. Each row: branch name, author · relative time;
+  // hover shows the exact time and commit subject.
+  function branchRelativeTime(isoDate) {
+    const then = Date.parse(String(isoDate || ""));
+    if (!then || Number.isNaN(then)) return "";
+    const seconds = Math.max(0, Math.floor((Date.now() - then) / 1000));
+    if (seconds < 60) return "just now";
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days} day${days === 1 ? "" : "s"} ago`;
+    const months = Math.floor(days / 30);
+    if (months < 12) return `${months} month${months === 1 ? "" : "s"} ago`;
+    const years = Math.floor(days / 365);
+    return `${years} year${years === 1 ? "" : "s"} ago`;
+  }
+
+  function branchListRow(branch, currentBranch) {
+    const name = String(branch.name || "");
+    const isCurrent = !branch.remote && name === currentBranch;
+    const author = String(branch.author || "");
+    const date = String(branch.date || "");
+    const subject = String(branch.subject || "");
+    const exact = date ? new Date(date).toLocaleString() : "";
+    const hover = [author && `${author}`, exact, subject && `"${subject}"`].filter(Boolean).join(" · ");
+    return `<button class="git-ui-branch-row${isCurrent ? " current" : ""}" title="${esc(hover)}" onclick="HerdrGitUi.switchFromBranchList(\'${arg(name)}\',${branch.remote ? "true" : "false"})">
+      <span class="git-ui-branch-row-name">${esc(name)}${isCurrent ? " <b>●</b>" : ""}${branch.remote ? `<i class="git-ui-branch-row-remote">remote</i>` : ""}</span>
+      <span class="git-ui-branch-row-meta">${esc(author)}${author && branchRelativeTime(date) ? " · " : ""}${esc(branchRelativeTime(date))}</span>
+    </button>`;
+  }
+
+  function renderBranchList() {
+    const list = state.branchList;
+    if (!list) return "";
+    if (list.loading) return `<div class="git-ui-branch-list" onclick="event.stopPropagation()"><div class="git-ui-loading"><span></span><strong>Loading branches</strong></div></div>`;
+    if (list.error) return `<div class="git-ui-branch-list" onclick="event.stopPropagation()"><div class="git-ui-error">${esc(list.error)}</div></div>`;
+    const filter = String(list.filter || "").toLowerCase();
+    const currentBranch = String(list.currentBranch || "");
+    const matches = (branch) => !filter || String(branch.name || "").toLowerCase().includes(filter);
+    const local = (list.local || []).filter(matches);
+    const remote = (list.remote || []).filter(matches);
+    const rows = (branches, label) => !branches.length ? "" : `<div class="git-ui-branch-list-section">${label}</div>${branches.map((branch) => branchListRow(branch, currentBranch)).join("")}`;
+    const empty = !local.length && !remote.length ? `<div class="git-ui-muted git-ui-branch-list-empty">No branches match</div>` : "";
+    return `<div class="git-ui-branch-list" onclick="event.stopPropagation()"><label class="git-ui-branch-list-filter"><span>Filter</span><input value="${esc(list.filter || "")}" placeholder="Type to filter" oninput="HerdrGitUi.branchListFilter(this.value)"></label>${rows(local, "Local branches")}${rows(remote, "Remote branches")}${empty}</div>`;
+  }
+
   function renderSide() {
     const view = active() || {};
     const s = view.status || {};
@@ -1546,7 +1656,7 @@
     const commitDisabled = canCommit ? "" : " disabled";
     const branchLabel = `${view.titleKind || "Branch"}: ${s.branch || view.title || "No branch"}`;
     const error = view.error && !cleanupOnly ? `<div class="git-ui-error">${esc(view.error)}</div>` : "";
-    const actions = cleanupOnly ? "" : `<div class="git-ui-toolbar"><div class="git-ui-toolbar-title">Worktree actions</div><div class="git-ui-actions"><button class="git-ui-btn primary" title="${esc(commitHint)}" onclick="HerdrGitUi.openCommitModal()"${commitDisabled}>Commit</button><button class="git-ui-btn" title="Fetch and fast-forward from the upstream (never creates a merge commit)" onclick="HerdrGitUi.updateFromUpstream()">↓ Update</button><button class="git-ui-btn" onclick="HerdrGitUi.openPullModal()">↓ Pull</button><button class="git-ui-btn" onclick="HerdrGitUi.openPushModal()">↑ Push</button><button class="git-ui-btn" onclick="HerdrGitUi.rebase()">Rebase</button><button class="git-ui-btn danger" onclick="HerdrGitUi.reset()">Reset</button></div></div>`;
+    const actions = cleanupOnly ? "" : renderWorktreeActions({ s, esc, commitHint, commitDisabled });
     const filterInput = sideFileCount(view)
       ? `<label class="git-ui-file-filter"><span class="git-ui-file-filter-icon" aria-hidden="true"></span><input value="${esc(view.fileFilter || "")}" id="gitUiFileFilter" name="git-ui-file-filter" autocomplete="off" placeholder="Filter files" oninput="HerdrGitUi.filterFiles(this.value)"></label>`
       : "";
@@ -1559,9 +1669,8 @@
       ? `<button class="git-ui-refresh-icon git-ui-current-changes-icon" title="Return to current changes" aria-label="Return to current changes" onclick="HerdrGitUi.latestChanges()"><span></span></button>`
       : "";
     const refreshButton = appRefreshIconButton({ className: "git-ui-refresh-icon", title: titleWithGitShortcut("Refresh", "refresh"), label: titleWithGitShortcut("Refresh Git state", "refresh"), spinning: !!view.refreshAnimating, onclick: "HerdrGitUi.refreshWithSpin()" });
-    const aheadBehind = cleanupOnly ? "" : renderAheadBehind(s, esc);
     const busy = view.mutating ? `<span class="git-ui-busy"><span class="git-ui-busy-spinner"></span>${esc(view.mutatingLabel || "Working...")}</span>` : "";
-    return `<aside class="git-ui-side" onscroll="HerdrGitUi.sideScroll(this)"><div class="git-ui-head"><div class="git-ui-head-main"><div class="git-ui-title-row"><div class="git-ui-title">Git</div><div class="git-ui-title-actions">${busy}${returnToCurrentChanges}${returnToWorkspace}${refreshButton}</div></div><div class="git-ui-subtitle">${esc(s.state || "closed")} · ${esc(compactPath(s.repo_path))}</div><button class="git-ui-branch-pill" title="${esc(titleWithGitShortcut("Change Git directory or switch branch", "branch"))}" onclick="HerdrGitUi.openBranchModal()"><span>${esc(branchLabel)}</span>${aheadBehind}<b>↗</b></button></div></div>${error}<div class="git-ui-toolbar git-ui-view-toolbar">${renderGitViewTabs(tabs, view.tab)}</div>${actions}${fileList}${sideBottom}</aside>`;
+    return `<aside class="git-ui-side" onscroll="HerdrGitUi.sideScroll(this)"><div class="git-ui-head"><div class="git-ui-head-main"><div class="git-ui-title-row"><div class="git-ui-title">Git</div><div class="git-ui-title-actions">${busy}${returnToCurrentChanges}${returnToWorkspace}${refreshButton}</div></div><div class="git-ui-subtitle">${esc(s.state || "closed")} · ${esc(compactPath(s.repo_path))}</div></div></div>${error}<div class="git-ui-toolbar git-ui-view-toolbar">${renderGitViewTabs(tabs, view.tab)}</div>${actions}${fileList}${sideBottom}</aside>`;
   }
 
   function renderDiffLayoutSideToggle(view) {
@@ -2576,7 +2685,7 @@
     const version = ++state.renderVersion;
     const panel = ensurePanel();
     panel.classList.toggle("mutating", !!activeView.mutating);
-    panel.innerHTML = renderSide() + renderMain() + renderContextMenu() + renderCommitModal() + renderCompareSelectedModal() + renderResetSelectedModal() + renderTagSelectedModal() + renderBranchModal() + renderGitOpModal() + renderCleanupConfirm() + renderGitToast();
+    panel.innerHTML = renderSide() + renderMain() + renderContextMenu() + renderHeaderMenu() + renderBranchList() + renderCommitModal() + renderCompareSelectedModal() + renderResetSelectedModal() + renderTagSelectedModal() + renderBranchModal() + renderGitOpModal() + renderCleanupConfirm() + renderGitToast();
     const side = panel.querySelector(".git-ui-side");
     if (side) side.scrollTop = state.sideScrollTop || 0;
     const nextContent = panel.querySelector(".git-ui-content");
@@ -3519,8 +3628,116 @@
         render();
       }
     },
+    async runFetchFromFromModal() {
+      const view = active();
+      if (!view) return;
+      const modal = state.gitOpModal || { type: "fetch-from" };
+      const branch = (document.getElementById("gitUiOpBranch") || {}).value || "";
+      state.gitOpModal = null;
+      try {
+        await postJson("/api/git-ui/fetch", { cwd: view.cwd, branch }, `Fetching ${branch || "origin"}`);
+      } catch (err) {
+        state.gitOpModal = Object.assign({}, modal, { type: "fetch-from", error: err.message || String(err) });
+        render();
+      }
+    },
+    async runPushToFromModal() {
+      const view = active();
+      if (!view) return;
+      const modal = state.gitOpModal || { type: "push-to" };
+      const branch = (document.getElementById("gitUiOpBranch") || {}).value || "";
+      const pushTags = !!((document.getElementById("gitUiPushTags") || {}).checked);
+      state.gitOpModal = null;
+      try {
+        await postJson("/api/git-ui/push", { cwd: view.cwd, mode: "regular", branch, push_tags: pushTags }, `Pushing to ${branch || "upstream"}`);
+      } catch (err) {
+        state.gitOpModal = Object.assign({}, modal, { type: "push-to", error: err.message || String(err) });
+        render();
+      }
+    },
     resolve(path, mode) { post("/api/git-ui/conflict-resolve", { cwd: active().cwd, path: decodeURIComponent(path), mode }, "Resolving conflict"); },
     conflictAction(action) { post("/api/git-ui/conflict-action", { cwd: active().cwd, action }, "Continuing operation"); },
+    async openBranchList(event) {
+      const view = active();
+      if (!view) return;
+      if (event && event.stopPropagation) event.stopPropagation();
+      // Re-open toggle: clicking the chip again closes the list.
+      if (state.branchList && !state.branchList.loading) {
+        state.branchList = null;
+        render();
+        return;
+      }
+      const currentBranch = ((view.status || {}).branch) || "";
+      state.branchList = { loading: true, error: "", local: [], remote: [], filter: "", currentBranch };
+      render();
+      try {
+        const data = await api(`/api/git-ui/branches?cwd=${encodeURIComponent(view.cwd)}`);
+        if (!state.branchList) return; // closed while loading
+        state.branchList = { loading: false, error: "", local: data.local || [], remote: data.remote || [], filter: state.branchList.filter || "", currentBranch };
+      } catch (err) {
+        if (!state.branchList) return;
+        state.branchList = { loading: false, error: err.message || String(err), local: [], remote: [], filter: state.branchList.filter || "", currentBranch };
+      }
+      render();
+    },
+    closeBranchList() {
+      if (!state.branchList) return;
+      state.branchList = null;
+      render();
+    },
+    branchListFilter(value) {
+      if (!state.branchList) return;
+      state.branchList.filter = String(value || "");
+      // Re-render only the list, not the whole panel: the filter input
+      // would lose focus otherwise.
+      const panel = document.getElementById("gitUiPanel");
+      const existing = panel && panel.querySelector(".git-ui-branch-list");
+      if (!existing) { render(); return; }
+      const template = document.createElement("div");
+      template.innerHTML = renderBranchList();
+      const next = template.firstElementChild;
+      if (!next) { render(); return; } // DOM without real parsing (tests): full re-render
+      existing.replaceWith(next);
+      const input = next.querySelector("input");
+      if (input && typeof input.focus === "function") {
+        input.focus();
+        try { input.setSelectionRange(String(value || "").length, String(value || "").length); } catch (_) {}
+      }
+    },
+    async switchFromBranchList(encodedName, isRemote) {
+      const name = decodeURIComponent(String(encodedName || ""));
+      const view = active();
+      if (!view || !name) return;
+      state.branchList = null;
+      render();
+      const localName = isRemote ? name.split("/").slice(1).join("/") : name;
+      if (!localName) return;
+      const currentBranch = ((view.status || {}).branch) || "";
+      if (localName === currentBranch) return;
+      await postJson("/api/git-ui/switch", { cwd: view.cwd, branch: localName }, `Switching to ${name}`);
+    },
+    toggleHeaderMenu(event) {
+      if (event && event.stopPropagation) event.stopPropagation();
+      if (state.headerMenu) { state.headerMenu = null; render(); return; }
+      const rect = event && event.currentTarget && event.currentTarget.getBoundingClientRect ? event.currentTarget.getBoundingClientRect() : null;
+      state.headerMenu = { x: rect ? rect.left : (event && event.clientX) || 0, y: rect ? rect.bottom + 4 : (event && event.clientY) || 0 };
+      render();
+    },
+    async fetchOrigin() {
+      state.headerMenu = null;
+      const view = active();
+      if (!view) return;
+      await postJson("/api/git-ui/fetch", { cwd: view.cwd }, "Fetching origin");
+    },
+    openFetchFromModal() { state.headerMenu = null; this.openGitOpModal("fetch-from"); },
+    async pullWithRebase() {
+      state.headerMenu = null;
+      const view = active();
+      if (!view) return;
+      await postJson("/api/git-ui/pull", { cwd: view.cwd, mode: "rebase" }, "Pulling with rebase");
+    },
+    openPushToModal() { state.headerMenu = null; this.openGitOpModal("push-to"); },
+    openForcePushModal() { state.headerMenu = null; state.gitOpModal = { type: "force-push", error: "", branches: [], loading: false }; render(); },
     async openBranchModal() {
       const view = active();
       if (!view) return;

--- a/src/assets/desktop/git_ui/layout.css
+++ b/src/assets/desktop/git_ui/layout.css
@@ -96,7 +96,31 @@
   color: var(--muted);
   font-size: 12px;
 }
-.git-ui-branch-pill {
+.git-ui-ahead-behind-group {
+  align-items: center;
+  display: inline-flex;
+  flex: none;
+  gap: 3px;
+  margin-left: 2px;
+}
+
+/* ── Worktree actions row with branch chip (GitHub-flow header) ────── */
+.git-ui-worktree-row {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+}
+.git-ui-worktree-left {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.git-ui-worktree-right {
+  flex: none;
+  justify-content: flex-end;
+  margin-left: auto;
+}
+.git-ui-branch-chip {
   align-items: center;
   background: rgba(56, 139, 253, 0.12);
   border: 1px solid rgba(56, 139, 253, 0.45);
@@ -108,32 +132,126 @@
   font-size: 12px;
   font-weight: 800;
   gap: 6px;
-  margin-top: 5px;
   max-width: 100%;
   overflow: hidden;
   padding: 3px 8px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.git-ui-branch-pill span {
+.git-ui-branch-chip-name {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.git-ui-branch-pill b {
+.git-ui-chip-count {
+  border-radius: 999px;
   flex: none;
   font-size: 11px;
-  line-height: 1;
+  padding: 0 6px;
 }
-.git-ui-branch-pill:hover {
-  background: rgba(56, 139, 253, 0.2);
+.git-ui-chip-count.behind { background: rgba(56, 139, 253, 0.2); }
+.git-ui-chip-count.ahead { background: rgba(63, 185, 80, 0.2); }
+.git-ui-chip-count.synced { background: rgba(63, 185, 80, 0.16); color: var(--success, #3fb950); }
+.git-ui-chip-caret { font-size: 10px; }
+.git-ui-split { padding-right: 4px; }
+.git-ui-split .git-ui-chip-caret { margin-left: 2px; }
+
+/* Header pull/fetch dropdown */
+.git-ui-header-menu {
+  max-height: 320px;
+  overflow-y: auto;
 }
-.git-ui-ahead-behind-group {
+.git-ui-menu-hint {
+  color: var(--muted);
+  float: right;
+  font-size: 11px;
+  font-weight: 400;
+  margin-left: 12px;
+}
+
+/* Branch list popover */
+.git-ui-branch-list {
+  background: var(--panel);
+  border: 1px solid var(--border2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  left: 10px;
+  max-height: 420px;
+  overflow-y: auto;
+  padding: 8px;
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 40;
+}
+.git-ui-branch-list-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+.git-ui-branch-list-filter span {
+  color: var(--muted);
+  font-size: 11px;
+}
+.git-ui-branch-list-filter input {
+  background: var(--panel2);
+  border: 1px solid var(--border2);
+  border-radius: 7px;
+  color: var(--fg);
+  font: 12px var(--font);
+  padding: 6px 8px;
+}
+.git-ui-branch-list-section {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin: 8px 0 4px;
+  text-transform: uppercase;
+}
+.git-ui-branch-row {
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  color: var(--fg);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  font: inherit;
+  gap: 2px;
+  padding: 6px 8px;
+  text-align: left;
+  width: 100%;
+}
+.git-ui-branch-row:hover,
+.git-ui-branch-row.current {
+  background: var(--panel2);
+}
+.git-ui-branch-row-name {
   align-items: center;
-  display: inline-flex;
-  flex: none;
-  gap: 3px;
-  margin-left: 2px;
+  display: flex;
+  font-size: 13px;
+  font-weight: 700;
+  gap: 6px;
+}
+.git-ui-branch-row-name b { color: var(--accent); font-size: 10px; }
+.git-ui-branch-row-remote {
+  background: var(--panel2);
+  border: 1px solid var(--border2);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 600;
+  padding: 0 6px;
+}
+.git-ui-branch-row-meta {
+  color: var(--muted);
+  font-size: 11px;
+}
+.git-ui-branch-list-empty {
+  padding: 8px;
 }
 .git-ui-ahead-behind {
   align-items: center;

--- a/src/assets/git_ui_behavior.test.mjs
+++ b/src/assets/git_ui_behavior.test.mjs
@@ -394,3 +394,97 @@ test("Update button fetch+ff from upstream and Pull modal default to update mode
   assert.match(rebaseHtml, /Fetch selected branch \(and main\/master\) before rebasing onto origin/);
   await ui.closeGitOpModal();
 });
+
+test("header menu dropdown offers fetch, pull and push variants", async () => {
+  const booted = await openedWithStatus(emptyStatus());
+  const { ui, calls } = booted;
+
+  const chipEvent = { stopPropagation() {}, currentTarget: null, clientX: 0, clientY: 0 };
+  await ui.openBranchList(chipEvent); // opens then closes (toggle) — leave closed
+  const toggleEvent = { stopPropagation() {}, currentTarget: { getBoundingClientRect: () => ({ left: 40, bottom: 60 }) }, clientX: 40, clientY: 60 };
+  ui.toggleHeaderMenu(toggleEvent);
+  let html = String(ctxHtml(booted));
+  assert.match(html, /class="git-ui-menu git-ui-header-menu"/);
+  assert.match(html, /HerdrGitUi\.fetchOrigin\(\)/);
+  assert.match(html, /HerdrGitUi\.openFetchFromModal\(\)/);
+  assert.match(html, /HerdrGitUi\.openPullModal\(\)/);
+  assert.match(html, /HerdrGitUi\.pullWithRebase\(\)/);
+  assert.match(html, /HerdrGitUi\.openPushModal\(\)/);
+  assert.match(html, /HerdrGitUi\.openPushToModal\(\)/);
+  assert.match(html, /HerdrGitUi\.openForcePushModal\(\)/);
+
+  // Fetch from the menu posts to the fetch endpoint.
+  const before = calls.length;
+  await ui.fetchOrigin();
+  const fetchPosts = calls.slice(before).filter((call) => call.path === "/api/git-ui/fetch");
+  assert.equal(fetchPosts.length, 1, "fetch POST fired");
+  assert.equal(JSON.parse(fetchPosts[0].init.body).cwd, "/tmp/demo-repo");
+  assert.equal(JSON.parse(fetchPosts[0].init.body).branch, undefined);
+
+  // Pull (Rebase) posts mode=rebase.
+  ui.toggleHeaderMenu(toggleEvent); // reopen
+  const beforeRebase = calls.length;
+  await ui.pullWithRebase();
+  const pullPosts = calls.slice(beforeRebase).filter((call) => call.path === "/api/git-ui/pull");
+  assert.equal(pullPosts.length, 1, "pull POST fired");
+  assert.equal(JSON.parse(pullPosts[0].init.body).mode, "rebase");
+  const menuHtml = String(ctxHtml(booted));
+  assert.ok(!menuHtml.includes("git-ui-header-menu"), "menu closes after action");
+});
+
+test("branch chip shows sync arrows when diverged and opens the branch list", async () => {
+  const booted = await bootGitUi({
+    "/api/git-ui/status": { branch: "feature-x", ahead: 2, behind: 3, staged: [], unstaged: [], untracked: [], conflicted: [], upstream: "origin/feature-x" },
+    "/api/git-ui/diff": { files: [] },
+    "/api/git-ui/compare": { files: [] },
+    "/api/git-ui/log": { commits: [], lines: [], rows: [], has_more: false, limit: 80 },
+    "/api/git-ui/branches": { local: [{ name: "main", author: "Ada", date: "2026-01-02T03:04:05Z", subject: "initial" }, { name: "feature-x", author: "Bob", date: "2026-01-03T03:04:05Z", subject: "wip" }], remote: [{ name: "origin/main", author: "Ada", date: "2026-01-02T03:04:05Z", subject: "initial" }] },
+  });
+  const { ui } = booted;
+  await ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
+
+  let html = String(ctxHtml(booted));
+  assert.match(html, /git-ui-branch-chip/);
+  assert.match(html, /<b class="git-ui-chip-count behind"[^>]*>↓3<\/b>/);
+  assert.match(html, /<b class="git-ui-chip-count ahead"[^>]*>↑2<\/b>/);
+
+  const chipEvent = { stopPropagation() {}, currentTarget: null, clientX: 0, clientY: 0 };
+  await ui.openBranchList(chipEvent);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  html = String(ctxHtml(booted));
+  assert.match(html, /git-ui-branch-list"/);
+  assert.match(html, /Local branches/);
+  assert.match(html, /Remote branches/);
+  assert.match(html, /Switching to feature-x|Ada · /);
+  // Rows carry author + relative time and a hover title with details.
+  assert.match(html, /title="[^"]*Ada[^"]*"/);
+
+  // Filter narrows the visible rows: in the vm the DOM stub cannot swap
+  // nodes, so assert the renderer honors the filter by re-rendering.
+  ui.branchListFilter("main");
+  html = String(ctxHtml(booted));
+  assert.ok(html.includes("main"), "matching branch stays visible");
+  const renderedNames = (html.match(/git-ui-branch-row-name">[^<]*/g) || []).join(" ");
+  assert.ok(!renderedNames.includes("feature-x"), "filtered rows hide non-matching branch");
+
+  // Switching to another local branch posts to /switch with the bare name.
+  const before = booted.calls.length;
+  await ui.switchFromBranchList(encodeURIComponent("main"), false);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const switchPosts = booted.calls.slice(before).filter((call) => call.path === "/api/git-ui/switch");
+  assert.equal(switchPosts.length, 1, "switch POST fired");
+  assert.equal(JSON.parse(switchPosts[0].init.body).branch, "main");
+  assert.ok(!String(ctxHtml(booted)).includes("git-ui-branch-list"), "list closes after switch");
+});
+
+test("branch chip shows a synced check when in sync with upstream", async () => {
+  const booted = await bootGitUi({
+    "/api/git-ui/status": { branch: "main", ahead: 0, behind: 0, staged: [], unstaged: [], untracked: [], conflicted: [], upstream: "origin/main" },
+    "/api/git-ui/diff": { files: [] },
+    "/api/git-ui/compare": { files: [] },
+    "/api/git-ui/log": { commits: [], lines: [], rows: [], has_more: false, limit: 80 },
+  });
+  await booted.ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
+  const html = String(ctxHtml(booted));
+  assert.match(html, /<b class="git-ui-chip-count synced" title="In sync with origin\/main">✓<\/b>/);
+});

--- a/src/assets/git_ui_behavior.test.mjs
+++ b/src/assets/git_ui_behavior.test.mjs
@@ -81,7 +81,17 @@ function context(fetchImpl) {
       execCommand: () => true,
       querySelector: () => element(),
       querySelectorAll: () => [],
-      getElementById: () => element(),
+      __panelHtml: "",
+      getElementById(id) {
+        const el = element();
+        if (id === "gitUiPanel") {
+          Object.defineProperty(el, "innerHTML", {
+            get() { return ctx.document.__panelHtml; },
+            set(value) { ctx.document.__panelHtml = String(value); },
+          });
+        }
+        return el;
+      },
       addEventListener() {},
     },
     localStorage: {
@@ -165,6 +175,12 @@ async function openedWithStatus(status) {
 function lastPostCall(calls, path) {
   const posts = calls.filter((call) => call.path === path);
   return posts[posts.length - 1] || null;
+}
+
+// The vm document stub captures the git panel's rendered HTML so tests can
+// assert on toolbar buttons and modal markup.
+function ctxHtml(booted) {
+  return (booted.ctx.document.__panelHtml || "");
 }
 
 test("folder context menu stages, unstages, and discards files under a directory", async () => {
@@ -344,4 +360,37 @@ test("folder mutations are hidden and refused outside the changes view", async (
   await ui.menuAction("stage");
   const staged = booted.calls.slice(before).filter((call) => call.path === "/api/git-ui/stage");
   assert.equal(staged.length, 0, "no stage POST may fire outside changes mode");
+});
+
+test("Update button fetch+ff from upstream and Pull modal default to update mode (GitHub flow)", async () => {
+  const booted = await openedWithStatus(emptyStatus());
+  const { ui, calls } = booted;
+
+  // The worktree toolbar exposes the dedicated Update button.
+  const html = String(ctxHtml(booted));
+  assert.match(html, /onclick="HerdrGitUi.updateFromUpstream\(\)">↓ Update<\/button>/);
+  assert.match(html, /title="Fetch and fast-forward from the upstream \(never creates a merge commit\)"/);
+
+  // Update posts mode=update with no branch (ff-only @{u}).
+  const before = calls.length;
+  await ui.updateFromUpstream();
+  const updateCall = lastPostCall(calls.slice(before), "/api/git-ui/pull") || lastPostCall(calls.slice(before).map(c => c), "/api/git-ui/pull");
+  const updatePosts = calls.slice(before).filter((call) => call.path === "/api/git-ui/pull");
+  assert.equal(updatePosts.length, 1, "exactly one pull POST fired");
+  assert.equal(JSON.parse(updatePosts[0].init.body).mode, "update");
+  assert.equal(JSON.parse(updatePosts[0].init.body).branch, undefined);
+
+  // Pull modal offers Update as the default mode and Rebase fetches main/master.
+  await ui.openPullModal();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const pullHtml = String(ctxHtml(booted));
+  assert.match(pullHtml, /<option value="update" selected>Update \(fetch \+ fast-forward\)<\/option>/);
+
+  await ui.closeGitOpModal();
+  await ui.rebase();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const rebaseHtml = String(ctxHtml(booted));
+  assert.match(rebaseHtml, /id="gitUiRebasePullFirst" type="checkbox" checked/);
+  assert.match(rebaseHtml, /Fetch selected branch \(and main\/master\) before rebasing onto origin/);
+  await ui.closeGitOpModal();
 });

--- a/src/git_ui/branch.rs
+++ b/src/git_ui/branch.rs
@@ -27,6 +27,25 @@ pub(super) struct GitUiBranchDeleteRequest {
     pub(super) confirmed: Option<bool>,
 }
 
+/// One git call per branch keeps this simple and correct; branch lists are
+/// small and the endpoint is invoked when the popover opens, not per render.
+fn branch_tip_details(cwd: &str, ref_name: &str) -> Option<String> {
+    git_ui_text(cwd, &["show", "-s", "--format=%an%x00%cI%x00%s", ref_name])
+        .ok()
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+/// Splits the NUL-delimited tip details into (author, ISO date, subject).
+/// Missing pieces come back as empty strings.
+fn split_branch_tip_details(details: &str) -> (String, String, String) {
+    let mut parts = details.splitn(3, '\0');
+    let author = parts.next().unwrap_or("").to_string();
+    let date = parts.next().unwrap_or("").to_string();
+    let subject = parts.next().unwrap_or("").to_string();
+    (author, date, subject)
+}
+
 fn git_ui_branches_blocking(cwd: String) -> Result<Response, (StatusCode, String)> {
     let worktree_paths = git_ui_text(&cwd, &["worktree", "list", "--porcelain"])
         .map(|raw| parse_worktree_branch_paths(&raw))
@@ -37,7 +56,22 @@ fn git_ui_branches_blocking(cwd: String) -> Result<Response, (StatusCode, String
     };
     let local_json = local
         .iter()
-        .map(|b| json!({ "name": b.name, "current": b.current, "remote": false, "worktree_path": worktree_paths.get(&b.name).cloned(), "pushed": b.pushed, "upstream": b.upstream.as_deref() }))
+        .map(|b| {
+            let tip = branch_tip_details(&cwd, &format!("refs/heads/{}", b.name));
+            let details = tip.as_deref().unwrap_or("");
+            let (author, date, subject) = split_branch_tip_details(details);
+            json!({
+                "name": b.name,
+                "current": b.current,
+                "remote": false,
+                "worktree_path": worktree_paths.get(&b.name).cloned(),
+                "pushed": b.pushed,
+                "upstream": b.upstream.as_deref(),
+                "author": author,
+                "date": date,
+                "subject": subject,
+            })
+        })
         .collect::<Vec<_>>();
     let remote_text = match git_ui_text(&cwd, &["branch", "-r", "--format=%(refname:short)"]) {
         Ok(text) => text,
@@ -51,7 +85,18 @@ fn git_ui_branches_blocking(cwd: String) -> Result<Response, (StatusCode, String
                 return None;
             }
             let local = local_branch_name_for_remote(name);
-            Some(json!({ "name": name, "current": false, "remote": true, "worktree_path": worktree_paths.get(local).cloned() }))
+            let tip = branch_tip_details(&cwd, &format!("refs/remotes/{name}"));
+            let details = tip.as_deref().unwrap_or("");
+            let (author, date, subject) = split_branch_tip_details(details);
+            Some(json!({
+                "name": name,
+                "current": false,
+                "remote": true,
+                "worktree_path": worktree_paths.get(local).cloned(),
+                "author": author,
+                "date": date,
+                "subject": subject,
+            }))
         })
         .collect::<Vec<_>>();
     let mut branches = local_json.clone();
@@ -84,6 +129,69 @@ pub(super) fn parse_worktree_branch_paths(raw: &str) -> HashMap<String, String> 
         }
     }
     paths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_branch_tip_details_parses_all_fields() {
+        let (author, date, subject) =
+            split_branch_tip_details("Ada\02026-09-01T10:00:00+02:00\0fix the thing");
+        assert_eq!(author, "Ada");
+        assert_eq!(date, "2026-09-01T10:00:00+02:00");
+        assert_eq!(subject, "fix the thing");
+        let (author, date, subject) = split_branch_tip_details("Ada");
+        assert_eq!(author, "Ada");
+        assert_eq!(date, "");
+        assert_eq!(subject, "");
+    }
+
+    #[test]
+    fn branches_payload_includes_author_and_date() {
+        let root =
+            std::env::temp_dir().join(format!("herdr-webui-branch-details-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["init", "-b", "main"])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        for args in [
+            ["config", "user.email", "t@t"],
+            ["config", "user.name", "T"],
+        ] {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(&args)
+                .output()
+                .unwrap();
+            assert!(out.status.success());
+        }
+        std::fs::write(root.join("a.txt"), "base\n").unwrap();
+        for args in [vec!["add", "-A"], vec!["commit", "-m", "hello"]] {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(out.status.success());
+        }
+        let details = branch_tip_details(root.to_str().unwrap(), "refs/heads/main");
+        assert!(details.is_some());
+        let (author, date, subject) = split_branch_tip_details(&details.unwrap());
+        assert_eq!(author, "T");
+        assert!(date.starts_with("20"), "date: {date}");
+        assert_eq!(subject, "hello");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }
 
 pub(super) async fn git_ui_branches(

--- a/src/git_ui/log.rs
+++ b/src/git_ui/log.rs
@@ -623,6 +623,48 @@ pub(super) async fn git_ui_pull(
     }
 }
 
+fn git_ui_fetch_blocking(
+    cwd: String,
+    branch: Option<String>,
+) -> Result<Response, (StatusCode, String)> {
+    let mut args = vec!["fetch".to_string(), "origin".to_string()];
+    if let Some(branch) = branch.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+        args.push(branch.to_string());
+    }
+    match git_ui_text_strings(&cwd, &args) {
+        Ok(text) => Ok(Json(json!({ "ok": true, "message": text })).into_response()),
+        Err(err) => Err((StatusCode::BAD_GATEWAY, err)),
+    }
+}
+
+pub(super) async fn git_ui_fetch(
+    State(state): State<WebState>,
+    headers: HeaderMap,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    Json(body): Json<GitUiPullPushRequest>,
+) -> Response {
+    if let Err(response) = require_auth(&state, &headers, remote) {
+        return response;
+    }
+    let branch = match body
+        .branch
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        Some(value) => match safe_git_token(value, "branch") {
+            Ok(v) => Some(v.to_string()),
+            Err(err) => return git_json_error(StatusCode::BAD_REQUEST, err),
+        },
+        None => None,
+    };
+    let cwd = body.cwd;
+    match tokio::task::spawn_blocking(move || git_ui_fetch_blocking(cwd, branch)).await {
+        Ok(Ok(response)) => response,
+        Ok(Err((status, msg))) => git_json_error(status, msg),
+        Err(err) => git_json_error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+    }
+}
+
 fn git_ui_push_blocking(
     cwd: String,
     mode: String,

--- a/src/git_ui/log.rs
+++ b/src/git_ui/log.rs
@@ -1011,6 +1011,11 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
 
         run_git(&root, &["init", "--bare", "origin.git"]);
+        // Pin the bare repo's HEAD to main: clones derive their initial
+        // branch from it, and git builds whose default is master (Homebrew
+        // git on CI runners, no init.defaultBranch configured) would
+        // otherwise check out master and break the main refspecs below.
+        run_git(&origin, &["symbolic-ref", "HEAD", "refs/heads/main"]);
         run_git(&root, &["init", "-b", "main", "work"]);
         run_git(&clone, &["config", "user.email", "t@t"]);
         run_git(&clone, &["config", "user.name", "T"]);
@@ -1086,6 +1091,9 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
 
         run_git(&root, &["init", "--bare", "origin.git"]);
+        // Pin the bare repo's HEAD to main (see the pull-update test above:
+        // clones derive their initial branch from it).
+        run_git(&origin, &["symbolic-ref", "HEAD", "refs/heads/main"]);
         run_git(&root, &["init", "-b", "main", "work"]);
         std::fs::write(clone.join("a.txt"), "base\n").unwrap();
         run_git(&clone, &["config", "user.email", "t@t"]);

--- a/src/git_ui/log.rs
+++ b/src/git_ui/log.rs
@@ -350,6 +350,26 @@ fn fetched_rebase_ref(ref_name: &str) -> String {
     }
 }
 
+/// Fetches the repo's default base branch (main or master, whichever
+/// exists as a remote-tracking ref) unless it was already fetched as the
+/// selected branch. Repos with neither are left untouched.
+fn fetch_default_base(cwd: &str) -> Result<(), (StatusCode, String)> {
+    for base in ["main", "master"] {
+        if git_ui_text(cwd, &["rev-parse", "--verify", &format!("origin/{base}")]).is_err() {
+            continue; // no such remote-tracking ref; try the next candidate
+        }
+        return git_ui_text(cwd, &["fetch", "origin", base])
+            .map(|_| ())
+            .map_err(|err| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    format!("fetch {base} failed:\n{err}"),
+                )
+            });
+    }
+    Ok(())
+}
+
 fn git_ui_rebase_blocking(
     cwd: String,
     upstream: String,
@@ -363,6 +383,10 @@ fn git_ui_rebase_blocking(
             Err(err) => return Err((StatusCode::BAD_REQUEST, err)),
         },
     };
+    // GitHub-flow rebase: when fetching, always refresh main/master too so
+    // the default base is never stale, and rebase onto the remote-tracking
+    // ref of the selected branch. Without fetching, keep the caller's ref
+    // exactly as given (local branch name or explicit origin/ ref).
     let rebase_onto = if pull_first {
         let fetch_branch = fetch_branch_name(&onto).to_string();
         git_ui_text(&cwd, &["fetch", "origin", &fetch_branch]).map_err(|err| {
@@ -371,6 +395,11 @@ fn git_ui_rebase_blocking(
                 format!("fetch selected branch failed:\n{err}"),
             )
         })?;
+        // GitHub-flow rebase: keep the default base fresh too. When the
+        // caller rebases onto something other than main/master, fetch the
+        // repo's default branch as well so the next "rebase onto main" is
+        // not based on a stale ref.
+        fetch_default_base(&cwd)?;
         fetched_rebase_ref(&onto)
     } else {
         onto.clone()
@@ -526,6 +555,26 @@ fn git_ui_pull_blocking(
     mode: String,
     branch: Option<String>,
 ) -> Result<Response, (StatusCode, String)> {
+    if mode == "update" {
+        // GitHub-flow update: fetch everything, then fast-forward the
+        // current branch only. Never creates a merge commit.
+        git_ui_text_strings(&cwd, &["fetch".to_string(), "origin".to_string()]).map_err(|err| {
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("fetch origin failed:\n{err}"),
+            )
+        })?;
+        let mut args = vec!["merge".to_string(), "--ff-only".to_string()];
+        if let Some(branch) = branch.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+            args.push(format!("origin/{branch}"));
+        } else {
+            args.push("@{u}".to_string());
+        }
+        return match git_ui_text_strings(&cwd, &args) {
+            Ok(text) => Ok(Json(json!({ "ok": true, "message": text })).into_response()),
+            Err(err) => Err((StatusCode::BAD_GATEWAY, err)),
+        };
+    }
     let mut args = vec!["pull".to_string()];
     match mode.as_str() {
         "regular" => {}
@@ -894,6 +943,7 @@ mod tests {
 
     #[test]
     fn rebase_pull_first_fetches_branch_and_rebases_onto_remote_tracking_ref() {
+        // (kept: unit expectations for fetch/ref naming helpers)
         assert_eq!(fetch_branch_name("master"), "master");
         assert_eq!(fetched_rebase_ref("master"), "origin/master");
         assert_eq!(fetch_branch_name("origin/master"), "master");
@@ -904,5 +954,147 @@ mod tests {
             fetched_rebase_ref("refs/remotes/origin/master"),
             "refs/remotes/origin/master"
         );
+    }
+
+    #[tokio::test]
+    async fn pull_update_mode_fetches_and_fast_forwards_without_merge_commit() {
+        // GitHub-flow update: after the remote advances, mode=update must
+        // fast-forward the local branch and leave a linear history (no merge
+        // commit). With no divergence it is a pure ff.
+        let root =
+            std::env::temp_dir().join(format!("herdr-webui-pull-update-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let origin = root.join("origin.git");
+        let clone = root.join("work");
+        std::fs::create_dir_all(&root).unwrap();
+
+        run_git(&root, &["init", "--bare", "origin.git"]);
+        run_git(&root, &["init", "-b", "main", "work"]);
+        run_git(&clone, &["config", "user.email", "t@t"]);
+        run_git(&clone, &["config", "user.name", "T"]);
+        std::fs::write(clone.join("a.txt"), "base\n").unwrap();
+        run_git(&clone, &["add", "-A"]);
+        run_git(&clone, &["commit", "-m", "base"]);
+        run_git(
+            &clone,
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+        );
+        run_git(&clone, &["push", "-u", "origin", "main"]);
+
+        // Remote advances behind the clone's back.
+        let other = root.join("other");
+        run_git(&root, &["clone", origin.to_str().unwrap(), "other"]);
+        run_git(&other, &["config", "user.email", "t@t"]);
+        run_git(&other, &["config", "user.name", "T"]);
+        std::fs::write(other.join("b.txt"), "advance\n").unwrap();
+        run_git(&other, &["add", "-A"]);
+        run_git(&other, &["commit", "-m", "advance main"]);
+        run_git(&other, &["push", "origin", "main"]);
+
+        let response = git_ui_pull_blocking(
+            clone.to_string_lossy().to_string(),
+            "update".to_string(),
+            None,
+        )
+        .expect("update pull should succeed");
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(payload["ok"], serde_json::json!(true));
+
+        // Local main now equals remote main, linear history.
+        let count = git_text(&clone, &["rev-list", "--count", "origin/main..main"]);
+        assert_eq!(count.trim(), "0");
+        let parents = git_text(&clone, &["rev-list", "--merges", "-1", "main"]);
+        assert_eq!(parents.trim(), "", "update must not create merge commits");
+
+        // True divergence: local commits AND remote advances from the same
+        // base. Update must refuse (ff-only) instead of merging or rewriting.
+        std::fs::write(clone.join("c.txt"), "local\n").unwrap();
+        run_git(&clone, &["add", "-A"]);
+        run_git(&clone, &["commit", "-m", "local work"]);
+        std::fs::write(other.join("d.txt"), "remote\n").unwrap();
+        run_git(&other, &["add", "-A"]);
+        run_git(&other, &["commit", "-m", "remote work"]);
+        run_git(&other, &["push", "origin", "main"]);
+        let result = git_ui_pull_blocking(
+            clone.to_string_lossy().to_string(),
+            "update".to_string(),
+            None,
+        );
+        assert!(result.is_err(), "diverged update must fail, not merge");
+        // Nothing merged behind the error.
+        let merges = git_text(&clone, &["rev-list", "--merges", "-1", "main"]);
+        assert_eq!(merges.trim(), "", "no merge commit may appear");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn rebase_pull_first_fetches_main_alongside_selected_branch() {
+        // Real repo with a local "origin": main advances on the remote after
+        // the feature branch is created. Rebase with pull_first=true must
+        // rebase onto the FETCHED origin/main, not the stale local main.
+        let root =
+            std::env::temp_dir().join(format!("herdr-webui-rebase-gh-flow-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let origin = root.join("origin.git");
+        let clone = root.join("work");
+        std::fs::create_dir_all(&root).unwrap();
+
+        run_git(&root, &["init", "--bare", "origin.git"]);
+        run_git(&root, &["init", "-b", "main", "work"]);
+        std::fs::write(clone.join("a.txt"), "base\n").unwrap();
+        run_git(&clone, &["config", "user.email", "t@t"]);
+        run_git(&clone, &["config", "user.name", "T"]);
+        run_git(&clone, &["add", "-A"]);
+        run_git(&clone, &["commit", "-m", "base"]);
+        run_git(
+            &clone,
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+        );
+        run_git(&clone, &["push", "-u", "origin", "main"]);
+
+        // Feature branch with its own commit.
+        run_git(&clone, &["checkout", "-b", "feature"]);
+        std::fs::write(clone.join("f.txt"), "feature\n").unwrap();
+        run_git(&clone, &["add", "-A"]);
+        run_git(&clone, &["commit", "-m", "feature"]);
+
+        // Remote main advances behind the clone's back.
+        let other = root.join("other");
+        run_git(&root, &["clone", origin.to_str().unwrap(), "other"]);
+        run_git(&other, &["config", "user.email", "t@t"]);
+        run_git(&other, &["config", "user.name", "T"]);
+        std::fs::write(other.join("b.txt"), "advance\n").unwrap();
+        run_git(&other, &["add", "-A"]);
+        run_git(&other, &["commit", "-m", "advance main"]);
+        run_git(&other, &["push", "origin", "main"]);
+
+        // Rebase feature onto main with fetch: backend fetches origin/main
+        // (the default base), then rebases onto origin/main.
+        let response = git_ui_rebase_blocking(
+            clone.to_string_lossy().to_string(),
+            "main".to_string(),
+            None,
+            true,
+        )
+        .expect("rebase should succeed");
+        let bytes = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(payload["onto"], serde_json::json!("origin/main"));
+
+        // The feature commit now sits on top of the advanced remote main.
+        let log = git_text(&clone, &["log", "--oneline", "origin/main..HEAD"]);
+        assert_eq!(log.lines().count(), 1, "only the feature commit on top");
+        assert!(log.contains("feature"), "log: {log}");
+        // And origin/main contains the advanced commit.
+        let main_log = git_text(&clone, &["log", "--oneline", "-1", "origin/main"]);
+        assert!(main_log.contains("advance main"), "log: {main_log}");
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/git_ui/mod.rs
+++ b/src/git_ui/mod.rs
@@ -73,6 +73,7 @@ pub(crate) fn routes() -> Router<WebState> {
         .route("/api/git-ui/switch", post(branch::git_ui_switch))
         .route("/api/git-ui/reset", post(log::git_ui_reset))
         .route("/api/git-ui/rebase", post(log::git_ui_rebase))
+        .route("/api/git-ui/fetch", post(log::git_ui_fetch))
         .route("/api/git-ui/pull", post(log::git_ui_pull))
         .route("/api/git-ui/push", post(log::git_ui_push))
         .route("/api/git-ui/commit", post(log::git_ui_commit))

--- a/src/main.rs
+++ b/src/main.rs
@@ -4362,16 +4362,29 @@ mod tests {
             .unwrap_or_else(|poison| poison.into_inner())
     }
 
+    /// Monotonic suffix for fake-socket names. Timestamps alone can collide
+    /// when parallel tests start within the same clock tick on loaded CI
+    /// runners; a collision makes the second create clobber the first
+    /// listener and the first accept() fail (observed as flaky 502s in
+    /// proxy tests that never fail locally).
+    fn fake_socket_suffix() -> u64 {
+        static COUNTER: OnceLock<std::sync::atomic::AtomicU64> = OnceLock::new();
+        COUNTER
+            .get_or_init(|| std::sync::atomic::AtomicU64::new(0))
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
     #[cfg(unix)]
     fn fake_api_socket(response: serde_json::Value) -> (PathBuf, thread::JoinHandle<()>) {
         use interprocess::local_socket::{prelude::*, GenericFilePath, ListenerOptions};
 
         let path = std::env::temp_dir().join(format!(
-            "herdr-webui-api-test-{}.sock",
+            "herdr-webui-api-test-{}-{}.sock",
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            fake_socket_suffix()
         ));
         let _ = fs::remove_file(&path);
         let name = path.clone().to_fs_name::<GenericFilePath>().unwrap();
@@ -6757,11 +6770,12 @@ mod tests {
         use interprocess::local_socket::{prelude::*, GenericFilePath, ListenerOptions};
 
         let path = std::env::temp_dir().join(format!(
-            "herdr-webui-test-{}.sock",
+            "herdr-webui-test-{}-{}.sock",
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            fake_socket_suffix()
         ));
         let _ = fs::remove_file(&path);
         let name = path.clone().to_fs_name::<GenericFilePath>().unwrap();
@@ -6796,11 +6810,12 @@ mod tests {
         use interprocess::local_socket::{prelude::*, GenericFilePath, ListenerOptions};
 
         let path = std::env::temp_dir().join(format!(
-            "herdr-webui-multi-test-{}.sock",
+            "herdr-webui-multi-test-{}-{}.sock",
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
-                .as_nanos()
+                .as_nanos(),
+            fake_socket_suffix()
         ));
         let _ = fs::remove_file(&path);
         let name = path.clone().to_fs_name::<GenericFilePath>().unwrap();


### PR DESCRIPTION
## Summary

Two commits fixing the GitHub flow end to end:

**1. Rebase fetches fresh base + Update pull mode + Update button** (340f10a)
- Rebase with fetch now also refreshes the repo's default base branch (origin/main or origin/master), so rebasing onto a feature branch no longer leaves the default base stale for the next operation.
- New pull update mode: fetch origin + merge --ff-only @{u}. Never creates merge commits, refuses true divergence instead of merging. The Pull modal lists it first as "Update (fetch + fast-forward)".
- The worktree toolbar gets a dedicated Update button for the common git pull --ff-only case.

**2. Git header rework: branch chip, dropdown and branch list** (92cb8ca)
- Branch info and actions live in one place. A right-justified branch chip shows the current branch with live sync state (down/up counts when diverged from upstream, a check when in sync) and opens a filterable branch list popover: local then remote; each row shows tip author and relative time with the exact timestamp and commit subject on hover. Switching from a remote row strips origin/ and creates the local branch.
- Pull became a split button whose caret opens a dropdown: Fetch, Fetch from..., Pull, Pull (Rebase), Push, Push to..., Force Push. All wired to real flows.
- New /api/git-ui/fetch endpoint (origin or a given branch); branches payload now carries tip author/date/subject via git show -s (NUL-separated, split in Rust).

## Verification

- Rust: real-repo integration tests. Rebase uses the freshly fetched origin/main after the remote advanced; update fast-forwards linearly then refuses on true divergence. 384 pass, fmt clean, clippy 0.
- JS vm tests: chip sync states, dropdown entries, fetch payload, Update button/payload, modal defaults, list rendering/filter/switch payloads. 429 pass.
- Real-backend git e2e grew from 8 to 34 checks, all passing: chip markup from real status, menu wiring, real fetch against a bare origin, branch payload fields from real git, popover rendering, filter behavior, and a real checkout round trip (switch to feature-lane and back) on a clean clone.
- All six real-browser suites green: acceptance 28/28, git 34/34, content-search, LSP, mobile 52/52, theme 15/15.

Release note added under 0.4.7.
