### PR TITLE
git-ui: Zed-style branch selector and status split button

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,18 @@
   keep both binaries in sync. The TUI remains a separate binary: nothing
   is embedded in the main executable, and installs from a bare main
   binary (no sibling TUI) behave exactly as before.
+- Zed-style Git branch selector: the desktop Git header now puts the branch
+  chip left (next to Commit, showing just the branch name) and a status
+  split button right. The status label reflects the sync state — Pull ↓N
+  when behind, Push ↑N when ahead, plain Fetch otherwise — and its ▾
+  dropdown holds exactly seven git-flow actions: Fetch, Fetch From, Pull,
+  Pull (rebase), Push, Push to, Force push. The old Update/split/Rebase/
+  Reset toolbar buttons are gone. The branch list popover gains two-line
+  rows (branch name, then author · relative time), the current branch
+  pinned with a ✓ at the top of the local section, a filter input at the
+  bottom, a scroll area sized for seven rows, and a trash icon on row
+  hover that deletes a local branch through the existing branch-delete
+  endpoint (remote branches and the checked-out branch are refused).
 
 ## 0.4.7 Release Notes
 - Open desktop files now detect external changes: on window refocus the

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,13 +1,6 @@
 # Release notes
 
-## 0.4.8 Release Notes
-- `herdr-webui install-mac`, `update-mac`, `install-linux`, and
-  `update-linux` now also install the `herdr-webui-tui` binary into
-  `~/.local/bin` when it sits next to the running `herdr-webui` binary
-  (the release tarball layout), so the built-in install/update commands
-  keep both binaries in sync. The TUI remains a separate binary: nothing
-  is embedded in the main executable, and installs from a bare main
-  binary (no sibling TUI) behave exactly as before.
+## 0.4.10 Release Notes
 - Zed-style Git branch selector: the desktop Git header now puts the branch
   chip left (next to Commit, showing just the branch name) and a status
   split button right. The status label reflects the sync state — Pull ↓N
@@ -20,6 +13,15 @@
   bottom, a scroll area sized for seven rows, and a trash icon on row
   hover that deletes a local branch through the existing branch-delete
   endpoint (remote branches and the checked-out branch are refused).
+
+## 0.4.8 Release Notes
+- `herdr-webui install-mac`, `update-mac`, `install-linux`, and
+  `update-linux` now also install the `herdr-webui-tui` binary into
+  `~/.local/bin` when it sits next to the running `herdr-webui` binary
+  (the release tarball layout), so the built-in install/update commands
+  keep both binaries in sync. The TUI remains a separate binary: nothing
+  is embedded in the main executable, and installs from a bare main
+  binary (no sibling TUI) behave exactly as before.
 
 ## 0.4.7 Release Notes
 - Open desktop files now detect external changes: on window refocus the

--- a/scripts/e2e/git-acceptance.mjs
+++ b/scripts/e2e/git-acceptance.mjs
@@ -198,20 +198,27 @@ assert(/herdr-tree-row dir/.test(html), "changes tree renders a dir row for scra
 assert(!/title="scratchdir\/"/.test(html), "no phantom file row for scratchdir/");
 assert(/fileMenu\(event,'scratchdir'[^)]*,'dir'\)/.test(html), "dir row wires the dir context menu kind");
 
-// 6. Header rework: the branch chip renders with the current branch and a
-// caret for the pull/fetch dropdown.
+// 6. Header rework: the branch chip renders left-justified with the current
+// branch, and the right side carries the status split button (Fetch, or
+// Pull ↓N / Push ↑N when diverged).
 const chipRes = await httpsJson(`${ORIGIN}/api/git-ui/status?cwd=${encodeURIComponent(REPO)}`);
 const chipStatus = await chipRes.json();
 const panelHtml = () => ctx.document.__panelHtml || "";
 let headerHtml = panelHtml();
 assert(/git-ui-branch-chip/.test(headerHtml), "branch chip rendered in header");
 assert(new RegExp(`git-ui-branch-chip-name">${chipStatus.branch}</span>`).test(headerHtml), `chip shows the real branch name (${chipStatus.branch})`);
+assert(new RegExp(`git-ui-branch-chip-name">${chipStatus.branch}</span><b class="git-ui-chip-caret">`).test(headerHtml), "chip label sits left of the caret with no sync badges");
+assert(/git-ui-status-label/.test(headerHtml), "status split button rendered on the right");
+assert(/git-ui-status-caret/.test(headerHtml), "status dropdown caret rendered");
 
-// 7. The dropdown menu exposes every git-flow action.
+// 7. The dropdown menu exposes exactly the seven git-flow actions.
 ui.toggleHeaderMenu({ stopPropagation() {}, currentTarget: { getBoundingClientRect: () => ({ left: 12, bottom: 40 }) }, clientX: 12, clientY: 40 });
 headerHtml = panelHtml();
+const menuChunk = (headerHtml.match(/git-ui-header-menu" style[^>]*>[\s\S]*?<\/div>/) || [""])[0];
+const menuLabels = (menuChunk.match(/<button onclick="[^"]*">[^<]+/g) || []).map((chunk) => chunk.replace(/^<button onclick="[^"]*">/, ""));
+assert.deepEqual(menuLabels, ["Fetch", "Fetch From", "Pull", "Pull (rebase)", "Push", "Push to", "Force push"], "menu offers exactly the seven Zed actions");
 for (const method of ["fetchOrigin", "openFetchFromModal", "openPullModal", "pullWithRebase", "openPushModal", "openPushToModal", "openForcePushModal"]) {
-  assert(new RegExp(`HerdrGitUi\\.${method}\\(\\)`).test(headerHtml), `header menu wires ${method}`);
+  assert(new RegExp(`HerdrGitUi\\.${method}\\(\\)`).test(menuChunk), `header menu wires ${method}`);
 }
 ui.toggleHeaderMenu({ stopPropagation() {}, currentTarget: { getBoundingClientRect: () => ({ left: 12, bottom: 40 }) }, clientX: 12, clientY: 40 });
 

--- a/scripts/e2e/git-acceptance.mjs
+++ b/scripts/e2e/git-acceptance.mjs
@@ -216,7 +216,8 @@ ui.toggleHeaderMenu({ stopPropagation() {}, currentTarget: { getBoundingClientRe
 headerHtml = panelHtml();
 const menuChunk = (headerHtml.match(/git-ui-header-menu" style[^>]*>[\s\S]*?<\/div>/) || [""])[0];
 const menuLabels = (menuChunk.match(/<button onclick="[^"]*">[^<]+/g) || []).map((chunk) => chunk.replace(/^<button onclick="[^"]*">/, ""));
-assert.deepEqual(menuLabels, ["Fetch", "Fetch From", "Pull", "Pull (rebase)", "Push", "Push to", "Force push"], "menu offers exactly the seven Zed actions");
+const expectedLabels = ["Fetch", "Fetch From", "Pull", "Pull (rebase)", "Push", "Push to", "Force push"];
+assert(JSON.stringify(menuLabels) === JSON.stringify(expectedLabels), `menu offers exactly the seven Zed actions (${menuLabels.join(", ")})`);
 for (const method of ["fetchOrigin", "openFetchFromModal", "openPullModal", "pullWithRebase", "openPushModal", "openPushToModal", "openForcePushModal"]) {
   assert(new RegExp(`HerdrGitUi\\.${method}\\(\\)`).test(menuChunk), `header menu wires ${method}`);
 }

--- a/src/assets/desktop/git_ui.js
+++ b/src/assets/desktop/git_ui.js
@@ -1524,35 +1524,11 @@
     return "";
   }
 
-  function aheadBehindHint(s) {
-    const ahead = Number(s.ahead) || 0;
-    const behind = Number(s.behind) || 0;
-    const upstream = String(s.upstream || "").trim();
-    if (!upstream) return "";
-    const parts = [];
-    if (ahead > 0) parts.push(`ahead ${ahead} (local has commits not on ${upstream})`);
-    if (behind > 0) parts.push(`behind ${behind} (${upstream} has commits not on local)`);
-    if (!parts.length) parts.push(`in sync with ${upstream}`);
-    return parts.join(" · ");
-  }
-
-  function renderAheadBehind(s, esc) {
-    const upstream = String(s.upstream || "").trim();
-    if (!upstream) return "";
-    const ahead = Number(s.ahead) || 0;
-    const behind = Number(s.behind) || 0;
-    const title = aheadBehindHint(s);
-    const badges = [];
-    if (ahead > 0) badges.push(`<span class="git-ui-ahead-behind ahead" title="${esc(title)}">↑${esc(String(ahead))}</span>`);
-    if (behind > 0) badges.push(`<span class="git-ui-ahead-behind behind" title="${esc(title)}">↓${esc(String(behind))}</span>`);
-    if (!badges.length) badges.push(`<span class="git-ui-ahead-behind synced" title="${esc(title)}">✓</span>`);
-    return `<span class="git-ui-ahead-behind-group" title="${esc(title)}">${badges.join("")}</span>`;
-  }
-
-  // ── Worktree actions row (GitHub-flow header rework) ─────────────────
-  // Branch chip lives here, right-justified: name (opens the branch list),
-  // sync arrows with counts when diverged, Fetch when in sync, and a
-  // pull/fetch dropdown triangle.
+  // ── Worktree actions row (Zed-style selector rework) ─────────────────
+  // Branch chip left-justified next to Commit: just the name (opens the
+  // branch list popover). Status split button right-justified: Pull ↓N
+  // when behind, Push ↑N when ahead, plain Fetch when in sync; the ▾
+  // triangle opens the git-flow menu.
   function renderWorktreeActions(ctx) {
     const s = ctx.s || {};
     const esc = ctx.esc;
@@ -1561,31 +1537,44 @@
     const branch = String(s.branch || "");
     const ahead = Number(s.ahead) || 0;
     const behind = Number(s.behind) || 0;
-    const diverged = ahead > 0 || behind > 0;
     const upstream = String(s.upstream || "").trim();
-    const syncBadge = upstream
-      ? diverged
-        ? `${behind > 0 ? `<b class="git-ui-chip-count behind" title="${esc(aheadBehindHint(s))}">↓${behind}</b>` : ""}${ahead > 0 ? `<b class="git-ui-chip-count ahead" title="${esc(aheadBehindHint(s))}">↑${ahead}</b>` : ""}`
-        : `<b class="git-ui-chip-count synced" title="In sync with ${esc(upstream)}">✓</b>`
-      : "";
     const chip = branch
-      ? `<button class="git-ui-branch-chip" title="${esc(titleWithGitShortcut("Switch branch", "branch"))}" onclick="HerdrGitUi.openBranchList(event)"><span class="git-ui-branch-chip-name">${esc(branch)}</span>${syncBadge}<b class="git-ui-chip-caret">▾</b></button>`
+      ? `<button class="git-ui-branch-chip" title="${esc(titleWithGitShortcut("Switch branch", "branch"))}" onclick="HerdrGitUi.openBranchList(event)"><span class="git-ui-branch-chip-name">${esc(branch)}</span><b class="git-ui-chip-caret">▾</b></button>`
       : "";
-    return `<div class="git-ui-toolbar git-ui-worktree-row"><div class="git-ui-actions git-ui-worktree-left"><button class="git-ui-btn primary" title="${esc(commitHint)}" onclick="HerdrGitUi.openCommitModal()"${commitDisabled}>Commit</button><button class="git-ui-btn" title="Fetch and fast-forward from the upstream (never creates a merge commit)" onclick="HerdrGitUi.updateFromUpstream()">↓ Update</button><button class="git-ui-btn git-ui-split" title="Pull, fetch and push options" aria-haspopup="menu" aria-expanded="${state.headerMenu ? "true" : "false"}" onclick="HerdrGitUi.toggleHeaderMenu(event)"><span>↓ Pull</span><b class="git-ui-chip-caret">▾</b></button><button class="git-ui-btn" onclick="HerdrGitUi.rebase()">Rebase</button><button class="git-ui-btn danger" onclick="HerdrGitUi.reset()">Reset</button></div><div class="git-ui-worktree-right">${chip}</div></div>`;
+    // Status label mirrors the sync state: incoming → Pull ↓N, outgoing →
+    // Push ↑N, otherwise plain Fetch with no arrows or counts.
+    let statusMethod = "fetchOrigin";
+    let statusLabel = "Fetch";
+    let statusHint = "git fetch origin";
+    if (upstream && behind > 0) {
+      statusMethod = "pullUpdateFromUpstream";
+      statusLabel = `Pull ↓${behind}`;
+      statusHint = "Fetch and fast-forward from the upstream (never creates a merge commit)";
+    } else if (upstream && ahead > 0) {
+      statusMethod = "pushNow";
+      statusLabel = `Push ↑${ahead}`;
+      statusHint = "Push local commits to the upstream";
+    }
+    const menuOpen = state.headerMenu ? "true" : "false";
+    const statusButton = `<button class="git-ui-btn git-ui-status-label" data-method="${esc(statusMethod)}" title="${esc(statusHint)}" onclick="HerdrGitUi.runStatusAction()">${esc(statusLabel)}</button>`;
+    const statusCaret = `<button class="git-ui-btn git-ui-status-caret" title="Pull, fetch and push options" aria-haspopup="menu" aria-expanded="${menuOpen}" onclick="HerdrGitUi.toggleHeaderMenu(event)"><b class="git-ui-chip-caret">▾</b></button>`;
+    return `<div class="git-ui-toolbar git-ui-worktree-row"><div class="git-ui-actions git-ui-worktree-left"><button class="git-ui-btn primary" title="${esc(commitHint)}" onclick="HerdrGitUi.openCommitModal()"${commitDisabled}>Commit</button>${chip}</div><div class="git-ui-actions git-ui-worktree-right">${statusButton}${statusCaret}</div></div>`;
   }
 
-  // Dropdown next to Pull: Fetch / Fetch from / Pull / Pull (Rebase) /
-  // Push / Push to / Force Push.
+  // Dropdown next to the status button, exactly seven items: Fetch /
+  // Fetch From / Pull / Pull (rebase) / Push / Push to / Force push.
   function renderHeaderMenu() {
     const menu = state.headerMenu;
     if (!menu) return "";
     const item = (label, method, hint) => `<button onclick="HerdrGitUi.${method}()">${esc(label)}${hint ? `<span class="git-ui-menu-hint">${esc(hint)}</span>` : ""}</button>`;
-    return `<div class="git-ui-menu git-ui-header-menu" style="left:${Math.max(0, menu.x)}px;top:${Math.max(0, menu.y)}px" onclick="event.stopPropagation()">${item("Fetch", "fetchOrigin", "git fetch origin")}${item("Fetch from…", "openFetchFromModal", "choose a branch")}${item("Pull", "openPullModal", "opens pull options")}${item("Pull (Rebase)", "pullWithRebase", "git pull --rebase")}${item("Push", "openPushModal", "opens push options")}${item("Push to…", "openPushToModal", "choose a branch")}${item("Force Push", "openForcePushModal", "force-with-lease first")}</div>`;
+    return `<div class="git-ui-menu git-ui-header-menu" style="left:${Math.max(0, menu.x)}px;top:${Math.max(0, menu.y)}px" onclick="event.stopPropagation()">${item("Fetch", "fetchOrigin", "git fetch origin")}${item("Fetch From", "openFetchFromModal", "choose a branch")}${item("Pull", "openPullModal", "opens pull options")}${item("Pull (rebase)", "pullWithRebase", "git pull --rebase")}${item("Push", "openPushModal", "opens push options")}${item("Push to", "openPushToModal", "choose a branch")}${item("Force push", "openForcePushModal", "force-with-lease first")}</div>`;
   }
 
-  // Branch list popover: opens from the branch chip. Local section first,
-  // then remote; filterable. Each row: branch name, author · relative time;
-  // hover shows the exact time and commit subject.
+  // Branch list popover: opens from the branch chip. Local section first
+  // (current branch pinned at the top with a ✓), then remote; filterable
+  // from the bottom. Each row is two lines: branch name, then author +
+  // relative time; hover reveals a trash icon on the right to delete the
+  // branch, and the row title carries the exact time and commit subject.
   function branchRelativeTime(isoDate) {
     const then = Date.parse(String(isoDate || ""));
     if (!then || Number.isNaN(then)) return "";
@@ -1611,10 +1600,21 @@
     const subject = String(branch.subject || "");
     const exact = date ? new Date(date).toLocaleString() : "";
     const hover = [author && `${author}`, exact, subject && `"${subject}"`].filter(Boolean).join(" · ");
-    return `<button class="git-ui-branch-row${isCurrent ? " current" : ""}" title="${esc(hover)}" onclick="HerdrGitUi.switchFromBranchList(\'${arg(name)}\',${branch.remote ? "true" : "false"})">
-      <span class="git-ui-branch-row-name">${esc(name)}${isCurrent ? " <b>●</b>" : ""}${branch.remote ? `<i class="git-ui-branch-row-remote">remote</i>` : ""}</span>
-      <span class="git-ui-branch-row-meta">${esc(author)}${author && branchRelativeTime(date) ? " · " : ""}${esc(branchRelativeTime(date))}</span>
-    </button>`;
+    // Two lines: name line (✓ for the current branch, branch icon
+    // otherwise) and a meta line with author + relative time. The trash
+    // icon only appears on hover; it stops propagation so the row click
+    // (switch) does not fire.
+    const icon = isCurrent ? `<b class="git-ui-branch-row-check" title="Current branch">✓</b>` : `<b class="git-ui-branch-row-icon" aria-hidden="true"></b>`;
+    const meta = [author, branchRelativeTime(date)].filter(Boolean).join(" · ");
+    const trash = isCurrent
+      ? "" // deleting the checked-out branch from the list makes no sense
+      : `<button class="git-ui-branch-row-trash" title="Delete branch" aria-label="Delete branch ${esc(name)}" onclick="event.stopPropagation();HerdrGitUi.deleteFromBranchList(\'${arg(name)}\',${branch.remote ? "true" : "false"})"><span></span></button>`;
+    return `<div class="git-ui-branch-row${isCurrent ? " current" : ""}" title="${esc(hover)}">
+      <button class="git-ui-branch-row-main" onclick="HerdrGitUi.switchFromBranchList(\'${arg(name)}\',${branch.remote ? "true" : "false"})">
+        <span class="git-ui-branch-row-name">${icon}<span class="git-ui-branch-row-name-text">${esc(name)}</span>${branch.remote ? `<i class="git-ui-branch-row-remote">remote</i>` : ""}</span>
+        <span class="git-ui-branch-row-meta">${esc(meta)}</span>
+      </button>${trash}
+    </div>`;
   }
 
   function renderBranchList() {
@@ -1625,11 +1625,16 @@
     const filter = String(list.filter || "").toLowerCase();
     const currentBranch = String(list.currentBranch || "");
     const matches = (branch) => !filter || String(branch.name || "").toLowerCase().includes(filter);
-    const local = (list.local || []).filter(matches);
+    // Current branch stays pinned at the top of the local section.
+    const localAll = (list.local || []).filter(matches);
+    const currentRows = localAll.filter((branch) => !branch.remote && branch.name === currentBranch);
+    const local = currentRows.concat(localAll.filter((branch) => !currentRows.includes(branch)));
     const remote = (list.remote || []).filter(matches);
     const rows = (branches, label) => !branches.length ? "" : `<div class="git-ui-branch-list-section">${label}</div>${branches.map((branch) => branchListRow(branch, currentBranch)).join("")}`;
     const empty = !local.length && !remote.length ? `<div class="git-ui-muted git-ui-branch-list-empty">No branches match</div>` : "";
-    return `<div class="git-ui-branch-list" onclick="event.stopPropagation()"><label class="git-ui-branch-list-filter"><span>Filter</span><input value="${esc(list.filter || "")}" placeholder="Type to filter" oninput="HerdrGitUi.branchListFilter(this.value)"></label>${rows(local, "Local branches")}${rows(remote, "Remote branches")}${empty}</div>`;
+    // Filter input lives at the bottom, below the scrollable rows, so the
+    // list reads top-down like Zed's branch popover.
+    return `<div class="git-ui-branch-list" onclick="event.stopPropagation()"><div class="git-ui-branch-list-scroll">${rows(local, "Local branches")}${rows(remote, "Remote branches")}${empty}</div><label class="git-ui-branch-list-filter"><span>Filter</span><input value="${esc(list.filter || "")}" placeholder="Type to filter" oninput="HerdrGitUi.branchListFilter(this.value)"></label></div>`;
   }
 
   function renderSide() {
@@ -3583,10 +3588,28 @@
       render();
     },
     openPullModal() { this.openGitOpModal("pull"); },
-    async updateFromUpstream() {
+    // Status button actions: Pull (fetch + ff-only) when behind, Push when
+    // ahead, plain Fetch otherwise. Chosen from status state at click time.
+    async pullUpdateFromUpstream() {
       const view = active();
       if (!view || view.mutating) return;
       await postJson("/api/git-ui/pull", { cwd: view.cwd, mode: "update" }, "Updating from upstream");
+    },
+    async pushNow() {
+      const view = active();
+      if (!view || view.mutating) return;
+      await postJson("/api/git-ui/push", { cwd: view.cwd, mode: "regular", push_tags: false }, "Pushing");
+    },
+    async runStatusAction() {
+      const view = active();
+      if (!view || view.mutating) return;
+      const s = view.status || {};
+      const ahead = Number(s.ahead) || 0;
+      const behind = Number(s.behind) || 0;
+      const upstream = String(s.upstream || "").trim();
+      if (upstream && behind > 0) return this.pullUpdateFromUpstream();
+      if (upstream && ahead > 0) return this.pushNow();
+      return this.fetchOrigin();
     },
     openPushModal() { this.openGitOpModal("push"); },
     closeGitOpModal() { state.gitOpModal = null; render(); },
@@ -3715,6 +3738,40 @@
       const currentBranch = ((view.status || {}).branch) || "";
       if (localName === currentBranch) return;
       await postJson("/api/git-ui/switch", { cwd: view.cwd, branch: localName }, `Switching to ${name}`);
+    },
+    // Trash icon in a branch-list row: deletes the branch through the same
+    // endpoint the cleanup view uses. Remote rows and the current branch
+    // are refused (the backend also refuses the checked-out branch).
+    async deleteFromBranchList(encodedName, isRemote) {
+      const name = decodeURIComponent(String(encodedName || ""));
+      const view = active();
+      if (!view || !name) return;
+      if (isRemote) {
+        if (state.branchList) {
+          state.branchList.error = "Deleting remote branches is not supported here";
+          render();
+        }
+        return;
+      }
+      const currentBranch = String(((view.status || {}).branch) || "");
+      if (name === currentBranch) return;
+      if (!window.confirm(`Delete branch "${name}"?`)) return;
+      const filter = String((state.branchList && state.branchList.filter) || "");
+      state.branchList = { loading: true, error: "", local: [], remote: [], filter, currentBranch };
+      render();
+      try {
+        await api("/api/git-ui/branch-delete", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ cwd: view.cwd, branch: name, force: false, confirmed: true }),
+        });
+        const data = await api(`/api/git-ui/branches?cwd=${encodeURIComponent(view.cwd)}`);
+        state.branchList = { loading: false, error: "", local: data.local || [], remote: data.remote || [], filter, currentBranch };
+      } catch (err) {
+        state.branchList = { loading: false, error: err.message || String(err), local: [], remote: [], filter, currentBranch };
+      }
+      render();
+      await refresh();
     },
     toggleHeaderMenu(event) {
       if (event && event.stopPropagation) event.stopPropagation();

--- a/src/assets/desktop/git_ui/layout.css
+++ b/src/assets/desktop/git_ui/layout.css
@@ -96,15 +96,8 @@
   color: var(--muted);
   font-size: 12px;
 }
-.git-ui-ahead-behind-group {
-  align-items: center;
-  display: inline-flex;
-  flex: none;
-  gap: 3px;
-  margin-left: 2px;
-}
 
-/* ── Worktree actions row with branch chip (GitHub-flow header) ────── */
+/* ── Worktree actions row with branch chip (Zed-style selector) ────── */
 .git-ui-worktree-row {
   align-items: center;
   display: flex;
@@ -112,13 +105,22 @@
   justify-content: space-between;
 }
 .git-ui-worktree-left {
+  align-items: center;
+  display: flex;
   flex: 1 1 auto;
+  gap: 6px;
   min-width: 0;
+}
+.git-ui-worktree-left.git-ui-actions {
+  flex-wrap: nowrap;
 }
 .git-ui-worktree-right {
   flex: none;
   justify-content: flex-end;
   margin-left: auto;
+}
+.git-ui-worktree-right.git-ui-actions {
+  flex-wrap: nowrap;
 }
 .git-ui-branch-chip {
   align-items: center;
@@ -143,18 +145,24 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.git-ui-chip-count {
-  border-radius: 999px;
-  flex: none;
-  font-size: 11px;
-  padding: 0 6px;
-}
-.git-ui-chip-count.behind { background: rgba(56, 139, 253, 0.2); }
-.git-ui-chip-count.ahead { background: rgba(63, 185, 80, 0.2); }
-.git-ui-chip-count.synced { background: rgba(63, 185, 80, 0.16); color: var(--success, #3fb950); }
 .git-ui-chip-caret { font-size: 10px; }
-.git-ui-split { padding-right: 4px; }
-.git-ui-split .git-ui-chip-caret { margin-left: 2px; }
+
+/* Right-justified status split button: label + ▾ triangle joined. */
+.git-ui-status-label {
+  border-bottom-right-radius: 0;
+  border-right: 0;
+  border-top-right-radius: 0;
+}
+.git-ui-status-caret {
+  border-bottom-left-radius: 0;
+  border-left: 1px solid var(--border2);
+  border-top-left-radius: 0;
+  padding: 5px 6px;
+}
+.git-ui-status-label:hover:not(:disabled),
+.git-ui-status-caret:hover:not(:disabled) {
+  transform: none;
+}
 
 /* Header pull/fetch dropdown */
 .git-ui-header-menu {
@@ -175,20 +183,33 @@
   border: 1px solid var(--border2);
   border-radius: 10px;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
   left: 10px;
   max-height: 420px;
-  overflow-y: auto;
   padding: 8px;
   position: absolute;
   right: 10px;
   top: 10px;
   z-index: 40;
 }
+.git-ui-branch-list-scroll {
+  /* Seven two-line rows (2 x ~32px) plus section headers. */
+  --git-ui-branch-row-height: 52px;
+  flex: 1 1 auto;
+  max-height: calc(var(--git-ui-branch-row-height) * 7 + 48px);
+  min-height: calc(var(--git-ui-branch-row-height) * 3);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
 .git-ui-branch-list-filter {
+  border-top: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   gap: 4px;
-  margin-bottom: 8px;
+  margin-bottom: 0;
+  margin-top: 8px;
+  padding-top: 8px;
 }
 .git-ui-branch-list-filter span {
   color: var(--muted);
@@ -210,23 +231,37 @@
   margin: 8px 0 4px;
   text-transform: uppercase;
 }
+.git-ui-branch-list-scroll .git-ui-branch-list-section:first-child {
+  margin-top: 0;
+}
 .git-ui-branch-row {
+  align-items: stretch;
   background: transparent;
-  border: 0;
   border-radius: 8px;
   color: var(--fg);
-  cursor: pointer;
   display: flex;
-  flex-direction: column;
-  font: inherit;
-  gap: 2px;
-  padding: 6px 8px;
-  text-align: left;
+  gap: 4px;
+  padding: 0;
   width: 100%;
 }
 .git-ui-branch-row:hover,
 .git-ui-branch-row.current {
   background: var(--panel2);
+}
+.git-ui-branch-row-main {
+  align-items: stretch;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  font: inherit;
+  gap: 2px;
+  min-width: 0;
+  padding: 6px 8px;
+  text-align: left;
 }
 .git-ui-branch-row-name {
   align-items: center;
@@ -234,13 +269,37 @@
   font-size: 13px;
   font-weight: 700;
   gap: 6px;
+  min-width: 0;
 }
-.git-ui-branch-row-name b { color: var(--accent); font-size: 10px; }
+.git-ui-branch-row-name > span,
+.git-ui-branch-row-name > i {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.git-ui-branch-row-name > span.git-ui-branch-row-name-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.git-ui-branch-row-check {
+  color: var(--accent);
+  flex: none;
+  font-size: 12px;
+}
+.git-ui-branch-row-icon {
+  background: currentColor;
+  display: inline-block;
+  flex: none;
+  height: 12px;
+  mask: url("/assets/icons/git.svg") center / contain no-repeat;
+  width: 12px;
+}
 .git-ui-branch-row-remote {
   background: var(--panel2);
   border: 1px solid var(--border2);
   border-radius: 999px;
   color: var(--muted);
+  flex: none;
   font-size: 10px;
   font-style: normal;
   font-weight: 600;
@@ -249,35 +308,38 @@
 .git-ui-branch-row-meta {
   color: var(--muted);
   font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.git-ui-branch-row-trash {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--muted);
+  cursor: pointer;
+  display: none;
+  flex: none;
+  padding: 6px;
+  width: 28px;
+}
+.git-ui-branch-row:hover .git-ui-branch-row-trash {
+  align-items: center;
+  display: inline-flex;
+}
+.git-ui-branch-row-trash:hover {
+  color: var(--danger, #f85149);
+}
+.git-ui-branch-row-trash span {
+  background: currentColor;
+  display: inline-block;
+  height: 13px;
+  mask: url("/assets/icons/trash.svg") center / contain no-repeat;
+  width: 13px;
 }
 .git-ui-branch-list-empty {
   padding: 8px;
-}
-.git-ui-ahead-behind {
-  align-items: center;
-  border-radius: 999px;
-  display: inline-flex;
-  font-size: 10px;
-  font-weight: 800;
-  gap: 1px;
-  line-height: 1;
-  padding: 1px 5px;
-  white-space: nowrap;
-}
-.git-ui-ahead-behind.ahead {
-  background: color-mix(in srgb, var(--git-added-color) 18%, transparent);
-  border: 1px solid color-mix(in srgb, var(--git-added-color) 60%, var(--border2));
-  color: var(--git-added-color);
-}
-.git-ui-ahead-behind.behind {
-  background: color-mix(in srgb, var(--git-conflict-color) 18%, transparent);
-  border: 1px solid color-mix(in srgb, var(--git-conflict-color) 60%, var(--border2));
-  color: var(--git-conflict-color);
-}
-.git-ui-ahead-behind.synced {
-  background: color-mix(in srgb, var(--muted) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--muted) 40%, var(--border2));
-  color: var(--muted);
 }
 .git-ui-busy {
   align-items: center;

--- a/src/assets/git_ui_behavior.test.mjs
+++ b/src/assets/git_ui_behavior.test.mjs
@@ -362,56 +362,72 @@ test("folder mutations are hidden and refused outside the changes view", async (
   assert.equal(staged.length, 0, "no stage POST may fire outside changes mode");
 });
 
-test("Update button fetch+ff from upstream and Pull modal default to update mode (GitHub flow)", async () => {
-  const booted = await openedWithStatus(emptyStatus());
-  const { ui, calls } = booted;
+test("status button labels Pull/Push/Fetch from sync state and runs the matching action", async () => {
+  // In sync: plain Fetch, no arrows or counts.
+  const synced = await openedWithStatus({ branch: "main", ahead: 0, behind: 0, staged: [], unstaged: [], untracked: [], conflicted: [], upstream: "origin/main" });
+  let html = String(ctxHtml(synced));
+  assert.match(html, /git-ui-status-label" data-method="fetchOrigin"[^>]*title="git fetch origin"[^>]*>Fetch</);
+  assert.ok(!/Pull ↓|Push ↑/.test(html), "synced status shows no arrows");
+  assert.ok(!html.includes("updateFromUpstream"), "old Update button is gone");
+  assert.ok(!html.includes("git-ui-split"), "old split button is gone");
+  assert.ok(!/HerdrGitUi\.rebase\(\)">Rebase</.test(html), "old Rebase button is gone");
+  assert.ok(!/HerdrGitUi\.reset\(\)">Reset</.test(html), "old Reset button is gone");
 
-  // The worktree toolbar exposes the dedicated Update button.
-  const html = String(ctxHtml(booted));
-  assert.match(html, /onclick="HerdrGitUi.updateFromUpstream\(\)">↓ Update<\/button>/);
-  assert.match(html, /title="Fetch and fast-forward from the upstream \(never creates a merge commit\)"/);
+  const before = synced.calls.length;
+  await synced.ui.runStatusAction();
+  const fetchPosts = synced.calls.slice(before).filter((call) => call.path === "/api/git-ui/fetch");
+  assert.equal(fetchPosts.length, 1, "synced status runs fetch");
+  assert.equal(JSON.parse(fetchPosts[0].init.body).cwd, "/tmp/demo-repo");
 
-  // Update posts mode=update with no branch (ff-only @{u}).
-  const before = calls.length;
-  await ui.updateFromUpstream();
-  const updateCall = lastPostCall(calls.slice(before), "/api/git-ui/pull") || lastPostCall(calls.slice(before).map(c => c), "/api/git-ui/pull");
-  const updatePosts = calls.slice(before).filter((call) => call.path === "/api/git-ui/pull");
-  assert.equal(updatePosts.length, 1, "exactly one pull POST fired");
-  assert.equal(JSON.parse(updatePosts[0].init.body).mode, "update");
-  assert.equal(JSON.parse(updatePosts[0].init.body).branch, undefined);
+  // Behind: Pull ↓N posts mode=update (fetch + ff-only, no branch).
+  const behind = await openedWithStatus({ branch: "main", ahead: 0, behind: 3, staged: [], unstaged: [], untracked: [], conflicted: [], upstream: "origin/main" });
+  html = String(ctxHtml(behind));
+  assert.match(html, /git-ui-status-label" data-method="pullUpdateFromUpstream"[^>]*>Pull ↓3</);
+  const beforePull = behind.calls.length;
+  await behind.ui.pullUpdateFromUpstream();
+  const pullPosts = behind.calls.slice(beforePull).filter((call) => call.path === "/api/git-ui/pull");
+  assert.equal(pullPosts.length, 1, "exactly one pull POST fired");
+  assert.equal(JSON.parse(pullPosts[0].init.body).mode, "update");
+  assert.equal(JSON.parse(pullPosts[0].init.body).branch, undefined);
 
-  // Pull modal offers Update as the default mode and Rebase fetches main/master.
-  await ui.openPullModal();
+  // Ahead: Push ↑N posts a regular push.
+  const ahead = await openedWithStatus({ branch: "main", ahead: 2, behind: 0, staged: [], unstaged: [], untracked: [], conflicted: [], upstream: "origin/main" });
+  html = String(ctxHtml(ahead));
+  assert.match(html, /git-ui-status-label" data-method="pushNow"[^>]*>Push ↑2</);
+  const beforePush = ahead.calls.length;
+  await ahead.ui.pushNow();
+  const pushPosts = ahead.calls.slice(beforePush).filter((call) => call.path === "/api/git-ui/push");
+  assert.equal(pushPosts.length, 1, "push POST fired");
+  assert.equal(JSON.parse(pushPosts[0].init.body).mode, "regular");
+
+  // Pull modal still offers Update as the default mode.
+  await ahead.ui.openPullModal();
   await new Promise((resolve) => setTimeout(resolve, 0));
-  const pullHtml = String(ctxHtml(booted));
+  const pullHtml = String(ctxHtml(ahead));
   assert.match(pullHtml, /<option value="update" selected>Update \(fetch \+ fast-forward\)<\/option>/);
-
-  await ui.closeGitOpModal();
-  await ui.rebase();
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  const rebaseHtml = String(ctxHtml(booted));
-  assert.match(rebaseHtml, /id="gitUiRebasePullFirst" type="checkbox" checked/);
-  assert.match(rebaseHtml, /Fetch selected branch \(and main\/master\) before rebasing onto origin/);
-  await ui.closeGitOpModal();
+  await ahead.ui.closeGitOpModal();
 });
 
-test("header menu dropdown offers fetch, pull and push variants", async () => {
+test("header menu dropdown offers exactly the seven git-flow actions", async () => {
   const booted = await openedWithStatus(emptyStatus());
   const { ui, calls } = booted;
 
-  const chipEvent = { stopPropagation() {}, currentTarget: null, clientX: 0, clientY: 0 };
-  await ui.openBranchList(chipEvent); // opens then closes (toggle) — leave closed
+  // Old Update/split toolbar buttons no longer exist.
+  let html = String(ctxHtml(booted));
+  assert.ok(!html.includes("git-ui-header-menu"), "menu closed initially");
+
   const toggleEvent = { stopPropagation() {}, currentTarget: { getBoundingClientRect: () => ({ left: 40, bottom: 60 }) }, clientX: 40, clientY: 60 };
   ui.toggleHeaderMenu(toggleEvent);
-  let html = String(ctxHtml(booted));
+  html = String(ctxHtml(booted));
   assert.match(html, /class="git-ui-menu git-ui-header-menu"/);
-  assert.match(html, /HerdrGitUi\.fetchOrigin\(\)/);
-  assert.match(html, /HerdrGitUi\.openFetchFromModal\(\)/);
-  assert.match(html, /HerdrGitUi\.openPullModal\(\)/);
-  assert.match(html, /HerdrGitUi\.pullWithRebase\(\)/);
-  assert.match(html, /HerdrGitUi\.openPushModal\(\)/);
-  assert.match(html, /HerdrGitUi\.openPushToModal\(\)/);
-  assert.match(html, /HerdrGitUi\.openForcePushModal\(\)/);
+  const items = (html.match(/git-ui-header-menu" style[^>]*>.*?<\/div>/s) || [""])[0]
+    .split(/<button onclick="HerdrGitUi\./).slice(1)
+    .map((chunk) => (chunk.match(/^([a-zA-Z]+)\(\)/) || [])[1]);
+  assert.deepEqual(items, ["fetchOrigin", "openFetchFromModal", "openPullModal", "pullWithRebase", "openPushModal", "openPushToModal", "openForcePushModal"], "exactly seven menu items in Zed order");
+  const labels = (html.match(/git-ui-header-menu" style[^>]*>.*?<\/div>/s) || [""])[0]
+    .match(/<button onclick="[^"]*">[^<]+/g)
+    .map((chunk) => chunk.replace(/^<button onclick="[^"]*">/, ""));
+  assert.deepEqual(labels, ["Fetch", "Fetch From", "Pull", "Pull (rebase)", "Push", "Push to", "Force push"], "menu labels match the Zed wording");
 
   // Fetch from the menu posts to the fetch endpoint.
   const before = calls.length;
@@ -421,7 +437,7 @@ test("header menu dropdown offers fetch, pull and push variants", async () => {
   assert.equal(JSON.parse(fetchPosts[0].init.body).cwd, "/tmp/demo-repo");
   assert.equal(JSON.parse(fetchPosts[0].init.body).branch, undefined);
 
-  // Pull (Rebase) posts mode=rebase.
+  // Pull (rebase) posts mode=rebase.
   ui.toggleHeaderMenu(toggleEvent); // reopen
   const beforeRebase = calls.length;
   await ui.pullWithRebase();
@@ -432,7 +448,7 @@ test("header menu dropdown offers fetch, pull and push variants", async () => {
   assert.ok(!menuHtml.includes("git-ui-header-menu"), "menu closes after action");
 });
 
-test("branch chip shows sync arrows when diverged and opens the branch list", async () => {
+test("branch chip shows the branch and the status button shows sync arrows when diverged", async () => {
   const booted = await bootGitUi({
     "/api/git-ui/status": { branch: "feature-x", ahead: 2, behind: 3, staged: [], unstaged: [], untracked: [], conflicted: [], upstream: "origin/feature-x" },
     "/api/git-ui/diff": { files: [] },
@@ -445,8 +461,9 @@ test("branch chip shows sync arrows when diverged and opens the branch list", as
 
   let html = String(ctxHtml(booted));
   assert.match(html, /git-ui-branch-chip/);
-  assert.match(html, /<b class="git-ui-chip-count behind"[^>]*>↓3<\/b>/);
-  assert.match(html, /<b class="git-ui-chip-count ahead"[^>]*>↑2<\/b>/);
+  assert.match(html, /<span class="git-ui-branch-chip-name">feature-x<\/span>/);
+  // Incoming wins: Pull ↓3 on the status button (behind takes priority).
+  assert.match(html, /data-method="pullUpdateFromUpstream"[^>]*>Pull ↓3</);
 
   const chipEvent = { stopPropagation() {}, currentTarget: null, clientX: 0, clientY: 0 };
   await ui.openBranchList(chipEvent);
@@ -455,16 +472,28 @@ test("branch chip shows sync arrows when diverged and opens the branch list", as
   assert.match(html, /git-ui-branch-list"/);
   assert.match(html, /Local branches/);
   assert.match(html, /Remote branches/);
-  assert.match(html, /Switching to feature-x|Ada · /);
-  // Rows carry author + relative time and a hover title with details.
+  // Two-line rows: name line and author · relative time meta line; hover
+  // title carries the commit subject and details.
   assert.match(html, /title="[^"]*Ada[^"]*"/);
+  assert.match(html, /git-ui-branch-row-meta">[^<]*Ada[^<]*<\/span>/);
+  // Current branch pinned first with a ✓ check; other rows show the branch icon.
+  assert.match(html, /✓<\/b><span class="git-ui-branch-row-name-text">feature-x<\/span>/, "current branch row carries the ✓ check");
+  const localSection = html.indexOf("Local branches");
+  const firstRowAfterSection = html.slice(localSection).indexOf("git-ui-branch-row");
+  const firstRow = html.slice(localSection + firstRowAfterSection, localSection + firstRowAfterSection + 400);
+  assert.ok(localSection === -1 || firstRow.includes("feature-x"), "current branch row is pinned at the top of the local section");
+  assert.match(html, /git-ui-branch-row-icon/);
+  // Trash icon is wired for non-current rows.
+  assert.match(html, /deleteFromBranchList/);
+  // Filter lives below the scrollable rows.
+  assert.ok(html.indexOf("git-ui-branch-list-scroll") < html.indexOf("git-ui-branch-list-filter"), "filter sits at the bottom");
 
   // Filter narrows the visible rows: in the vm the DOM stub cannot swap
   // nodes, so assert the renderer honors the filter by re-rendering.
   ui.branchListFilter("main");
   html = String(ctxHtml(booted));
   assert.ok(html.includes("main"), "matching branch stays visible");
-  const renderedNames = (html.match(/git-ui-branch-row-name">[^<]*/g) || []).join(" ");
+  const renderedNames = (html.match(/git-ui-branch-row-name">.*?<\/span>/g) || []).join(" ");
   assert.ok(!renderedNames.includes("feature-x"), "filtered rows hide non-matching branch");
 
   // Switching to another local branch posts to /switch with the bare name.
@@ -477,7 +506,7 @@ test("branch chip shows sync arrows when diverged and opens the branch list", as
   assert.ok(!String(ctxHtml(booted)).includes("git-ui-branch-list"), "list closes after switch");
 });
 
-test("branch chip shows a synced check when in sync with upstream", async () => {
+test("status button shows plain Fetch and the chip no check when in sync with upstream", async () => {
   const booted = await bootGitUi({
     "/api/git-ui/status": { branch: "main", ahead: 0, behind: 0, staged: [], unstaged: [], untracked: [], conflicted: [], upstream: "origin/main" },
     "/api/git-ui/diff": { files: [] },
@@ -486,5 +515,53 @@ test("branch chip shows a synced check when in sync with upstream", async () => 
   });
   await booted.ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
   const html = String(ctxHtml(booted));
-  assert.match(html, /<b class="git-ui-chip-count synced" title="In sync with origin\/main">✓<\/b>/);
+  assert.match(html, /git-ui-status-label" data-method="fetchOrigin"[^>]*title="git fetch origin"[^>]*>Fetch</);
+  assert.ok(!/chip-count/.test(html), "sync badges moved off the chip");
+});
+
+test("branch list trash deletes a local branch and refreshes the list", async () => {
+  const branches = { local: [{ name: "main", author: "Ada", date: "2026-01-02T03:04:05Z", subject: "initial" }, { name: "wip", author: "Bob", date: "2026-01-03T03:04:05Z", subject: "wip" }], remote: [] };
+  const booted = await bootGitUi({
+    "/api/git-ui/status": { branch: "main", ahead: 0, behind: 0, staged: [], unstaged: [], untracked: [], conflicted: [], upstream: "origin/main" },
+    "/api/git-ui/diff": { files: [] },
+    "/api/git-ui/compare": { files: [] },
+    "/api/git-ui/log": { commits: [], lines: [], rows: [], has_more: false, limit: 80 },
+    "/api/git-ui/branches": () => ({ local: branches.local, remote: branches.remote }),
+    // Deleting really drops the branch, so the list reload loses the row.
+    "/api/git-ui/branch-delete": () => {
+      branches.local = branches.local.filter((branch) => branch.name !== "wip");
+      return { ok: true, message: "" };
+    },
+  });
+  const { ui, calls } = booted;
+  await ui.open({ cwd: "/tmp/demo-repo", title: "demo" }, { forceOpen: true });
+
+  // Current branch rows show no trash icon.
+  await ui.openBranchList({ stopPropagation() {}, currentTarget: null, clientX: 0, clientY: 0 });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  let html = String(ctxHtml(booted));
+  assert.match(html, /aria-label="Delete branch wip"/);
+  const mainRow = (html.match(/git-ui-branch-row current[\s\S]*?<\/div>/) || [""])[0];
+  assert.ok(!mainRow.includes("branch-row-trash"), "current branch row has no trash icon");
+
+  // Deleting refuses the current branch and remote rows without posting.
+  const before = calls.length;
+  await ui.deleteFromBranchList(encodeURIComponent("main"), false);
+  await ui.deleteFromBranchList(encodeURIComponent("origin/main"), true);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(calls.slice(before).filter((call) => call.path === "/api/git-ui/branch-delete").length, 0, "no delete POST for current or remote branch");
+
+  // Deleting a local branch posts to the endpoint, then reloads the list.
+  const deleteIndex = calls.length;
+  await ui.deleteFromBranchList(encodeURIComponent("wip"), false);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const deletePosts = calls.slice(deleteIndex).filter((call) => call.path === "/api/git-ui/branch-delete");
+  assert.equal(deletePosts.length, 1, "one branch-delete POST fired");
+  const body = JSON.parse(deletePosts[0].init.body);
+  assert.equal(body.branch, "wip");
+  assert.equal(body.confirmed, true);
+  // The handler reloads the branches endpoint; wip is gone from the list.
+  html = String(ctxHtml(booted));
+  assert.match(html, /git-ui-branch-list"/);
+  assert.ok(!/aria-label="Delete branch wip"/.test(html), "deleted branch is gone from the list");
 });


### PR DESCRIPTION
## Summary
- Branch chip moves left next to Commit (name + caret only), sync badges removed
- Right-justified status split button: Pull ↓N when behind, Push ↑N when ahead, plain Fetch otherwise; ▾ dropdown holds exactly seven git-flow actions with Zed wording: Fetch, Fetch From, Pull, Pull (rebase), Push, Push to, Force push
- Branch list popover: two-line rows (name, author + relative time), current branch pinned with ✓ at top of local section, filter at bottom, scroll sized for 7 rows, hover trash icon deletes local branch via existing branch-delete endpoint (remote and checked-out refused)
- Old Update/split/Rebase/Reset toolbar buttons removed
- e2e assertion fixed (custom assert helper has no deepEqual) and 0.4.8 release notes entry added

## Testing
- node --test src/assets/*.test.mjs: 430 pass, 0 fail (12 in git_ui_behavior)
- cargo test: all suites green
- cargo fmt --check: clean
- scripts/e2e/run-git-e2e.sh: GIT E2E ACCEPTANCE PASSED (real server + git backend)