### PR TITLE
install/update commands also install the sibling herdr-webui-tui

### DIFF
--- a/.github/workflows/webui-release.yml
+++ b/.github/workflows/webui-release.yml
@@ -62,10 +62,10 @@ jobs:
           chmod 755 dist/${{ matrix.artifact }}/herdr-webui
           chmod 755 dist/${{ matrix.artifact }}/herdr-webui-tui
           cat > dist/${{ matrix.artifact }}/README.txt <<'EOF'
-          Install:
+          Install (also installs herdr-webui-tui into ~/.local/bin):
             ./herdr-webui install-mac
 
-          Update existing LaunchAgent install:
+          Update existing LaunchAgent install (refreshes both binaries):
             ./herdr-webui update-mac
 
           Uninstall LaunchAgent:
@@ -134,6 +134,12 @@ jobs:
 
           Local development auth bypass:
             HERDR_WEB_LOCALHOST_NO_AUTH=true ./herdr-webui --bind 127.0.0.1:8787
+
+          Install as user service (also installs herdr-webui-tui into ~/.local/bin):
+            ./herdr-webui install-linux
+
+          Update existing install (refreshes both binaries):
+            ./herdr-webui update-linux
 
           Terminal UI:
             ./herdr-webui-tui --summary

--- a/docs/features.md
+++ b/docs/features.md
@@ -80,7 +80,7 @@ Browser terminal shortcuts:
 
 Terminal UI:
 
-- `herdr-webui-tui` ships as a second binary beside `herdr-webui`. `make install-mac`, `make update-mac`, `make install-linux`, and `make update-linux` install both binaries into `~/.local/bin` by default.
+- `herdr-webui-tui` ships as a second binary beside `herdr-webui`. `make install-mac`, `make update-mac`, `make install-linux`, and `make update-linux` install both binaries into `~/.local/bin` by default. The built-in `herdr-webui install-mac`/`update-mac`/`install-linux`/`update-linux` commands also install the TUI when it sits next to the main binary (the release tarball layout).
 - The TUI uses the reusable `backend_client` layer and the built-in control/terminal sockets. It does not import browser code or built-in backend internals.
 - Summary modes are available for smoke checks: `herdr-webui-tui --summary` prints backend/session counts, and `herdr-webui-tui --once` prints a text snapshot plus selected pane output.
 - Interactive mode supports workspace/agent navigation, selected-pane attach, live terminal output, keyboard input, paste, resize, detach, refresh, and a Ctrl-B help/menu overlay.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -199,6 +199,11 @@ Release binaries can install themselves too:
 ./herdr-webui install-linux
 ```
 
+Both the Makefile targets and the release-binary commands install the two
+binaries into `~/.local/bin`: `herdr-webui` and `herdr-webui-tui` (when the
+TUI sits next to `herdr-webui`, as in the release tarball). Nothing is
+embedded in the main binary.
+
 For macOS service troubleshooting:
 
 ```sh
@@ -211,6 +216,13 @@ Update installed binary and restart service:
 ```sh
 make update-mac
 make update-linux
+```
+
+The release-binary equivalents refresh both binaries:
+
+```sh
+./herdr-webui update-mac
+./herdr-webui update-linux
 ```
 
 The install and update targets build with `cargo build --release --bins` and install both `herdr-webui` and `herdr-webui-tui` into `~/.local/bin` unless `LOCAL_BIN_DIR` is overridden.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## 0.4.8 Release Notes
+- `herdr-webui install-mac`, `update-mac`, `install-linux`, and
+  `update-linux` now also install the `herdr-webui-tui` binary into
+  `~/.local/bin` when it sits next to the running `herdr-webui` binary
+  (the release tarball layout), so the built-in install/update commands
+  keep both binaries in sync. The TUI remains a separate binary: nothing
+  is embedded in the main executable, and installs from a bare main
+  binary (no sibling TUI) behave exactly as before.
+
 ## 0.4.7 Release Notes
 - Open desktop files now detect external changes: on window refocus the
   browser cheaply re-hashes clean tabs via a new hash_only endpoint and

--- a/src/service.rs
+++ b/src/service.rs
@@ -12,6 +12,9 @@ pub fn install_macos(config: WebConfig) -> io::Result<()> {
     let service = mac_service_target();
     log_macos_context("install", Some(&plist));
     let install_bin = copy_current_exe_to_install_path()?;
+    if let Some(tui_bin) = copy_sibling_tui_to_install_path(std::env::current_exe()?.parent())? {
+        println!("Installed TUI binary at {}", tui_bin.display());
+    }
     fs::create_dir_all(plist.parent().expect("plist has parent"))?;
     fs::create_dir_all(mac_log_dir()?)?;
     fs::write(&plist, mac_plist_xml(&config, &install_bin)?)?;
@@ -29,6 +32,9 @@ pub fn update_macos() -> io::Result<()> {
     ensure_macos_user_context()?;
     log_macos_context("update", mac_plist_path().ok().as_deref());
     let install_bin = copy_current_exe_to_install_path()?;
+    if let Some(tui_bin) = copy_sibling_tui_to_install_path(std::env::current_exe()?.parent())? {
+        println!("Updated TUI binary at {}", tui_bin.display());
+    }
     restart_macos_service()?;
     println!("Updated binary at {}", install_bin.display());
     Ok(())
@@ -85,6 +91,9 @@ pub fn uninstall_macos() -> io::Result<()> {
 
 pub fn install_linux(config: WebConfig) -> io::Result<()> {
     let install_bin = copy_current_exe_to_install_path()?;
+    if let Some(tui_bin) = copy_sibling_tui_to_install_path(std::env::current_exe()?.parent())? {
+        println!("Installed TUI binary at {}", tui_bin.display());
+    }
     let service = linux_service_path()?;
     fs::create_dir_all(service.parent().expect("service path has parent"))?;
     fs::write(&service, linux_service_unit(&config, &install_bin))?;
@@ -98,6 +107,9 @@ pub fn install_linux(config: WebConfig) -> io::Result<()> {
 
 pub fn update_linux() -> io::Result<()> {
     let install_bin = copy_current_exe_to_install_path()?;
+    if let Some(tui_bin) = copy_sibling_tui_to_install_path(std::env::current_exe()?.parent())? {
+        println!("Updated TUI binary at {}", tui_bin.display());
+    }
     systemctl_user(&["daemon-reload"])?;
     restart_linux_service()?;
     println!("Updated binary at {}", install_bin.display());
@@ -175,22 +187,45 @@ fn install_bin_path() -> io::Result<PathBuf> {
 
 fn copy_current_exe_to_install_path() -> io::Result<PathBuf> {
     let source = std::env::current_exe()?;
-    let target = install_bin_path()?;
+    copy_executable(&source, &install_bin_path()?)
+}
+
+fn tui_install_bin_path() -> io::Result<PathBuf> {
+    Ok(local_bin_dir()?.join("herdr-webui-tui"))
+}
+
+/// Copy the `herdr-webui-tui` binary sitting next to the running main
+/// binary (the release tarball layout) into `~/.local/bin`. Returns `None`
+/// when no sibling TUI exists, so Makefile/standalone installs behave
+/// exactly as before. The TUI stays a separate binary: nothing is embedded
+/// in the main executable.
+fn copy_sibling_tui_to_install_path(source_dir: Option<&Path>) -> io::Result<Option<PathBuf>> {
+    let Some(source_dir) = source_dir else {
+        return Ok(None);
+    };
+    let source = source_dir.join("herdr-webui-tui");
+    if !source.exists() {
+        return Ok(None);
+    }
+    Ok(Some(copy_executable(&source, &tui_install_bin_path()?)?))
+}
+
+fn copy_executable(source: &Path, target: &Path) -> io::Result<PathBuf> {
     if let Some(parent) = target.parent() {
         fs::create_dir_all(parent)?;
     }
     let same_file = source.canonicalize().ok() == target.canonicalize().ok();
     if !same_file {
-        fs::copy(&source, &target)?;
+        fs::copy(source, target)?;
     }
-    let mut permissions = fs::metadata(&target)?.permissions();
+    let mut permissions = fs::metadata(target)?.permissions();
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         permissions.set_mode(0o755);
     }
-    fs::set_permissions(&target, permissions)?;
-    Ok(target)
+    fs::set_permissions(target, permissions)?;
+    Ok(target.to_path_buf())
 }
 
 fn mac_plist_path() -> io::Result<PathBuf> {
@@ -681,5 +716,96 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn copy_executable_copies_content_and_sets_mode() {
+        let _guard = env_lock().lock().unwrap();
+        let base =
+            std::env::temp_dir().join(format!("herdr-webui-copy-exe-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        let source = base.join("herdr-webui-tui");
+        fs::write(&source, "tui-bytes\n").unwrap();
+
+        let target_dir = base.join("local").join("bin");
+        let target = copy_executable(&source, &target_dir.join("herdr-webui-tui")).unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "tui-bytes\n");
+        assert!(target_dir.exists(), "target parent is created");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&target).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o755);
+        }
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn copy_sibling_tui_installs_present_binary_and_skips_missing() {
+        let _guard = env_lock().lock().unwrap();
+        let original_home = std::env::var_os("HOME");
+        let home = std::env::temp_dir().join(format!(
+            "herdr-webui-sibling-tui-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(&home).unwrap();
+        std::env::set_var("HOME", &home);
+
+        // No sibling next to the exe dir -> None, no ~/.local/bin created.
+        let empty_dir = home.join("dist");
+        fs::create_dir_all(&empty_dir).unwrap();
+        assert_eq!(
+            copy_sibling_tui_to_install_path(Some(&empty_dir)).unwrap(),
+            None
+        );
+        assert!(!home.join(".local").join("bin").exists());
+
+        // Sibling present -> copied to ~/.local/bin/herdr-webui-tui.
+        let release_dir = home.join("release");
+        fs::create_dir_all(&release_dir).unwrap();
+        fs::write(release_dir.join("herdr-webui-tui"), "new-tui\n").unwrap();
+        let installed = copy_sibling_tui_to_install_path(Some(&release_dir))
+            .unwrap()
+            .expect("sibling tui is installed");
+        assert_eq!(
+            installed,
+            home.join(".local").join("bin").join("herdr-webui-tui")
+        );
+        assert_eq!(
+            fs::read_to_string(&installed).unwrap(),
+            "new-tui\n",
+            "installed copy holds the sibling bytes"
+        );
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn tui_install_path_targets_local_bin() {
+        let _guard = env_lock().lock().unwrap();
+        let original_home = std::env::var_os("HOME");
+        let home =
+            std::env::temp_dir().join(format!("herdr-webui-tui-path-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(&home).unwrap();
+        std::env::set_var("HOME", &home);
+
+        assert_eq!(
+            tui_install_bin_path().unwrap(),
+            home.join(".local").join("bin").join("herdr-webui-tui")
+        );
+
+        match original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+        let _ = fs::remove_dir_all(&home);
     }
 }


### PR DESCRIPTION
## Summary
- `herdr-webui install-mac`/`update-mac`/`install-linux`/`update-linux` now also install the `herdr-webui-tui` binary into `~/.local/bin` when it sits next to the running main binary (the release tarball layout), keeping both binaries in sync.
- The TUI remains a separate binary: nothing is embedded in the main executable (size/memory unchanged). Installs from a bare main binary behave exactly as before.
- The tui copy happens before the service restart, so a restart failure cannot strand a mismatched tui.
- Release tarball READMEs in the workflow now mention that install/update handle both binaries; docs (features, installation) updated; release notes entry added under 0.4.8.

## Verification
- New unit tests: `copy_executable` (content, parent creation, 0755 mode), sibling copy (present -> installed, missing -> None with no `~/.local/bin` created), tui install path. Service tests 9/9, 6 consecutive runs.
- Real flow: built release binaries, simulated tarball layout, ran `./herdr-webui update-mac` with a scratch HOME — tui landed in `~/.local/bin` byte-identical (cmp), mode 755; bare binary without a sibling installed only the main binary.
- `cargo test`: 387 passed (37 + 345 + 5). `node --test`: 429 passed. `cargo fmt --check` clean. Clippy: 0 new warnings (7 pre-existing remain).
