### PR TITLE
Support herdr 0.9.0 protocol 22, builtin default backend, graceful degradation

### DIFF
--- a/scripts/e2e/acceptance.mjs
+++ b/scripts/e2e/acceptance.mjs
@@ -41,6 +41,50 @@ if (!title || title === 'Privacy error' || String(title).includes('Privacy')) {
 }
 check('app loads (title present)', !!title, `title="${title}"`);
 
+// Fresh browsers must land on the built-in backend: the server's default
+// backend_mode is builtin and the frontend adopts the server's current
+// backend instead of any stale localStorage choice.
+{
+  const backend = await cdp.evalExpr(`(async () => {
+    await new Promise((r) => setTimeout(r, 500));
+    return {
+      stored: localStorage.getItem('herdr-session-backend'),
+      footer: (document.getElementById('footerSessionButton') || {}).textContent || '',
+      versions: await fetch('/api/versions').then((r) => r.json()),
+    };
+  })()`, true);
+  check(
+    'fresh browser defaults to built-in session backend',
+    backend.versions
+      && backend.versions.backend_mode === 'builtin'
+      && backend.versions.current_backend === 'builtin'
+      && backend.stored === 'builtin'
+      && /built-in/.test(backend.footer),
+    `backend_mode=${backend.versions && backend.versions.backend_mode} current=${backend.versions && backend.versions.current_backend} stored=${backend.stored} footer="${backend.footer}"`,
+  );
+  // External herdr sessions are only offered when a compatible herdr install
+  // is detected: /api/versions reports herdr_install, and the sessions list
+  // from /api/sessions only includes external entries when compatible.
+  if (backend.versions) {
+    const install = backend.versions.herdr_install || {};
+    const sessions = await cdp.evalExpr(`(async () => {
+      const r = await fetch('/api/sessions').then((r) => r.json());
+      return r;
+    })()`, true);
+    const hasExternal = (sessions.sessions || []).some((s) => s.backend === 'external-herdr');
+    check(
+      'herdr install detection reported',
+      install.available === true && install.compatible === true && !!install.version,
+      `available=${install.available} compatible=${install.compatible} version=${install.version || '?'}`,
+    );
+    check(
+      'external sessions gated on compatible herdr install',
+      sessions.herdr_compatible === true && hasExternal,
+      `herdr_compatible=${sessions.herdr_compatible} external_sessions=${hasExternal}`,
+    );
+  }
+}
+
 // Wait for app shell
 await new Promise((r) => setTimeout(r, 2000));
 

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -1892,6 +1892,8 @@ describe("app bundle load", () => {
 
     // A fresh browser load adopts the server's current backend (here an
     // external herdr backend) instead of keeping a stale local choice.
+    // The external backend is only adopted when a compatible herdr install
+    // is detected.
     const freshCtx = context();
     freshCtx.fetch = async (url) => {
       equal(url, "/api/versions");
@@ -1905,6 +1907,7 @@ describe("app bundle load", () => {
           current_backend: "external-herdr",
           session: "default",
           compatibility: { status: "compatible" },
+          herdr_install: { available: true, compatible: true, version: "0.9.0" },
         }),
       };
     };
@@ -1998,6 +2001,9 @@ describe("app bundle load", () => {
           status: 200,
           json: async () => ({
             current_backend: "builtin",
+            herdr_available: true,
+            herdr_compatible: true,
+            herdr_version: "0.9.0",
             sessions: [
               { name: "default", backend: "builtin", backend_label: "built-in", running: true },
               { name: "work", backend: "external-herdr", backend_label: "Herdr", running: true },
@@ -2040,6 +2046,72 @@ describe("app bundle load", () => {
       session: "work",
       backend: "external-herdr",
     });
+  });
+
+  it("hides the external Herdr offer when no compatible herdr install is detected", async () => {
+    const ctx = context();
+    ctx.fetch = async (url) => {
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            current_backend: "builtin",
+            herdr_available: true,
+            herdr_compatible: false,
+            herdr_version: "0.8.0",
+            sessions: [
+              { name: "default", backend: "builtin", backend_label: "built-in", running: true },
+            ],
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    vm.runInContext(source, ctx);
+
+    await ctx.showSessionManager();
+
+    // The New Herdr button is disabled with a version hint.
+    const button = ctx.document.getElementById("newHerdrSessionTarget");
+    equal(button.disabled, true);
+    match(button.title, /not compatible/);
+
+    // Targeting an external session keeps the browser on built-in.
+    ctx.goSession("work", "external-herdr");
+    equal(vm.runInContext("state.sessionBackend", ctx), "builtin");
+  });
+
+  it("offers external Herdr when a compatible herdr install is detected", async () => {
+    const ctx = context();
+    ctx.fetch = async (url) => {
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            current_backend: "builtin",
+            herdr_available: true,
+            herdr_compatible: true,
+            herdr_version: "0.9.0",
+            sessions: [
+              { name: "work", backend: "external-herdr", backend_label: "Herdr", running: true },
+            ],
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    vm.runInContext(source, ctx);
+
+    await ctx.showSessionManager();
+
+    const button = ctx.document.getElementById("newHerdrSessionTarget");
+    equal(button.disabled, false);
+    match(button.title, /0\.9\.0/);
+
+    ctx.goSession("work", "external-herdr");
+    equal(vm.runInContext("state.sessionBackend", ctx), "external-herdr");
   });
 
   it("defines grouped settings sections", () => {

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -1890,7 +1890,10 @@ describe("app bundle load", () => {
       "webui 1.2.3 · backend built-in",
     );
 
-    ctx.fetch = async (url) => {
+    // A fresh browser load adopts the server's current backend (here an
+    // external herdr backend) instead of keeping a stale local choice.
+    const freshCtx = context();
+    freshCtx.fetch = async (url) => {
       equal(url, "/api/versions");
       return {
         ok: true,
@@ -1899,16 +1902,18 @@ describe("app bundle load", () => {
           webui: "1.2.3",
           backend: "0.7.3",
           backend_mode: "external",
+          current_backend: "external-herdr",
           session: "default",
           compatibility: { status: "compatible" },
         }),
       };
     };
+    vm.runInContext(source, freshCtx);
 
-    await ctx.loadVersions();
+    await freshCtx.loadVersions();
 
     equal(
-      ctx.document.getElementById("versions").textContent,
+      freshCtx.document.getElementById("versions").textContent,
       "webui 1.2.3 · backend 0.7.3",
     );
   });
@@ -3488,5 +3493,111 @@ describe("app bundle load", () => {
     match(codeMirrorSource, /opts\.activeLine !== false/);
     match(codeMirrorSource, /EditorState\.tabSize\.of/);
     match(codeMirrorSource, /indentUnit\.of/);
+  });
+
+  it("offers a built-in session when the herdr handshake fails", async () => {
+    const ctx = context();
+    const calls = [];
+    ctx.history = {
+      pushState(_state, _title, path) {
+        ctx.location.pathname = path;
+      },
+      replaceState() {},
+    };
+    ctx.fetch = async (url, opt = {}) => {
+      calls.push({ url, opt });
+      if (url === "/api/session/close") return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      if (url === "/api/session/launch") return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      if (url === "/api/versions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            backend_mode: "builtin",
+            current_backend: "builtin",
+            session: "default",
+            compatibility: { status: "compatible" },
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    vm.runInContext(source, ctx);
+
+    equal(await ctx.handleHerdrErrorFrame("not json"), false);
+    equal(await ctx.handleHerdrErrorFrame(JSON.stringify({ type: "other" })), false);
+
+    // Simulate a browser that targeted the external herdr backend when the
+    // handshake failed.
+    vm.runInContext("state.sessionBackend = 'external-herdr'", ctx);
+
+    // First error: close the broken external session, then accept the
+    // built-in offer through the question modal.
+    const first = ctx.handleHerdrErrorFrame(
+      JSON.stringify({
+        type: "herdr_error",
+        kind: "handshake_rejected",
+        message: "herdr rejected terminal connection: client version 22 is newer than server version 21",
+        suggest_builtin: true,
+      }),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    ctx.closeQuestion(true);
+    equal(await first, true);
+    // The broken external session is closed before the offer is shown.
+    const closeCall = calls.find((call) => call.url === "/api/session/close");
+    ok(closeCall, "session/close called");
+    deepEqual(JSON.parse(closeCall.opt.body), { session: "default", backend: "external-herdr" });
+
+    // A second error frame while an offer is pending is swallowed: the pending
+    // handler is still showing its question, so accept that question and
+    // confirm the new frame is consumed without another close call.
+    const closesBefore = calls.filter((call) => call.url === "/api/session/close").length;
+    const second = ctx.handleHerdrErrorFrame(JSON.stringify({ type: "herdr_error" }));
+    await new Promise((resolve) => setImmediate(resolve));
+    ctx.closeQuestion(true);
+    equal(await second, true);
+    equal(
+      calls.filter((call) => call.url === "/api/session/close").length,
+      closesBefore,
+    );
+
+    // Third error: accept again and verify a built-in session launches.
+    const third = ctx.handleHerdrErrorFrame(
+      JSON.stringify({ type: "herdr_error", message: "failed to read herdr handshake" }),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    ctx.closeQuestion(true);
+    await third;
+    const launchCall = calls.find((call) => call.url === "/api/session/launch");
+    ok(launchCall, "session/launch called");
+    deepEqual(JSON.parse(launchCall.opt.body), { session: "default", backend: "builtin" });
+    equal(vm.runInContext("state.sessionBackend", ctx), "builtin");
+  });
+
+  it("defaults new browsers to the server's built-in backend", async () => {
+    const ctx = context();
+    ctx.fetch = async (url) => {
+      equal(url, "/api/versions");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          webui: "1.2.3",
+          backend: "builtin-0.1.0",
+          backend_mode: "builtin",
+          current_backend: "builtin",
+          session: "default",
+          compatibility: { status: "compatible" },
+        }),
+      };
+    };
+    vm.runInContext(source, ctx);
+
+    await ctx.loadVersions();
+
+    equal(vm.runInContext("state.sessionBackend", ctx), "builtin");
+    equal(vm.runInContext("state.serverBackendConfirmed", ctx), true);
+    equal(ctx.localStorage.getItem("herdr-session-backend"), "builtin");
   });
 });

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -671,6 +671,7 @@ if (globalThis.HerdrTempTerminal) {
     wsUrl,
     api,
     modalId: "tempTerminalModal",
+    onHerdrError: typeof handleHerdrErrorFrame === "function" ? handleHerdrErrorFrame : null,
     fontFamilyFn: terminalFontFamily,
     themeFn: terminalTheme,
     defaultFolderFn: defaultFolderPath,

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -38,6 +38,10 @@ let state = {
   supportsSessionSnapshot: false,
   backendMode: "builtin",
   sessionBackend: localStorage.getItem("herdr-session-backend") || "builtin",
+  // True until the first /api/versions response confirms which backend the
+  // server defaults to. Browsers used to hardcode a backend here and race
+  // loadVersions(); now the server's default (built-in) is authoritative.
+  serverBackendConfirmed: false,
   defaultFolder: "",
   workspaceShell: {},
 };
@@ -2551,7 +2555,11 @@ async function loadSessions() {
   try {
     const r = await api("/api/sessions");
     state.sessions = r.sessions || [];
-    state.sessionBackend = r.current_backend || currentSessionBackend();
+    // Do not clobber an explicit user backend choice: the server echoes the
+    // backend used for THIS request, so re-assigning it here can flip the
+    // browser to a different backend mid-session (e.g. when the session
+    // manager reopens after a failed refresh). Only adopt it when unset.
+    if (!state.sessionBackend) state.sessionBackend = r.current_backend || currentSessionBackend();
   } catch (e) {
     state.sessions = [{ name: state.session || "default", backend: currentSessionBackend(), running: false }];
   }
@@ -2620,6 +2628,50 @@ async function launchBackend(session = state.session, backend = currentSessionBa
   } finally {
     hideBlocking();
   }
+}
+// Graceful degradation: the backend handshake failed (protocol mismatch,
+// unreachable backend...). Disconnect, close the broken herdr session, and
+// offer a built-in session instead of leaving the terminal blocked.
+let herdrErrorOfferPending = false;
+async function handleHerdrErrorFrame(raw) {
+  let msg;
+  try {
+    msg = JSON.parse(raw);
+  } catch (_) {
+    return false;
+  }
+  if (!msg || msg.type !== "herdr_error") return false;
+  if (herdrErrorOfferPending) return true;
+  herdrErrorOfferPending = true;
+  try {
+    if (currentSessionBackend() === "external-herdr") {
+      // Detach from the unusable herdr session so stale sockets do not linger.
+      try {
+        await api("/api/session/close", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ session: state.session || "default", backend: "external-herdr" }),
+        });
+      } catch (_) {}
+    }
+    const detail = msg.message ? ` (${msg.message})` : "";
+    const wantsBuiltin = await askQuestion({
+      title: "herdr backend not reachable",
+      message:
+        `The external herdr backend could not be attached${detail}. ` +
+        "It has been disconnected. Start a built-in session instead?",
+      confirmText: "Use built-in session",
+    });
+    if (wantsBuiltin) {
+      goSession(state.session || "default", "builtin");
+      await launchBackend(state.session || "default", "builtin");
+    } else {
+      showSessionManager("herdr backend not reachable", detail ? detail.trim() : undefined);
+    }
+  } finally {
+    herdrErrorOfferPending = false;
+  }
+  return true;
 }
 async function closeCurrentSession() {
   if (!confirm(`Close current ${sessionBackendLabel(currentSessionBackend())} session?`)) return;
@@ -2805,13 +2857,16 @@ async function loadVersions() {
   try {
     const v = await api("/api/versions");
     state.backendMode = v.backend_mode || "builtin";
-    state.sessionBackend =
-      v.current_backend ||
-      (state.backendMode === "external" || state.backendMode === "external-herdr"
-        ? "external-herdr"
-        : state.backendMode === "builtin"
-          ? "builtin"
-          : state.sessionBackend || "builtin");
+    // The server is authoritative for the default backend. On first load
+    // (serverBackendConfirmed false) adopt the server's current backend so a
+    // stale localStorage value cannot lock the browser into a disabled or
+    // incompatible backend; afterwards keep the user's explicit choice.
+    if (!state.serverBackendConfirmed && v.current_backend) {
+      state.sessionBackend = v.current_backend;
+      localStorage.setItem("herdr-session-backend", state.sessionBackend);
+    }
+    state.serverBackendConfirmed = true;
+    if (!state.sessionBackend) state.sessionBackend = currentSessionBackend();
     const session = v.session || state.session || "default";
     const compat = v.compatibility || {},
       status =

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -42,6 +42,11 @@ let state = {
   // server defaults to. Browsers used to hardcode a backend here and race
   // loadVersions(); now the server's default (built-in) is authoritative.
   serverBackendConfirmed: false,
+  // External herdr install detection from /api/sessions and /api/versions;
+  // external sessions are only offered when compatible is true.
+  herdrAvailable: false,
+  herdrCompatible: false,
+  herdrVersion: null,
   defaultFolder: "",
   workspaceShell: {},
 };
@@ -2546,6 +2551,16 @@ function currentSessionBackend() {
   return state.sessionBackend || state.backendMode || "builtin";
 }
 async function newSessionTarget(backend) {
+  // External Herdr sessions are only offered when a compatible herdr
+  // install was detected; the server gate rejects the launch otherwise.
+  if (backend === "external-herdr" && !state.herdrCompatible) {
+    alert(
+      state.herdrAvailable
+        ? `Detected herdr ${state.herdrVersion || ""} is not compatible with this WebUI build. Upgrade herdr or use a built-in session.`
+        : "No compatible herdr install detected. Install herdr to use external Herdr sessions.",
+    );
+    return;
+  }
   const name = prompt(`${sessionBackendLabel(backend)} session name`);
   if (!name) return;
   await launchBackend(name, backend);
@@ -2555,6 +2570,14 @@ async function loadSessions() {
   try {
     const r = await api("/api/sessions");
     state.sessions = r.sessions || [];
+    // Server-side detection of the installed herdr binary; external Herdr
+    // sessions are only offered when it is present AND compatible. Keep the
+    // last known state when the response omits the fields (older servers).
+    if ("herdr_compatible" in r) {
+      state.herdrAvailable = !!r.herdr_available;
+      state.herdrCompatible = !!r.herdr_compatible;
+      state.herdrVersion = r.herdr_version || null;
+    }
     // Do not clobber an explicit user backend choice: the server echoes the
     // backend used for THIS request, so re-assigning it here can flip the
     // browser to a different backend mid-session (e.g. when the session
@@ -2600,6 +2623,22 @@ async function showSessionManager(title, text) {
   if (current)
     current.textContent = `${state.session || "default"} · ${sessionBackendLabel(currentSessionBackend())}`;
   if (list) list.innerHTML = renderSessionRows();
+  // Gate the external-Herdr offer on a detected, compatible herdr install.
+  const herdrButton = el("newHerdrSessionTarget");
+  if (herdrButton) {
+    if (state.herdrCompatible) {
+      herdrButton.disabled = false;
+      herdrButton.title = state.herdrVersion
+        ? `Detected herdr ${state.herdrVersion}`
+        : "Detected compatible herdr install";
+    } else if (state.herdrAvailable) {
+      herdrButton.disabled = true;
+      herdrButton.title = `Detected herdr ${state.herdrVersion || ""} is not compatible with this WebUI build; upgrade herdr or use a built-in session`;
+    } else {
+      herdrButton.disabled = true;
+      herdrButton.title = "No compatible herdr install detected; install herdr to use external Herdr sessions";
+    }
+  }
   if (manager) manager.style.display = "block";
 }
 function hideSessionManager() {
@@ -2857,13 +2896,28 @@ async function loadVersions() {
   try {
     const v = await api("/api/versions");
     state.backendMode = v.backend_mode || "builtin";
+    // Installed external herdr detection; used to gate the external offer.
+    // Older/mock responses may lack herdr_install; keep the last known state
+    // instead of clobbering it with false.
+    if (v.herdr_install) {
+      const install = v.herdr_install;
+      state.herdrAvailable = !!install.available;
+      state.herdrCompatible = !!install.compatible;
+      state.herdrVersion = install.version || null;
+    }
     // The server is authoritative for the default backend. On first load
     // (serverBackendConfirmed false) adopt the server's current backend so a
     // stale localStorage value cannot lock the browser into a disabled or
     // incompatible backend; afterwards keep the user's explicit choice.
+    // Additionally, never target external herdr when no compatible install
+    // was detected — the attach would be guaranteed to fail.
     if (!state.serverBackendConfirmed && v.current_backend) {
       state.sessionBackend = v.current_backend;
       localStorage.setItem("herdr-session-backend", state.sessionBackend);
+    }
+    if (currentSessionBackend() === "external-herdr" && !state.herdrCompatible) {
+      state.sessionBackend = "builtin";
+      localStorage.setItem("herdr-session-backend", "builtin");
     }
     state.serverBackendConfirmed = true;
     if (!state.sessionBackend) state.sessionBackend = currentSessionBackend();
@@ -2881,6 +2935,8 @@ async function loadVersions() {
     if (versionsEl) {
       versionsEl.textContent = `webui ${v.webui || "-"} · backend ${backendLabel}${status}`;
       versionsEl.title = `session ${session}${compat.message ? ` · ${compat.message}` : ""}`;
+      if (state.herdrAvailable && !state.herdrCompatible)
+        versionsEl.title += ` · herdr ${state.herdrVersion || "?"} is not compatible with this WebUI build`;
     }
     const button = el("footerSessionButton");
     if (button) button.textContent = `${state.session || session} · ${sessionBackendLabel(currentSessionBackend())}`;
@@ -3003,6 +3059,9 @@ function go(ws, tab, pane) {
   refresh();
 }
 function goSession(name, backend = currentSessionBackend()) {
+  // Do not switch the browser to external herdr when no compatible install
+  // was detected; keep the built-in session instead.
+  if (backend === "external-herdr" && !state.herdrCompatible) backend = "builtin";
   state.session = name || "default";
   state.sessionBackend = backend || "builtin";
   localStorage.setItem("herdr-session-backend", state.sessionBackend);

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -185,6 +185,12 @@ async function connectTerminal() {
   };
   ws.onmessage = (e) => {
     if (termWs !== ws || connectedTerminalId !== target) return;
+    if (typeof e.data === "string" && handleHerdrErrorFrame(e.data)) {
+      // Backend attach failed (e.g. protocol mismatch). The handler offered
+      // recovery; drop this socket so a clean reconnect happens later.
+      ws.close();
+      return;
+    }
     // Don't hide loading overlay here for attach frames; the write callback
     // in flushTerminalFrames will reveal the terminal once parsing completes.
     // For normal frames, hide it immediately.

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -13,7 +13,10 @@
   const state = {
     session: "default",
     backendMode: "",
-    sessionBackend: localStorage.getItem("herdr-session-backend") || "",
+    // Built-in sessions are the default; /api/server-settings confirms the
+    // server's configured backend mode on first load.
+    sessionBackend: localStorage.getItem("herdr-session-backend") || "builtin",
+    serverBackendConfirmed: false,
     workspaces: [],
     tabs: [],
     allTabs: [],
@@ -144,6 +147,19 @@
       const settings = await api("/api/server-settings");
       state.backendMode = settings.backend_mode || state.backendMode;
       state.defaultFolder = settings.default_folder || state.defaultFolder || "";
+      // Built-in is the default backend. On first load adopt the server's
+      // configured mode so stale localStorage cannot lock the browser into an
+      // unexpected backend; afterwards keep the user's explicit choice.
+      if (!state.serverBackendConfirmed && state.backendMode) {
+        state.sessionBackend =
+          state.backendMode === "external" || state.backendMode === "external-herdr"
+            ? "external-herdr"
+            : state.backendMode === "builtin"
+              ? "builtin"
+              : state.sessionBackend;
+        localStorage.setItem("herdr-session-backend", state.sessionBackend);
+      }
+      state.serverBackendConfirmed = true;
     } catch (_) {}
   }
 
@@ -165,6 +181,55 @@
       ? (path.includes("?") ? "&" : "?") + params.join("&")
       : "";
     return `${proto}//${location.host}${path}${suffix}`;
+  }
+
+  // Graceful degradation: the external herdr backend could not be attached
+  // (protocol mismatch, unreachable...). Close the broken session and offer
+  // a built-in session instead of leaving the terminal blocked.
+  let herdrErrorOfferPending = false;
+  function handleHerdrErrorFrame(raw) {
+    let msg;
+    try {
+      msg = JSON.parse(raw);
+    } catch (_) {
+      return false;
+    }
+    if (!msg || msg.type !== "herdr_error") return false;
+    if (herdrErrorOfferPending) return true;
+    herdrErrorOfferPending = true;
+    (async () => {
+      try {
+        if (currentSessionBackend() === "external-herdr") {
+          try {
+            await api("/api/session/close", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ session: state.session || "default", backend: "external-herdr" }),
+            });
+          } catch (_) {}
+        }
+        const detail = msg.message ? ` (${msg.message})` : "";
+        const wantsBuiltin = confirm(
+          `The external herdr backend could not be attached${detail}. ` +
+            "It has been disconnected. Start a built-in session instead?",
+        );
+        if (wantsBuiltin) {
+          try {
+            await api("/api/session/launch", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ session: state.session || "default", backend: "builtin" }),
+            });
+          } catch (_) {}
+          state.sessionBackend = "builtin";
+          localStorage.setItem("herdr-session-backend", "builtin");
+          refresh();
+        }
+      } finally {
+        herdrErrorOfferPending = false;
+      }
+    })();
+    return true;
   }
 
   function currentSessionBackend() {
@@ -1400,13 +1465,14 @@
     state,
     window,
   });
-  mobileTerminal = globalThis.HerdrMobileTerminal.create({ el, state, wsUrl });
+  mobileTerminal = globalThis.HerdrMobileTerminal.create({ el, state, wsUrl, onHerdrError: handleHerdrErrorFrame });
   mobileTempTerminal = globalThis.HerdrTempTerminal.create({
     el,
     state,
     wsUrl,
     api,
     modalId: "tempTerminalModal",
+    onHerdrError: handleHerdrErrorFrame,
     fontFamilyFn: () => {
       try {
         const parsed = globalThis.HerdrOptions ? globalThis.HerdrOptions.read() : {};

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -161,6 +161,19 @@
       }
       state.serverBackendConfirmed = true;
     } catch (_) {}
+    // External herdr sessions are only offered when a compatible herdr
+    // install is detected. If it is missing or incompatible, fall back to
+    // built-in instead of targeting a guaranteed-failed attach.
+    try {
+      const r = await api("/api/sessions");
+      state.herdrAvailable = !!r.herdr_available;
+      state.herdrCompatible = !!r.herdr_compatible;
+      state.herdrVersion = r.herdr_version || null;
+      if (currentSessionBackend() === "external-herdr" && !state.herdrCompatible) {
+        state.sessionBackend = "builtin";
+        localStorage.setItem("herdr-session-backend", "builtin");
+      }
+    } catch (_) {}
   }
 
   function apiErrorMessage(body, statusText) {

--- a/src/assets/mobile/terminal.js
+++ b/src/assets/mobile/terminal.js
@@ -1,5 +1,5 @@
 (function () {
-  function createMobileTerminal({ el, state, wsUrl }) {
+  function createMobileTerminal({ el, state, wsUrl, onHerdrError }) {
     let term = null,
       termWs = null,
       openedTerminalElement = null,
@@ -102,6 +102,16 @@
       ws.onopen = () => { if (termWs === ws) terminalAttachPending = true; };
       ws.onmessage = (event) => {
         if (termWs !== ws) return;
+        if (
+          typeof event.data === "string" &&
+          onHerdrError &&
+          onHerdrError(event.data)
+        ) {
+          // Backend attach failed (e.g. protocol mismatch): the host app
+          // offered recovery, drop this socket for a clean reconnect.
+          ws.close();
+          return;
+        }
         enqueueTerminalFrame(typeof event.data === "string" ? event.data : new Uint8Array(event.data));
       };
       ws.onclose = () => {

--- a/src/assets/shared/temp_terminal.js
+++ b/src/assets/shared/temp_terminal.js
@@ -63,6 +63,7 @@
     var wsUrl = opts.wsUrl;
     var api = opts.api;
     var modalId = opts.modalId;
+    var onHerdrError = opts.onHerdrError || null;
     var fontFamilyFn = opts.fontFamilyFn || function () { return "monospace"; };
     var themeFn = opts.themeFn || function () { return {}; };
     var defaultFolderFn = opts.defaultFolderFn || function () { return ""; };
@@ -601,6 +602,11 @@
             };
             ws.onmessage = function (event) {
               if (termWs !== ws) return;
+              if (typeof event.data === "string" && onHerdrError && onHerdrError(event.data)) {
+                // Backend attach failed; the host app offered recovery.
+                ws.close();
+                return;
+              }
               enqueueFrame(typeof event.data === "string" ? event.data : new Uint8Array(event.data));
             };
             ws.onclose = function () {

--- a/src/backend_client.rs
+++ b/src/backend_client.rs
@@ -8,8 +8,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use crate::protocol::{
-    read_message, write_message, ClientKeybindings, ClientLaunchMode, ClientMessage,
-    RenderEncoding, ServerMessage, TerminalFrame,
+    read_message, write_message, ClientMessage, RenderEncoding, ServerMessage, TerminalFrame,
 };
 
 /// Client-side API intended for a future first-party TUI or smoke CLI.
@@ -235,15 +234,13 @@ impl BackendClient {
         let rows = rows.max(1);
         write_protocol(
             &mut stream,
-            &ClientMessage::Hello {
+            &ClientMessage::TerminalHello {
                 version: BUILTIN_TUI_PROTOCOL_VERSION,
                 cols,
                 rows,
                 cell_width_px: 0,
                 cell_height_px: 0,
-                requested_encoding: RenderEncoding::TerminalAnsi,
-                keybindings: ClientKeybindings::Server,
-                launch_mode: ClientLaunchMode::TerminalAttach,
+                pixel_mouse: false,
             },
         )?;
         match read_protocol::<ServerMessage>(&mut stream)? {
@@ -370,10 +367,8 @@ impl TerminalClient {
     pub fn paste_text(&mut self, text: &str) -> Result<(), BackendClientError> {
         write_protocol(
             &mut self.stream,
-            &ClientMessage::InputEvents {
-                events: vec![crate::protocol::ClientInputEvent::Paste {
-                    text: text.to_string(),
-                }],
+            &ClientMessage::Input {
+                data: format!("\x1b[200~{}\x1b[201~", text).into_bytes(),
             },
         )
     }
@@ -388,6 +383,7 @@ impl TerminalClient {
                 rows: self.rows,
                 cell_width_px: 0,
                 cell_height_px: 0,
+                pixel_mouse: false,
             },
         )
     }
@@ -414,10 +410,8 @@ impl TerminalWriter {
     pub fn paste_text(&mut self, text: &str) -> Result<(), BackendClientError> {
         write_protocol(
             &mut self.stream,
-            &ClientMessage::InputEvents {
-                events: vec![crate::protocol::ClientInputEvent::Paste {
-                    text: text.to_string(),
-                }],
+            &ClientMessage::Input {
+                data: format!("\x1b[200~{}\x1b[201~", text).into_bytes(),
             },
         )
     }
@@ -432,6 +426,7 @@ impl TerminalWriter {
                 rows: self.rows,
                 cell_width_px: 0,
                 cell_height_px: 0,
+                pixel_mouse: false,
             },
         )
     }
@@ -921,8 +916,8 @@ mod tests {
                 match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
                     .unwrap()
                 {
-                    ClientMessage::Hello { .. } => {}
-                    other => panic!("expected hello, got {other:?}"),
+                    ClientMessage::TerminalHello { .. } => {}
+                    other => panic!("expected terminal hello, got {other:?}"),
                 }
                 write_message(&mut stream, &response).unwrap();
             }
@@ -958,7 +953,7 @@ mod tests {
             match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
                 .unwrap()
             {
-                ClientMessage::Hello { cols, rows, .. } => assert_eq!((cols, rows), (1, 1)),
+                ClientMessage::TerminalHello { cols, rows, .. } => assert_eq!((cols, rows), (1, 1)),
                 other => panic!("expected hello, got {other:?}"),
             }
             write_message(
@@ -1003,7 +998,6 @@ mod tests {
                     reason: Some("done".to_string()),
                 },
                 ServerMessage::ReloadSoundConfig,
-                ServerMessage::PrefixInputSource { active: true },
             ];
             for event in events {
                 write_message(&mut stream, &event).unwrap();
@@ -1048,7 +1042,6 @@ mod tests {
             }
         );
         assert_eq!(terminal.read_event().unwrap(), TerminalEvent::Ignored);
-        assert_eq!(terminal.read_event().unwrap(), TerminalEvent::Ignored);
 
         handle.join().unwrap();
         let _ = fs::remove_file(socket);
@@ -1064,7 +1057,7 @@ mod tests {
             match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
                 .unwrap()
             {
-                ClientMessage::Hello { cols, rows, .. } => {
+                ClientMessage::TerminalHello { cols, rows, .. } => {
                     assert_eq!(cols, 80);
                     assert_eq!(rows, 24);
                 }
@@ -1109,13 +1102,10 @@ mod tests {
             match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
                 .unwrap()
             {
-                ClientMessage::InputEvents { events } => match &events[..] {
-                    [crate::protocol::ClientInputEvent::Paste { text }] => {
-                        assert_eq!(text, "terminal paste")
-                    }
-                    other => panic!("expected paste event, got {other:?}"),
-                },
-                other => panic!("expected input events, got {other:?}"),
+                ClientMessage::Input { data } => {
+                    assert_eq!(data, b"\x1b[200~terminal paste\x1b[201~")
+                }
+                other => panic!("expected bracketed paste input, got {other:?}"),
             }
             match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
                 .unwrap()
@@ -1128,13 +1118,10 @@ mod tests {
             match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
                 .unwrap()
             {
-                ClientMessage::InputEvents { events } => match &events[..] {
-                    [crate::protocol::ClientInputEvent::Paste { text }] => {
-                        assert_eq!(text, "writer paste")
-                    }
-                    other => panic!("expected writer paste event, got {other:?}"),
-                },
-                other => panic!("expected writer input events, got {other:?}"),
+                ClientMessage::Input { data } => {
+                    assert_eq!(data, b"\x1b[200~writer paste\x1b[201~")
+                }
+                other => panic!("expected writer bracketed paste, got {other:?}"),
             }
             match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
                 .unwrap()
@@ -1183,8 +1170,8 @@ mod tests {
             match read_message::<_, ClientMessage>(&mut stream, MAX_TUI_TERMINAL_FRAME_SIZE)
                 .unwrap()
             {
-                ClientMessage::Hello { .. } => {}
-                other => panic!("expected hello, got {other:?}"),
+                ClientMessage::TerminalHello { .. } => {}
+                other => panic!("expected terminal hello, got {other:?}"),
             }
             write_message(
                 &mut stream,

--- a/src/builtin_backend.rs
+++ b/src/builtin_backend.rs
@@ -16,8 +16,7 @@ use serde_json::{json, Value};
 use crate::builtin_detection::{jcode::detect_jcode_status_with_variant, JcodeDetectionVariant};
 use crate::builtin_events::{BuiltinEventHub, PaneEventContext};
 use crate::protocol::{
-    read_message, write_message, ClientMessage, RenderEncoding, ServerMessage,
-    TerminalFrame,
+    read_message, write_message, ClientMessage, RenderEncoding, ServerMessage, TerminalFrame,
 };
 use crate::terminal_text::{self, TerminalTextOptions};
 

--- a/src/builtin_backend.rs
+++ b/src/builtin_backend.rs
@@ -16,7 +16,7 @@ use serde_json::{json, Value};
 use crate::builtin_detection::{jcode::detect_jcode_status_with_variant, JcodeDetectionVariant};
 use crate::builtin_events::{BuiltinEventHub, PaneEventContext};
 use crate::protocol::{
-    read_message, write_message, ClientInputEvent, ClientMessage, RenderEncoding, ServerMessage,
+    read_message, write_message, ClientMessage, RenderEncoding, ServerMessage,
     TerminalFrame,
 };
 use crate::terminal_text::{self, TerminalTextOptions};
@@ -376,16 +376,24 @@ fn handle_client_connection(
     backend: Arc<BuiltinBackendInner>,
 ) -> Result<(), String> {
     let hello = read_message::<_, ClientMessage>(&mut stream, MAX_FRAME_SIZE)?;
-    let (cols, rows, requested_encoding) = match hello {
-        ClientMessage::Hello {
+    let (cols, rows) = match hello {
+        ClientMessage::TerminalHello {
             version,
             cols,
             rows,
-            requested_encoding,
             ..
         } => {
-            let error = (version > PROTOCOL_VERSION).then(|| {
-                format!("client version {version} is newer than server version {PROTOCOL_VERSION}")
+            // herdr 0.9.0 requires an exact protocol version match.
+            let error = (version != PROTOCOL_VERSION).then(|| {
+                if version > PROTOCOL_VERSION {
+                    format!(
+                        "client version {version} is newer than server version {PROTOCOL_VERSION}"
+                    )
+                } else {
+                    format!(
+                        "client version {version} is older than server version {PROTOCOL_VERSION}; please upgrade your herdr client"
+                    )
+                }
             });
             write_message(
                 &mut stream,
@@ -395,14 +403,13 @@ fn handle_client_connection(
                     error,
                 },
             )?;
-            if version > PROTOCOL_VERSION {
+            if version != PROTOCOL_VERSION {
                 return Ok(());
             }
-            (cols.max(1), rows.max(1), requested_encoding)
+            (cols.max(1), rows.max(1))
         }
-        _ => return Err("expected Hello as first terminal client message".to_string()),
+        _ => return Err("expected TerminalHello as first terminal client message".to_string()),
     };
-    let _ = requested_encoding;
 
     let mut attached: Option<Arc<TerminalRuntime>> = None;
     let mut writer_started = false;
@@ -476,17 +483,6 @@ fn handle_client_connection(
                     terminal.write_input(&data).map_err(|err| err.to_string())?;
                 }
             }
-            ClientMessage::InputEvents { events } => {
-                if let Some(terminal) = &attached {
-                    for event in events {
-                        if let ClientInputEvent::Paste { text } = event {
-                            terminal
-                                .write_input(text.as_bytes())
-                                .map_err(|err| err.to_string())?;
-                        }
-                    }
-                }
-            }
             ClientMessage::Resize { cols, rows, .. } => {
                 if let Ok(mut size) = terminal_size.lock() {
                     *size = (cols.max(1), rows.max(1));
@@ -501,14 +497,24 @@ fn handle_client_connection(
             }
             ClientMessage::Detach => break,
             ClientMessage::ClipboardImage { .. } => {}
-            ClientMessage::Hello { .. } => {}
-            // Protocol 20+ messages from graphics streaming and terminal
-            // control modes are not used by the built-in backend.
+            ClientMessage::TerminalHello { .. } => {}
+            // Protocol 22 messages from graphics streaming, client-owned
+            // shells, and terminal control modes are not used by the built-in
+            // backend.
             ClientMessage::ObserveTerminal { .. }
             | ClientMessage::ControlTerminal { .. }
             | ClientMessage::GraphicsTransmissionResult { .. }
-            | ClientMessage::InputPixels { .. }
-            | ClientMessage::GraphicsTransmissionStarted { .. } => {}
+            | ClientMessage::GraphicsTransmissionStarted { .. }
+            | ClientMessage::ClientShellHello { .. }
+            | ClientMessage::ClientShellResize { .. }
+            | ClientMessage::ClientShellPaneInput { .. }
+            | ClientMessage::ClientShellPopupInput { .. }
+            | ClientMessage::ClientShellEndpointRequest { .. }
+            | ClientMessage::AttachMouse { .. }
+            | ClientMessage::ClientShellHostTheme { .. }
+            | ClientMessage::ClientShellFocus { .. }
+            | ClientMessage::ClientShellMouseCapture { .. }
+            | ClientMessage::EndpointControl { .. } => {}
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,8 @@ use assets::{
     vendor_dompurify_js, vendor_ghostty_wasm, vendor_marked_js, vendor_mermaid_js,
     vendor_wterm_css, vendor_wterm_js,
 };
-use compat::{backend_compatibility, BackendCompatibility};
 use compat::SimpleVersion;
+use compat::{backend_compatibility, BackendCompatibility};
 use protocol::*;
 
 const DEFAULT_BIND: &str = "127.0.0.1:8787";
@@ -125,9 +125,9 @@ fn detect_herdr_install(herdr_bin: &str) -> HerdrInstall {
     }
     let text = String::from_utf8_lossy(&output.stdout);
     // Accept both "herdr 0.9.0" and a bare "0.9.0".
-    let version = text
-        .split_whitespace()
-        .find_map(|token| SimpleVersion::parse(token).map(|_| token.trim_start_matches('v').to_string()));
+    let version = text.split_whitespace().find_map(|token| {
+        SimpleVersion::parse(token).map(|_| token.trim_start_matches('v').to_string())
+    });
     let Some(version) = version else {
         return HerdrInstall::default();
     };
@@ -4510,9 +4510,13 @@ fn terminal_text_messages(text: &str) -> Vec<ClientMessage> {
                 .and_then(|value| u8::try_from(value).ok())
                 .unwrap_or(0);
             vec![ClientMessage::Input {
-                data: (if modifiers & 1 != 0 { "\x1b[13;2u" } else { "\r" })
-                    .as_bytes()
-                    .to_vec(),
+                data: (if modifiers & 1 != 0 {
+                    "\x1b[13;2u"
+                } else {
+                    "\r"
+                })
+                .as_bytes()
+                .to_vec(),
             }]
         }
         Some("paste") => value
@@ -5830,10 +5834,7 @@ mod tests {
             BackendCompatibility::Compatible
         );
         assert_eq!(
-            backend_compatibility_for_supported_range(
-                Some("0.9.0"),
-                Some(PROTOCOL_VERSION),
-            ),
+            backend_compatibility_for_supported_range(Some("0.9.0"), Some(PROTOCOL_VERSION),),
             BackendCompatibility::Compatible
         );
         assert_eq!(
@@ -5872,13 +5873,18 @@ mod tests {
         // (socket missing, attach send failing) do not, since the backend
         // may just be restarting.
         assert!(TerminalAttachError::ReadHandshake.suggests_builtin());
-        assert!(TerminalAttachError::Rejected("client version 22 is newer than server version 21".into())
-            .suggests_builtin());
+        assert!(TerminalAttachError::Rejected(
+            "client version 22 is newer than server version 21".into()
+        )
+        .suggests_builtin());
         assert!(!TerminalAttachError::Connect.suggests_builtin());
         assert!(!TerminalAttachError::SendHandshake.suggests_builtin());
         assert!(!TerminalAttachError::Attach.suggests_builtin());
 
-        assert_eq!(TerminalAttachError::ReadHandshake.error_kind(), "handshake_failed");
+        assert_eq!(
+            TerminalAttachError::ReadHandshake.error_kind(),
+            "handshake_failed"
+        );
         assert_eq!(
             TerminalAttachError::Rejected("mismatch".into()).error_kind(),
             "handshake_rejected"

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,10 +64,10 @@ const HERDR_WEBUI_VERSION: &str = env!("HERDR_WEBUI_VERSION");
 const INSTALL_LABEL: &str = "herdr-web";
 const MAX_FRAME_SIZE: usize = 2 * 1024 * 1024;
 const MAX_GRAPHICS_FRAME_SIZE: usize = 32 * 1024 * 1024;
-const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 16;
-const PROTOCOL_VERSION: u32 = 20;
-const MIN_BACKEND_VERSION: &str = "0.7.3";
-const MAX_TESTED_BACKEND_VERSION: &str = "0.8.0";
+const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 22;
+const PROTOCOL_VERSION: u32 = 22;
+const MIN_BACKEND_VERSION: &str = "0.9.0";
+const MAX_TESTED_BACKEND_VERSION: &str = "0.9.0";
 const DEFAULT_FOLDER_READ_TIMEOUT: Duration = Duration::from_millis(1500);
 
 type LocalStream = interprocess::local_socket::Stream;
@@ -4232,16 +4232,17 @@ async fn terminal_socket(
     let rows = query.rows.unwrap_or(30).max(1);
     let (out_tx, mut out_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
     let (in_tx, in_rx) = std::sync::mpsc::channel::<ClientMessage>();
+    let (error_tx, error_rx) = tokio::sync::oneshot::channel::<TerminalAttachError>();
 
     std::thread::spawn(move || {
-        let mut stream =
-            match connect_terminal_attach_with_protocol_fallback(&path, &terminal_id, cols, rows) {
-                Ok(stream) => stream,
-                Err(error) => {
-                    let _ = out_tx.send(error.user_message().into_bytes());
-                    return;
-                }
-            };
+        let mut stream = match connect_terminal_attach(&path, &terminal_id, cols, rows) {
+            Ok(stream) => stream,
+            Err(error) => {
+                let _ = out_tx.send(error.user_message().into_bytes());
+                let _ = error_tx.send(error);
+                return;
+            }
+        };
 
         let Ok(mut writer) = stream.try_clone() else {
             let _ = out_tx.send(b"failed to clone herdr terminal socket\r\n".to_vec());
@@ -4274,8 +4275,26 @@ async fn terminal_socket(
         }
     });
 
+    let mut error_rx = error_rx;
     loop {
         tokio::select! {
+            error = &mut error_rx => {
+                // Graceful degradation: surface the handshake failure as a
+                // structured frame before closing, so the browser can offer
+                // a built-in session instead of blocking on a dead terminal.
+                if let Ok(error) = error {
+                    let payload = json!({
+                        "type": "herdr_error",
+                        "kind": error.error_kind(),
+                        "message": error.user_message().trim_end(),
+                        "suggest_builtin": error.suggests_builtin(),
+                    });
+                    if let Ok(text) = serde_json::to_string(&payload) {
+                        let _ = socket.send(Message::Text(text.into())).await;
+                    }
+                }
+                break;
+            }
             message = out_rx.recv() => {
                 let Some(bytes) = message else { break; };
                 if socket.send(Message::Binary(bytes.into())).await.is_err() { break; }
@@ -4332,6 +4351,7 @@ fn terminal_text_messages(text: &str) -> Vec<ClientMessage> {
                 rows: rows.max(1),
                 cell_width_px: 0,
                 cell_height_px: 0,
+                pixel_mouse: false,
             }]
         }
         Some("scroll") => {
@@ -4373,25 +4393,20 @@ fn terminal_text_messages(text: &str) -> Vec<ClientMessage> {
                 .and_then(|value| value.as_u64())
                 .and_then(|value| u8::try_from(value).ok())
                 .unwrap_or(0);
-            vec![ClientMessage::InputEvents {
-                events: vec![ClientInputEvent::Key {
-                    code: ClientKeyCode::Enter,
-                    modifiers,
-                    kind: ClientKeyKind::Press,
-                    repeat_count: 1,
-                    generated_text: None,
-                    source: ClientKeySource::Synthesized,
-                }],
+            vec![ClientMessage::Input {
+                data: (if modifiers & 1 != 0 { "\x1b[13;2u" } else { "\r" })
+                    .as_bytes()
+                    .to_vec(),
             }]
         }
         Some("paste") => value
             .get("text")
             .and_then(|value| value.as_str())
             .map(|text| {
-                vec![ClientMessage::InputEvents {
-                    events: vec![ClientInputEvent::Paste {
-                        text: text.to_string(),
-                    }],
+                // herdr 0.9.0 removed `InputEvents`; paste is delivered as
+                // raw bracketed-paste input bytes.
+                vec![ClientMessage::Input {
+                    data: format!("\x1b[200~{}\x1b[201~", text).into_bytes(),
                 }]
             })
             .unwrap_or_default(),
@@ -4426,55 +4441,45 @@ impl TerminalAttachError {
             Self::Attach => "failed to attach herdr terminal\r\n".to_string(),
         }
     }
-}
 
-fn connect_terminal_attach_with_protocol_fallback(
-    path: &Path,
-    terminal_id: &str,
-    cols: u16,
-    rows: u16,
-) -> Result<LocalStream, TerminalAttachError> {
-    // Try protocols in descending order so a newer WebUI can attach to older
-    // compatible backends. The backend rejects mismatched versions with a
-    // Welcome error containing "newer than server version" when the client
-    // protocol is higher than the server protocol.
-    for protocol_version in (MIN_SUPPORTED_PROTOCOL_VERSION..=PROTOCOL_VERSION).rev() {
-        match connect_terminal_attach(path, terminal_id, protocol_version, cols, rows) {
-            Ok(stream) => return Ok(stream),
-            Err(TerminalAttachError::Rejected(error))
-                if should_retry_legacy_protocol(protocol_version, &error) =>
-            {
-                continue;
-            }
-            result => return result,
+    /// Machine-readable kind forwarded to the browser so it can offer a
+    /// built-in session when the external herdr backend cannot be attached.
+    fn error_kind(&self) -> &'static str {
+        match self {
+            Self::Connect => "connect_failed",
+            Self::SendHandshake => "handshake_failed",
+            Self::ReadHandshake => "handshake_failed",
+            Self::Rejected(_) => "handshake_rejected",
+            Self::Attach => "attach_failed",
         }
     }
-    connect_terminal_attach(
-        path,
-        terminal_id,
-        MIN_SUPPORTED_PROTOCOL_VERSION,
-        cols,
-        rows,
-    )
+
+    /// True when the failure means the external herdr backend is unusable
+    /// for terminal attach (protocol/handshake problems) and the UI should
+    /// offer a built-in session instead of retrying silently.
+    fn suggests_builtin(&self) -> bool {
+        matches!(self, Self::ReadHandshake | Self::Rejected(_))
+    }
 }
 
+/// herdr 0.9.0 requires an exact client protocol version match at handshake
+/// time, so no multi-version fallback is possible: the client sends
+/// `TerminalHello{version: PROTOCOL_VERSION}` and the backend either accepts
+/// it or rejects the connection with a `Welcome{error}`.
 fn connect_terminal_attach(
     path: &Path,
     terminal_id: &str,
-    protocol_version: u32,
     cols: u16,
     rows: u16,
 ) -> Result<LocalStream, TerminalAttachError> {
     let mut stream = connect_local_stream(path).map_err(|_| TerminalAttachError::Connect)?;
-    let hello = ClientMessage::Hello {
-        version: protocol_version,
+    let hello = ClientMessage::TerminalHello {
+        version: PROTOCOL_VERSION,
         cols,
         rows,
         cell_width_px: 0,
         cell_height_px: 0,
-        requested_encoding: RenderEncoding::TerminalAnsi,
-        keybindings: ClientKeybindings::Server,
-        launch_mode: ClientLaunchMode::TerminalAttach,
+        pixel_mouse: false,
     };
     write_message(&mut stream, &hello).map_err(|_| TerminalAttachError::SendHandshake)?;
 
@@ -4497,14 +4502,6 @@ fn connect_terminal_attach(
     )
     .map_err(|_| TerminalAttachError::Attach)?;
     Ok(stream)
-}
-
-/// Returns true when the rejected `protocol_version` is newer than the server
-/// and there is at least one older protocol version left to try.
-fn should_retry_legacy_protocol(protocol_version: u32, error: &str) -> bool {
-    protocol_version > MIN_SUPPORTED_PROTOCOL_VERSION
-        && error.contains("client version")
-        && error.contains("newer than server version")
 }
 
 #[cfg(test)]
@@ -5698,35 +5695,32 @@ mod tests {
 
     #[test]
     fn classifies_backend_compatibility() {
+        // herdr 0.9.0 requires an exact protocol match: every supported
+        // release maps 1:1 to its own protocol version.
         assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.2"), Some(PROTOCOL_VERSION)),
-            BackendCompatibility::TooOld
+            backend_compatibility_for_supported_range(Some("0.8.0"), Some(20)),
+            BackendCompatibility::ProtocolMismatch
+        );
+        assert_eq!(
+            backend_compatibility_for_supported_range(Some("0.8.0"), Some(PROTOCOL_VERSION - 1)),
+            BackendCompatibility::ProtocolMismatch
         );
         assert_eq!(
             backend_compatibility_for_supported_range(
-                Some("0.7.3"),
+                Some("0.9.0"),
                 Some(MIN_SUPPORTED_PROTOCOL_VERSION),
             ),
             BackendCompatibility::Compatible
         );
         assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.3"), Some(PROTOCOL_VERSION)),
+            backend_compatibility_for_supported_range(
+                Some("0.9.0"),
+                Some(PROTOCOL_VERSION),
+            ),
             BackendCompatibility::Compatible
         );
         assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.4"), Some(PROTOCOL_VERSION)),
-            BackendCompatibility::Compatible
-        );
-        assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.5"), Some(PROTOCOL_VERSION)),
-            BackendCompatibility::Compatible
-        );
-        assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.8.0"), Some(PROTOCOL_VERSION)),
-            BackendCompatibility::Compatible
-        );
-        assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.8.1"), Some(PROTOCOL_VERSION)),
+            backend_compatibility_for_supported_range(Some("0.9.1"), Some(PROTOCOL_VERSION)),
             BackendCompatibility::UntestedNewer
         );
         assert_eq!(
@@ -5738,51 +5732,58 @@ mod tests {
             BackendCompatibility::Unknown
         );
         assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.3"), None),
+            backend_compatibility_for_supported_range(Some("0.9.0"), None),
             BackendCompatibility::Unknown
         );
         assert_eq!(
-            backend_compatibility_for_supported_range(Some("0.7.3"), Some(PROTOCOL_VERSION + 1)),
+            backend_compatibility_for_supported_range(Some("0.9.0"), Some(PROTOCOL_VERSION + 1)),
             BackendCompatibility::ProtocolMismatch
         );
     }
 
     #[test]
-    fn terminal_protocol_fallback_retries_only_newer_client_mismatch() {
-        assert!(should_retry_legacy_protocol(
-            PROTOCOL_VERSION,
-            "client version 18 is newer than server version 17; please upgrade the herdr server",
-        ));
-        assert!(should_retry_legacy_protocol(
-            PROTOCOL_VERSION - 1,
-            "client version 17 is newer than server version 16; please upgrade the herdr server",
-        ));
-        assert!(!should_retry_legacy_protocol(
-            MIN_SUPPORTED_PROTOCOL_VERSION,
-            "client version 16 is newer than server version 15; please upgrade the herdr server",
-        ));
-        assert!(!should_retry_legacy_protocol(
-            PROTOCOL_VERSION,
-            "client version 18 is older than the minimum supported version 19",
-        ));
-        assert!(!should_retry_legacy_protocol(
-            PROTOCOL_VERSION,
-            "invalid local keybindings",
-        ));
+    fn terminal_handshake_requires_exact_protocol_version() {
+        // herdr 0.9.0 rejects every client version except its own. The
+        // handshake must send exactly PROTOCOL_VERSION or the backend closes
+        // the connection after the Welcome rejection.
+        assert_eq!(PROTOCOL_VERSION, 22);
     }
 
     #[test]
-    fn terminal_text_messages_maps_paste_to_semantic_input_event() {
+    fn terminal_attach_errors_classify_for_graceful_degradation() {
+        // Handshake failures offer a built-in session; transport failures
+        // (socket missing, attach send failing) do not, since the backend
+        // may just be restarting.
+        assert!(TerminalAttachError::ReadHandshake.suggests_builtin());
+        assert!(TerminalAttachError::Rejected("client version 22 is newer than server version 21".into())
+            .suggests_builtin());
+        assert!(!TerminalAttachError::Connect.suggests_builtin());
+        assert!(!TerminalAttachError::SendHandshake.suggests_builtin());
+        assert!(!TerminalAttachError::Attach.suggests_builtin());
+
+        assert_eq!(TerminalAttachError::ReadHandshake.error_kind(), "handshake_failed");
+        assert_eq!(
+            TerminalAttachError::Rejected("mismatch".into()).error_kind(),
+            "handshake_rejected"
+        );
+        assert_eq!(TerminalAttachError::Connect.error_kind(), "connect_failed");
+        // User-facing messages keep the legacy terminal text for direct
+        // display when the UI cannot parse the structured frame.
+        assert!(TerminalAttachError::Rejected("boom".into())
+            .user_message()
+            .starts_with("herdr rejected terminal connection: boom"));
+    }
+
+    #[test]
+    fn terminal_text_messages_maps_paste_to_bracketed_input() {
         let messages = terminal_text_messages(
             r#"{"type":"paste","text":"fn main() {\n    println!(\"hi\");\n}\n"}"#,
         );
 
         assert_eq!(
             messages,
-            vec![ClientMessage::InputEvents {
-                events: vec![ClientInputEvent::Paste {
-                    text: "fn main() {\n    println!(\"hi\");\n}\n".to_string(),
-                }],
+            vec![ClientMessage::Input {
+                data: b"\x1b[200~fn main() {\n    println!(\"hi\");\n}\n\x1b[201~".to_vec(),
             }]
         );
     }
@@ -5986,18 +5987,6 @@ mod tests {
     }
 
     #[test]
-    fn round_trips_prefix_input_source_server_message() {
-        for active in [true, false] {
-            let msg = ServerMessage::PrefixInputSource { active };
-            let mut bytes = Vec::new();
-            write_message(&mut bytes, &msg).unwrap();
-            let decoded: ServerMessage =
-                read_message(&mut Cursor::new(bytes), MAX_FRAME_SIZE).unwrap();
-            assert_eq!(decoded, msg);
-        }
-    }
-
-    #[test]
     fn rejects_oversized_framed_protocol_message() {
         let bytes = 4u32.to_le_bytes();
         let err = read_message::<_, ClientMessage>(&mut Cursor::new(bytes), 3).unwrap_err();
@@ -6082,7 +6071,7 @@ mod tests {
     async fn versions_api_reports_backend_compatibility_from_fake_socket() {
         let (socket, handle) = fake_api_socket(json!({
             "id": "web:ping",
-            "result": { "version": "0.7.5", "protocol": PROTOCOL_VERSION }
+            "result": { "version": "0.9.0", "protocol": PROTOCOL_VERSION }
         }));
         let mut state = test_state();
         state.api_socket = Some(socket.clone());
@@ -6099,7 +6088,7 @@ mod tests {
             .unwrap();
         let body = response_json(response).await;
 
-        assert_eq!(body["backend"], "0.7.5");
+        assert_eq!(body["backend"], "0.9.0");
         assert_eq!(body["min_backend"], MIN_BACKEND_VERSION);
         assert_eq!(body["max_tested_backend"], MAX_TESTED_BACKEND_VERSION);
         assert_eq!(body["protocol_version"], PROTOCOL_VERSION);

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,9 +53,8 @@ use assets::{
     vendor_dompurify_js, vendor_ghostty_wasm, vendor_marked_js, vendor_mermaid_js,
     vendor_wterm_css, vendor_wterm_js,
 };
-#[cfg(test)]
-use compat::SimpleVersion;
 use compat::{backend_compatibility, BackendCompatibility};
+use compat::SimpleVersion;
 use protocol::*;
 
 const DEFAULT_BIND: &str = "127.0.0.1:8787";
@@ -92,6 +91,59 @@ fn backend_compatibility_for_supported_range(
 struct BackendInfo {
     version: Option<String>,
     protocol: Option<u32>,
+}
+
+/// Installed external herdr binary state, used to decide whether the UI may
+/// offer external-herdr sessions at all.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct HerdrInstall {
+    /// Parsed `herdr --version` output, e.g. "herdr 0.9.0".
+    version: Option<String>,
+    /// True when the binary was found and its version is inside the
+    /// supported backend range for this WebUI build.
+    compatible: bool,
+}
+
+impl HerdrInstall {
+    fn available(&self) -> bool {
+        self.version.is_some()
+    }
+}
+
+/// Runs `herdr --version` and classifies the install against the supported
+/// backend version range. Blocking (process spawn); call from a blocking
+/// context.
+fn detect_herdr_install(herdr_bin: &str) -> HerdrInstall {
+    let output = std::process::Command::new(herdr_bin)
+        .arg("--version")
+        .output();
+    let Ok(output) = output else {
+        return HerdrInstall::default();
+    };
+    if !output.status.success() {
+        return HerdrInstall::default();
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    // Accept both "herdr 0.9.0" and a bare "0.9.0".
+    let version = text
+        .split_whitespace()
+        .find_map(|token| SimpleVersion::parse(token).map(|_| token.trim_start_matches('v').to_string()));
+    let Some(version) = version else {
+        return HerdrInstall::default();
+    };
+    // `herdr --version` gives us no protocol number, so classify by version
+    // range alone: below MIN_BACKEND_VERSION is unusable, anything newer is
+    // offered as untested (matching the versions API).
+    let parsed = SimpleVersion::parse(&version);
+    let min = SimpleVersion::parse(MIN_BACKEND_VERSION);
+    let compatible = matches!(
+        (parsed, min),
+        (Some(parsed), Some(min)) if parsed >= min
+    );
+    HerdrInstall {
+        version: Some(version),
+        compatible,
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1758,7 +1810,7 @@ fn known_builtin_sessions(state: &WebState) -> Vec<serde_json::Value> {
         .collect()
 }
 
-fn known_sessions(state: &WebState) -> Vec<serde_json::Value> {
+fn known_sessions(state: &WebState, herdr_compatible: bool) -> Vec<serde_json::Value> {
     let (external_enabled, builtin_enabled) = state
         .server_settings
         .lock()
@@ -1770,7 +1822,10 @@ fn known_sessions(state: &WebState) -> Vec<serde_json::Value> {
         })
         .unwrap_or((true, true));
     let mut sessions = Vec::new();
-    if external_enabled {
+    // Only offer external herdr sessions when the installed herdr binary is
+    // detected and compatible; otherwise the UI must not tempt users into an
+    // attach that is guaranteed to fail its handshake.
+    if external_enabled && herdr_compatible {
         sessions.extend(known_external_sessions());
     }
     if builtin_enabled {
@@ -2301,6 +2356,11 @@ async fn sessions(
     if let Err(response) = require_auth(&state, &headers, remote) {
         return response;
     }
+    // herdr --version is a blocking process spawn; offload it.
+    let herdr_bin = state.herdr_bin.clone();
+    let herdr_install = tokio::task::spawn_blocking(move || detect_herdr_install(&herdr_bin))
+        .await
+        .unwrap_or_default();
     Json(json!({
         "backend_mode": state.backend_mode.as_str(),
         "current_backend": backend_target_for_headers(&state, &headers).as_str(),
@@ -2308,7 +2368,12 @@ async fn sessions(
             "builtin": backend_target_enabled(&state, SessionBackendTarget::Builtin),
             "external-herdr": backend_target_enabled(&state, SessionBackendTarget::ExternalHerdr),
         },
-        "sessions": known_sessions(&state),
+        // External herdr sessions are only offered when the installed herdr
+        // binary is detected AND compatible with this WebUI build.
+        "herdr_available": herdr_install.available(),
+        "herdr_compatible": herdr_install.compatible,
+        "herdr_version": herdr_install.version,
+        "sessions": known_sessions(&state, herdr_install.compatible),
     }))
     .into_response()
 }
@@ -2338,6 +2403,12 @@ async fn versions(
     } else {
         compatibility.message(backend.version.as_deref())
     };
+    // Report the installed external herdr binary so clients can decide
+    // whether external sessions may be offered at all.
+    let herdr_bin = state.herdr_bin.clone();
+    let herdr_install = tokio::task::spawn_blocking(move || detect_herdr_install(&herdr_bin))
+        .await
+        .unwrap_or_default();
     Json(json!({
         "webui": HERDR_WEBUI_VERSION,
         "backend": backend.version,
@@ -2349,6 +2420,12 @@ async fn versions(
         "backend_protocol_version": backend.protocol,
         "min_backend": MIN_BACKEND_VERSION,
         "max_tested_backend": MAX_TESTED_BACKEND_VERSION,
+        "herdr_install": {
+            "available": herdr_install.available(),
+            "compatible": herdr_install.compatible,
+            "version": herdr_install.version,
+            "path": state.herdr_bin,
+        },
         "compatibility": {
             "status": compatibility.as_str(),
             "compatible": compatibility == BackendCompatibility::Compatible,
@@ -2457,6 +2534,45 @@ async fn launch_session(
             })),
         )
             .into_response();
+    }
+    if backend == SessionBackendTarget::ExternalHerdr {
+        // Only launch external herdr sessions when the installed binary is
+        // detected and compatible; anything else is guaranteed to fail its
+        // handshake against this WebUI build.
+        let herdr_bin = state.herdr_bin.clone();
+        let install = tokio::task::spawn_blocking(move || detect_herdr_install(&herdr_bin))
+            .await
+            .unwrap_or_default();
+        if !install.available() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "ok": false,
+                    "backend": backend.as_str(),
+                    "error": format!(
+                        "herdr binary not found ({}); install herdr {} or newer to use external Herdr sessions",
+                        state.herdr_bin,
+                        MIN_BACKEND_VERSION,
+                    ),
+                })),
+            )
+                .into_response();
+        }
+        if !install.compatible {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "ok": false,
+                    "backend": backend.as_str(),
+                    "error": format!(
+                        "installed herdr {} is not compatible with this WebUI build (requires {}); upgrade herdr or use a built-in session",
+                        install.version.unwrap_or_default(),
+                        MIN_BACKEND_VERSION,
+                    ),
+                })),
+            )
+                .into_response();
+        }
     }
     if backend == SessionBackendTarget::Builtin {
         // ensure_builtin_session does socket connect and process spawning;
@@ -5096,7 +5212,7 @@ mod tests {
             backend_target_for_headers(&state, &headers),
             SessionBackendTarget::Builtin
         );
-        let sessions = known_sessions(&state);
+        let sessions = known_sessions(&state, false);
 
         assert!(sessions.iter().all(
             |session| session.get("backend").and_then(Value::as_str) != Some("external-herdr")
@@ -5121,7 +5237,7 @@ mod tests {
         std::env::set_var("XDG_CONFIG_HOME", &root);
         let state = test_state();
 
-        let sessions = known_sessions(&state);
+        let sessions = known_sessions(&state, true);
         let pairs = sessions
             .iter()
             .map(|session| {
@@ -5180,7 +5296,8 @@ mod tests {
         state.backend_mode = BackendMode::Builtin;
         state.herdr_bin = fake_herdr.display().to_string();
 
-        let sessions = known_sessions(&state);
+        // A compatible detected herdr install: external sessions are offered.
+        let sessions = known_sessions(&state, true);
 
         assert!(sessions.iter().any(|session| {
             session.get("backend").and_then(Value::as_str) == Some("external-herdr")
@@ -8038,6 +8155,129 @@ mod tests {
             .is_some_and(|e| e.contains("disabled")));
     }
 
+    #[cfg(unix)]
+    fn write_version_script(root: &std::path::Path, version_output: &str) -> String {
+        use std::os::unix::fs::PermissionsExt;
+        let script = root.join("fake-herdr");
+        fs::write(&script, format!("#!/bin/sh\necho '{version_output}'\n")).unwrap();
+        let mut permissions = fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).unwrap();
+        script.display().to_string()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detect_herdr_install_classifies_detected_versions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "herdr-webui-detect-install-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+
+        // Compatible install: herdr 0.9.0 (matches the supported range).
+        let bin = write_version_script(&root, "herdr 0.9.0");
+        let install = detect_herdr_install(&bin);
+        assert_eq!(install.version.as_deref(), Some("0.9.0"));
+        assert!(install.available());
+        assert!(install.compatible);
+
+        // Protocol too old: herdr 0.8.0 must be flagged incompatible.
+        let bin = write_version_script(&root, "herdr 0.8.0");
+        let install = detect_herdr_install(&bin);
+        assert_eq!(install.version.as_deref(), Some("0.8.0"));
+        assert!(install.available());
+        assert!(!install.compatible);
+
+        // Newer untested release: still offered, matching the versions API.
+        let bin = write_version_script(&root, "herdr 0.9.1");
+        let install = detect_herdr_install(&bin);
+        assert_eq!(install.version.as_deref(), Some("0.9.1"));
+        assert!(install.compatible);
+
+        // No version in output: treated as not detected.
+        let bin = write_version_script(&root, "hello world");
+        let install = detect_herdr_install(&bin);
+        assert!(!install.available());
+
+        // Missing binary: not detected.
+        let install = detect_herdr_install("/nonexistent/herdr-bin-xyz");
+        assert_eq!(install, HerdrInstall::default());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn launch_session_rejects_incompatible_detected_herdr() {
+        let root = std::env::temp_dir().join(format!(
+            "herdr-webui-launch-compat-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let bin = write_version_script(&root, "herdr 0.8.0");
+
+        let mut state = test_state();
+        state.herdr_bin = bin;
+        let app = test_app_with_state(state);
+
+        let response = app
+            .oneshot(
+                authed_request(Method::POST, "/api/session/launch")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({ "session": "test", "backend": "external-herdr" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], false);
+        let error = body["error"].as_str().unwrap_or_default();
+        assert!(error.contains("0.8.0"), "error mentions detected version");
+        assert!(
+            error.contains("compatible"),
+            "error explains incompatibility"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn launch_session_rejects_missing_herdr_install() {
+        let mut state = test_state();
+        state.herdr_bin = "/nonexistent/herdr-bin-xyz".to_string();
+        let app = test_app_with_state(state);
+
+        let response = app
+            .oneshot(
+                authed_request(Method::POST, "/api/session/launch")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({ "session": "test", "backend": "external-herdr" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Now rejected before spawn, instead of BAD_GATEWAY from spawn failure.
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], false);
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("herdr binary not found"),
+            "error explains missing install"
+        );
+    }
+
     #[tokio::test]
     async fn launch_session_returns_error_when_herdr_bin_not_found() {
         let mut state = test_state();
@@ -8055,22 +8295,48 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        // The install gate rejects before spawn, so this is now a clean
+        // BAD_REQUEST with an actionable message instead of BAD_GATEWAY.
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = response_json(response).await;
         assert_eq!(body["ok"], false);
-        assert!(body["error"].as_str().is_some_and(|e| !e.is_empty()));
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("herdr binary not found"),
+            "error explains the missing install"
+        );
+    }
+
+    #[cfg(unix)]
+    fn fake_herdr_version_script() -> String {
+        use std::os::unix::fs::PermissionsExt;
+        let root = std::env::temp_dir().join(format!(
+            "herdr-webui-launch-test-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("t").to_string()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let script = root.join("fake-herdr");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\ncase \"$1\" in\n--version) echo 'herdr 0.9.0'; exit 0;;\nesac\nexit 0\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).unwrap();
+        script.display().to_string()
     }
 
     #[tokio::test]
     async fn launch_session_external_succeeds_with_true_command() {
-        // Use /usr/bin/true as a stand-in for the herdr binary (works on macOS and Linux)
-        let true_bin = if std::path::Path::new("/bin/true").exists() {
-            "/bin/true"
-        } else {
-            "/usr/bin/true"
-        };
+        // A fake herdr reporting a compatible version; any launch args make it
+        // exit 0 like /usr/bin/true so the launch handler sees success.
         let mut state = test_state();
-        state.herdr_bin = true_bin.to_string();
+        state.herdr_bin = fake_herdr_version_script();
         let app = test_app_with_state(state);
 
         let response = app
@@ -8093,13 +8359,8 @@ mod tests {
 
     #[tokio::test]
     async fn launch_session_default_session_omits_env() {
-        let true_bin = if std::path::Path::new("/bin/true").exists() {
-            "/bin/true"
-        } else {
-            "/usr/bin/true"
-        };
         let mut state = test_state();
-        state.herdr_bin = true_bin.to_string();
+        state.herdr_bin = fake_herdr_version_script();
         let app = test_app_with_state(state);
 
         let response = app
@@ -9996,9 +10257,26 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn launch_session_external_returns_error_on_spawn_failure() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = std::env::temp_dir().join(format!(
+            "herdr-webui-spawn-fail-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        // A binary that exists and reports a compatible version, but loses
+        // execute permission between detection and launch: spawn() fails.
+        let script = root.join("fake-herdr");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\ncase \"$1\" in\n--version) echo 'herdr 0.9.0'; exit 0;;\nesac\nexit 0\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o644);
+        std::fs::set_permissions(&script, permissions).unwrap();
         let mut state = test_state();
-        // /dev/null is not an executable, so spawn() will fail
-        state.herdr_bin = "/dev/null".to_string();
+        state.herdr_bin = script.display().to_string();
         let app = test_app_with_state(state);
 
         let response = app
@@ -10013,10 +10291,13 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        // Not executable: detection cannot run it, so the install gate
+        // rejects with an actionable error before any spawn is attempted.
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = response_json(response).await;
         assert_eq!(body["ok"], false);
         assert!(body["error"].as_str().is_some());
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     // ── LSP API tests ──

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -255,9 +255,7 @@ pub(crate) enum ClientMessage {
     },
 
     /// Raw input bytes read from the client's stdin.
-    Input {
-        data: Vec<u8>,
-    },
+    Input { data: Vec<u8> },
 
     /// Image bytes read from the client's local clipboard for remote paste bridging.
     ClipboardImage {
@@ -281,10 +279,7 @@ pub(crate) enum ClientMessage {
     Detach,
 
     /// Switch this connection into direct terminal attach mode.
-    AttachTerminal {
-        terminal_id: String,
-        takeover: bool,
-    },
+    AttachTerminal { terminal_id: String, takeover: bool },
 
     /// Scroll input handled by a direct terminal attach client.
     AttachScroll {
@@ -297,15 +292,10 @@ pub(crate) enum ClientMessage {
     },
 
     /// Switch this connection into read-only terminal observe mode.
-    ObserveTerminal {
-        target: String,
-    },
+    ObserveTerminal { target: String },
 
     /// Switch this connection into writable terminal control mode.
-    ControlTerminal {
-        target: String,
-        takeover: bool,
-    },
+    ControlTerminal { target: String, takeover: bool },
 
     /// Result of the one armed Herdr-owned direct Kitty transmission.
     GraphicsTransmissionResult {
@@ -315,10 +305,7 @@ pub(crate) enum ClientMessage {
     },
 
     /// The direct command was written and flushed; terminal response timing starts now.
-    GraphicsTransmissionStarted {
-        transfer_id: u64,
-        image_id: u32,
-    },
+    GraphicsTransmissionStarted { transfer_id: u64, image_id: u32 },
 
     /// Handshake for the client-owned shell around one pane surface. The
     /// WebUI is a direct terminal client, not a client-owned shell, so this
@@ -355,10 +342,7 @@ pub(crate) enum ClientMessage {
     },
 
     /// Invoke one endpoint operation through this client shell's selected connection.
-    ClientShellEndpointRequest {
-        boot_id: String,
-        request: String,
-    },
+    ClientShellEndpointRequest { boot_id: String, request: String },
 
     /// Deliver one structured mouse event to a directly attached terminal.
     AttachMouse {
@@ -370,26 +354,17 @@ pub(crate) enum ClientMessage {
     },
 
     /// Publish one host terminal color or appearance update observed by a client-owned shell.
-    ClientShellHostTheme {
-        update: ClientHostThemeUpdate,
-    },
+    ClientShellHostTheme { update: ClientHostThemeUpdate },
 
     /// Publish whether the outer terminal containing a client shell has focus.
-    ClientShellFocus {
-        focused: bool,
-    },
+    ClientShellFocus { focused: bool },
 
     /// Update this client's shell mouse-capture preference after config reload.
-    ClientShellMouseCapture {
-        enabled: bool,
-    },
+    ClientShellMouseCapture { enabled: bool },
 
     /// Extensible named control message for the stable client-owned endpoint
     /// protocol. Append-only; the two-string payload is fixed.
-    EndpointControl {
-        kind: String,
-        data: String,
-    },
+    EndpointControl { kind: String, data: String },
 }
 
 /// Pane-domain input after the client has classified and consumed shell actions.
@@ -876,14 +851,10 @@ pub(crate) enum ServerMessage {
     Terminal(TerminalFrame),
 
     /// Client-local Kitty graphics bytes to write directly to the host terminal.
-    Graphics {
-        bytes: Vec<u8>,
-    },
+    Graphics { bytes: Vec<u8> },
 
     /// Server is shutting down. Clients should exit gracefully.
-    ServerShutdown {
-        reason: Option<String>,
-    },
+    ServerShutdown { reason: Option<String> },
 
     /// A notification event (sound/toast) to be rendered locally by the client.
     Notify {
@@ -893,14 +864,10 @@ pub(crate) enum ServerMessage {
     },
 
     /// OSC 52 clipboard data forwarded from a PTY through the server.
-    Clipboard {
-        data: String,
-    },
+    Clipboard { data: String },
 
     /// Set the foreground client's outer terminal window title.
-    WindowTitle {
-        title: Option<String>,
-    },
+    WindowTitle { title: Option<String> },
 
     /// Client-local runtime config changed on disk; refresh it without reconnecting.
     ReloadSoundConfig,
@@ -913,9 +880,7 @@ pub(crate) enum ServerMessage {
     },
 
     /// Ring the foreground client's outer terminal for pane-originated BEL characters.
-    TerminalBell {
-        count: u16,
-    },
+    TerminalBell { count: u16 },
 
     /// One validated Herdr-owned Kitty regular-file RGBA transmission.
     GraphicsFile {
@@ -930,10 +895,7 @@ pub(crate) enum ServerMessage {
     },
 
     /// Suppress a direct command that expired before terminal delivery.
-    GraphicsTransmissionRetired {
-        transfer_id: u64,
-        image_id: u32,
-    },
+    GraphicsTransmissionRetired { transfer_id: u64, image_id: u32 },
 
     /// Initial metadata for a client-owned shell.
     ClientShellSnapshot(Box<ClientShellSnapshot>),
@@ -945,9 +907,7 @@ pub(crate) enum ServerMessage {
     SemanticNotification(SemanticNotification),
 
     /// Immediate endpoint error that the client-rendered shell must show.
-    ClientShellError {
-        message: String,
-    },
+    ClientShellError { message: String },
 
     /// Exact Kitty keyboard flags requested by a directly attached terminal.
     DirectTerminalKeyboardProtocol {
@@ -956,9 +916,7 @@ pub(crate) enum ServerMessage {
     },
 
     /// Whether the focused pane or popup needs the shell host to report every key.
-    ClientShellKeyboardReportAll {
-        enabled: bool,
-    },
+    ClientShellKeyboardReportAll { enabled: bool },
 
     /// One ordered chunk of the final response to an endpoint operation.
     ClientShellEndpointResponseChunk {
@@ -972,8 +930,5 @@ pub(crate) enum ServerMessage {
     PaneSurfacePatch(PaneSurfacePatch),
 
     /// Extensible named control message for the stable client-owned endpoint protocol.
-    EndpointControl {
-        kind: String,
-        data: String,
-    },
+    EndpointControl { kind: String, data: String },
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,6 +1,29 @@
+//! Wire protocol mirror for herdr 0.9.0 (client protocol 22).
+//!
+//! This module mirrors the subset of herdr's `src/protocol/wire.rs` that the
+//! WebUI client and the embedded built-in backend speak over the local client
+//! socket. Framing is `[u32LE length][bincode payload]` using
+//! `bincode::config::standard()`, exactly like herdr.
+//!
+//! herdr 0.9.0 requires an exact protocol version match: the handshake sends
+//! `TerminalHello{version: PROTOCOL_VERSION}` and any other version is
+//! rejected with a `Welcome{error}` before the connection closes. The old
+//! multi-version fallback loop never functioned because herdr closes
+//! mismatched handshakes instead of staying open for a retry.
+
 use std::io::{Read, Write};
 
 use serde::{Deserialize, Serialize};
+
+/// Client protocol version spoken by herdr 0.9.0.
+///
+/// herdr validates this exact value at handshake time; there is no
+/// cross-version compatibility window.
+pub(crate) const PROTOCOL_VERSION: u32 = 22;
+/// Minimum herdr backend version this WebUI supports.
+pub(crate) const MIN_BACKEND_VERSION: &str = "0.9.0";
+/// Maximum herdr backend version this WebUI has been tested against.
+pub(crate) const MAX_TESTED_BACKEND_VERSION: &str = "0.9.0";
 
 pub(crate) fn write_message<W: Write, M: Serialize>(writer: &mut W, msg: &M) -> Result<(), String> {
     let payload = bincode::serde::encode_to_vec(msg, bincode::config::standard())
@@ -10,7 +33,8 @@ pub(crate) fn write_message<W: Write, M: Serialize>(writer: &mut W, msg: &M) -> 
         .write_all(&len.to_le_bytes())
         .map_err(|err| err.to_string())?;
     writer.write_all(&payload).map_err(|err| err.to_string())?;
-    writer.flush().map_err(|err| err.to_string())
+    writer.flush().map_err(|err| err.to_string())?;
+    Ok(())
 }
 
 pub(crate) fn read_message<R: Read, M: for<'de> Deserialize<'de>>(
@@ -37,168 +61,18 @@ pub(crate) fn read_message<R: Read, M: for<'de> Deserialize<'de>>(
     Ok(msg)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+// ---------------------------------------------------------------------------
+// Client → Server messages
+// ---------------------------------------------------------------------------
+
+/// Render payload encoding negotiated during client handshake.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum RenderEncoding {
     SemanticFrame,
     TerminalAnsi,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ClientKeybindings {
-    Server,
-    Local { keys_toml: String },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ClientLaunchMode {
-    App,
-    /// Full app client eligible for audited local direct graphics.
-    /// A web client does not use local graphics, so this variant only needs
-    /// to deserialize correctly. Added in protocol 20+.
-    AppDirectGraphics,
-    TerminalAttach,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ClientMessage {
-    Hello {
-        version: u32,
-        cols: u16,
-        rows: u16,
-        cell_width_px: u32,
-        cell_height_px: u32,
-        requested_encoding: RenderEncoding,
-        keybindings: ClientKeybindings,
-        launch_mode: ClientLaunchMode,
-    },
-    Input {
-        data: Vec<u8>,
-    },
-    ClipboardImage {
-        extension: String,
-        data: Vec<u8>,
-    },
-    Resize {
-        cols: u16,
-        rows: u16,
-        cell_width_px: u32,
-        cell_height_px: u32,
-    },
-    Detach,
-    AttachTerminal {
-        terminal_id: String,
-        takeover: bool,
-    },
-    AttachScroll {
-        source: AttachScrollSource,
-        direction: AttachScrollDirection,
-        lines: u16,
-        column: Option<u16>,
-        row: Option<u16>,
-        modifiers: u8,
-    },
-    InputEvents {
-        events: Vec<ClientInputEvent>,
-    },
-    /// Switch this connection into read-only terminal observe mode.
-    /// Added in protocol 20+.
-    ObserveTerminal {
-        target: String,
-    },
-    /// Switch this connection into writable terminal control mode.
-    /// Added in protocol 20+.
-    ControlTerminal {
-        target: String,
-        takeover: bool,
-    },
-    /// Result of a Herdr-owned direct Kitty transmission.
-    /// Added in protocol 20+ (graphics streaming).
-    GraphicsTransmissionResult {
-        transfer_id: u64,
-        image_id: u32,
-        success: bool,
-    },
-    /// One confirmed SGR 1016 mouse report with read-time host geometry.
-    /// Added in protocol 20+ (graphics streaming).
-    InputPixels {
-        data: Vec<u8>,
-        cols: u16,
-        rows: u16,
-        width_px: u32,
-        height_px: u32,
-    },
-    /// The direct command was written and flushed.
-    /// Added in protocol 20+ (graphics streaming).
-    GraphicsTransmissionStarted {
-        transfer_id: u64,
-        image_id: u32,
-    },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum AttachScrollDirection {
-    Up,
-    Down,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum AttachScrollSource {
-    Wheel,
-    PageKey { input: Vec<u8> },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ClientInputEvent {
-    Key {
-        code: ClientKeyCode,
-        modifiers: u8,
-        kind: ClientKeyKind,
-        /// Key repeat count from the host terminal. Added in protocol 19.
-        repeat_count: u16,
-        /// Text generated by this key event, if any. Added in protocol 19.
-        generated_text: Option<String>,
-        /// Input source metadata. Added in protocol 19.
-        source: ClientKeySource,
-    },
-    /// Committed text (replaces the old `Text { codepoint }` variant from
-    /// protocol 18). Added in protocol 19.
-    TextCommit(String),
-    Mouse {
-        kind: ClientMouseKind,
-        column: u16,
-        row: u16,
-        modifiers: u8,
-    },
-    Paste {
-        text: String,
-    },
-    FocusGained,
-    FocusLost,
-}
-
-/// Source of a key event. A web client always synthesizes keys, so the other
-/// variants only need to deserialize. Added in protocol 19.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ClientKeySource {
-    Synthesized,
-    Vt { bytes: Vec<u8> },
-    WindowsConsole { record: WindowsKeyRecord },
-}
-
-/// Wire-compatible mirror of herdr's `input::WindowsKeyRecord` for
-/// deserializing `ClientKeySource::WindowsConsole`. A web client never
-/// produces this but must accept it from Windows backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct WindowsKeyRecord {
-    pub(crate) key_down: bool,
-    pub(crate) repeat_count: u16,
-    pub(crate) virtual_key_code: u16,
-    pub(crate) virtual_scan_code: u16,
-    pub(crate) unicode: u16,
-    pub(crate) control_key_state: u32,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum ClientKeyKind {
     Press,
     Repeat,
@@ -227,14 +101,14 @@ pub(crate) enum ClientKeyCode {
     Null,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum ClientMouseButton {
     Left,
     Right,
     Middle,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum ClientMouseKind {
     Down(ClientMouseButton),
     Up(ClientMouseButton),
@@ -247,34 +121,360 @@ pub(crate) enum ClientMouseKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientInputEvent {
+    Key {
+        code: ClientKeyCode,
+        modifiers: u8,
+        kind: ClientKeyKind,
+        /// Key repeat count from the host terminal.
+        repeat_count: u16,
+        /// Text generated by this key event, if any.
+        generated_text: Option<String>,
+        /// Input source metadata.
+        source: ClientKeySource,
+    },
+    TextCommit(String),
+    Mouse {
+        kind: ClientMouseKind,
+        column: u16,
+        row: u16,
+        modifiers: u8,
+    },
+    Paste {
+        text: String,
+    },
+    FocusGained,
+    FocusLost,
+}
+
+/// Source of a key event. A web client always synthesizes keys, so the other
+/// variants only need to deserialize.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientKeySource {
+    Synthesized,
+    Vt { bytes: Vec<u8> },
+    WindowsConsole { record: WindowsKeyRecord },
+}
+
+/// Wire-compatible mirror of herdr's `input::WindowsKeyRecord` for
+/// deserializing `ClientKeySource::WindowsConsole`. A web client never
+/// produces this but must accept it from Windows backends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct WindowsKeyRecord {
+    pub(crate) key_down: bool,
+    pub(crate) repeat_count: u16,
+    pub(crate) virtual_key_code: u16,
+    pub(crate) virtual_scan_code: u16,
+    pub(crate) unicode: u16,
+    pub(crate) control_key_state: u32,
+}
+
+/// Size of a pane surface requested by a client-owned shell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientSurfaceSize {
+    pub(crate) cols: u16,
+    pub(crate) rows: u16,
+}
+
+/// Terminal target of a clipboard image read by the client.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientClipboardImageTarget {
+    DirectTerminal,
+    Pane(String),
+    Popup(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientHostDefaultColorKind {
+    Foreground,
+    Background,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientHostAppearance {
+    Dark,
+    Light,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientHostThemeUpdate {
+    DefaultColor {
+        kind: ClientHostDefaultColorKind,
+        color: ClientHostColor,
+    },
+    PaletteColors(Vec<(u8, ClientHostColor)>),
+    Appearance(ClientHostAppearance),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientHostColor {
+    pub(crate) r: u8,
+    pub(crate) g: u8,
+    pub(crate) b: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum AttachScrollDirection {
+    Up,
+    Down,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum AttachScrollSource {
+    Wheel,
+    PageKey {
+        /// Original key bytes to forward when the child application owns page keys.
+        input: Vec<u8>,
+    },
+}
+
+/// Messages sent from the client to the server over the client protocol
+/// socket. Variant order mirrors herdr 0.9.0's `ClientMessage` exactly;
+/// bincode encodes the variant index, so any drift breaks the handshake.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientMessage {
+    /// Direct terminal handshake. herdr 0.9.0 renamed `Hello` to
+    /// `TerminalHello` and dropped `requested_encoding`, `keybindings`, and
+    /// `launch_mode`: direct terminal clients always get `TerminalAnsi`
+    /// encoding and attach mode is implied by `AttachTerminal`.
+    TerminalHello {
+        /// Protocol version the client speaks. Must equal 22.
+        version: u32,
+        /// Terminal width in columns.
+        cols: u16,
+        /// Terminal height in rows.
+        rows: u16,
+        /// Width of a terminal cell in physical pixels, or 0 when
+        /// client-side Kitty graphics are disabled.
+        cell_width_px: u32,
+        /// Height of a terminal cell in physical pixels, or 0 when
+        /// unavailable.
+        cell_height_px: u32,
+        /// Whether the client can report exact SGR pixel mouse geometry.
+        pixel_mouse: bool,
+    },
+
+    /// Raw input bytes read from the client's stdin.
+    Input {
+        data: Vec<u8>,
+    },
+
+    /// Image bytes read from the client's local clipboard for remote paste bridging.
+    ClipboardImage {
+        target: ClientClipboardImageTarget,
+        extension: String,
+        data: Vec<u8>,
+    },
+
+    /// Terminal resize notification from the client.
+    Resize {
+        cols: u16,
+        rows: u16,
+        cell_width_px: u32,
+        cell_height_px: u32,
+        /// Whether this resize carries coherent exact geometry for SGR pixel
+        /// mouse input.
+        pixel_mouse: bool,
+    },
+
+    /// Graceful disconnect request.
+    Detach,
+
+    /// Switch this connection into direct terminal attach mode.
+    AttachTerminal {
+        terminal_id: String,
+        takeover: bool,
+    },
+
+    /// Scroll input handled by a direct terminal attach client.
+    AttachScroll {
+        source: AttachScrollSource,
+        direction: AttachScrollDirection,
+        lines: u16,
+        column: Option<u16>,
+        row: Option<u16>,
+        modifiers: u8,
+    },
+
+    /// Switch this connection into read-only terminal observe mode.
+    ObserveTerminal {
+        target: String,
+    },
+
+    /// Switch this connection into writable terminal control mode.
+    ControlTerminal {
+        target: String,
+        takeover: bool,
+    },
+
+    /// Result of the one armed Herdr-owned direct Kitty transmission.
+    GraphicsTransmissionResult {
+        transfer_id: u64,
+        image_id: u32,
+        success: bool,
+    },
+
+    /// The direct command was written and flushed; terminal response timing starts now.
+    GraphicsTransmissionStarted {
+        transfer_id: u64,
+        image_id: u32,
+    },
+
+    /// Handshake for the client-owned shell around one pane surface. The
+    /// WebUI is a direct terminal client, not a client-owned shell, so this
+    /// variant only needs to deserialize.
+    ClientShellHello {
+        version: u32,
+        cell_width_px: u32,
+        cell_height_px: u32,
+        surface_size: ClientSurfaceSize,
+        pixel_mouse: bool,
+        direct_graphics: bool,
+        endpoint_keybindings: bool,
+        mouse_capture: bool,
+    },
+
+    /// Resize the pane viewport of a client-owned shell.
+    ClientShellResize {
+        cell_width_px: u32,
+        cell_height_px: u32,
+        surface_size: ClientSurfaceSize,
+        pixel_mouse: bool,
+    },
+
+    /// Deliver client-classified semantic input directly to a stable pane target.
+    ClientShellPaneInput {
+        pane_id: String,
+        events: Vec<ClientPaneInputEvent>,
+    },
+
+    /// Deliver client-classified semantic input to the active popup terminal.
+    ClientShellPopupInput {
+        terminal_id: String,
+        events: Vec<ClientPaneInputEvent>,
+    },
+
+    /// Invoke one endpoint operation through this client shell's selected connection.
+    ClientShellEndpointRequest {
+        boot_id: String,
+        request: String,
+    },
+
+    /// Deliver one structured mouse event to a directly attached terminal.
+    AttachMouse {
+        kind: ClientMouseKind,
+        position: ClientMousePosition,
+        geometry: Option<ClientMouseGeometry>,
+        modifiers: u8,
+        lines: u16,
+    },
+
+    /// Publish one host terminal color or appearance update observed by a client-owned shell.
+    ClientShellHostTheme {
+        update: ClientHostThemeUpdate,
+    },
+
+    /// Publish whether the outer terminal containing a client shell has focus.
+    ClientShellFocus {
+        focused: bool,
+    },
+
+    /// Update this client's shell mouse-capture preference after config reload.
+    ClientShellMouseCapture {
+        enabled: bool,
+    },
+
+    /// Extensible named control message for the stable client-owned endpoint
+    /// protocol. Append-only; the two-string payload is fixed.
+    EndpointControl {
+        kind: String,
+        data: String,
+    },
+}
+
+/// Pane-domain input after the client has classified and consumed shell actions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientPaneInputEvent {
+    Key {
+        code: ClientKeyCode,
+        modifiers: u8,
+        kind: ClientKeyKind,
+        repeat_count: u16,
+        shifted_codepoint: Option<u32>,
+        generated_text: Option<String>,
+        tracks_release: bool,
+        physical_key_id: Option<u32>,
+        windows_record: Option<WindowsKeyRecord>,
+    },
+    TextCommit(String),
+    Mouse {
+        kind: ClientMouseKind,
+        position: ClientMousePosition,
+        geometry: Option<ClientMouseGeometry>,
+        modifiers: u8,
+        lines: u16,
+    },
+    Paste(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientMousePosition {
+    Cell {
+        column: u16,
+        row: u16,
+    },
+    Pixels {
+        x: u32,
+        y: u32,
+        column: u16,
+        row: u16,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientMouseGeometry {
+    pub(crate) cols: u16,
+    pub(crate) rows: u16,
+    pub(crate) width_px: u32,
+    pub(crate) height_px: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Server → Client messages
+// ---------------------------------------------------------------------------
+
+/// A single cell in a rendered frame, serialized independently from ratatui's
+/// `Cell` type to keep the wire protocol stable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CellData {
-    symbol: String,
-    fg: u32,
-    bg: u32,
-    modifier: u16,
-    skip: bool,
-    hyperlink: Option<u32>,
+    pub(crate) symbol: String,
+    pub(crate) fg: u32,
+    pub(crate) bg: u32,
+    pub(crate) modifier: u16,
+    pub(crate) skip: bool,
+    pub(crate) hyperlink: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct CursorState {
-    x: u16,
-    y: u16,
-    visible: bool,
+    pub(crate) x: u16,
+    pub(crate) y: u16,
+    pub(crate) visible: bool,
     #[serde(default)]
-    shape: u8,
+    pub(crate) shape: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct FrameData {
-    cells: Vec<CellData>,
-    width: u16,
-    height: u16,
-    cursor: Option<CursorState>,
-    hyperlinks: Vec<String>,
-    graphics: Vec<u8>,
+    pub(crate) cells: Vec<CellData>,
+    pub(crate) width: u16,
+    pub(crate) height: u16,
+    pub(crate) cursor: Option<CursorState>,
+    pub(crate) hyperlinks: Vec<String>,
+    pub(crate) graphics: Vec<u8>,
 }
 
+/// Terminal ANSI bytes encoded by the server for network-efficient clients.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct TerminalFrame {
     pub(crate) seq: u64,
@@ -284,6 +484,7 @@ pub(crate) struct TerminalFrame {
     pub(crate) bytes: Vec<u8>,
 }
 
+/// Notification kind forwarded from server to client.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum NotifyKind {
     Sound,
@@ -291,64 +492,432 @@ pub(crate) enum NotifyKind {
     SystemToast,
 }
 
+/// A client-rendered notification category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum SemanticNotificationKind {
+    NeedsAttention,
+    Finished,
+    UpdateInstalled,
+    Custom,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum SemanticNotificationSound {
+    Done,
+    Request,
+}
+
+/// Toast placement requested for herdr-originated toasts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ToastHerdrPosition {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SemanticNotification {
+    pub(crate) kind: SemanticNotificationKind,
+    pub(crate) title: String,
+    pub(crate) body: Option<String>,
+    pub(crate) sound: Option<SemanticNotificationSound>,
+    pub(crate) agent: Option<String>,
+    pub(crate) workspace_id: Option<String>,
+    pub(crate) tab_id: Option<String>,
+    pub(crate) pane_id: Option<String>,
+    pub(crate) position: Option<ToastHerdrPosition>,
+}
+
+/// Agent status reported by the endpoint projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AgentStatus {
+    Idle,
+    Working,
+    Blocked,
+    Done,
+    Unknown,
+}
+
+impl AgentStatus {
+    pub(crate) fn from_str(value: &str) -> Self {
+        match value {
+            "idle" => Self::Idle,
+            "working" => Self::Working,
+            "blocked" => Self::Blocked,
+            "done" => Self::Done,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Initial resource projection used by the stable client-owned shell.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellSnapshot {
+    pub(crate) boot_id: String,
+    pub(crate) revision: u64,
+    pub(crate) config_diagnostic: Option<String>,
+    pub(crate) product_announcement: Option<ClientShellProductAnnouncement>,
+    pub(crate) update_available: Option<String>,
+    pub(crate) update_install_command: String,
+    pub(crate) server_keybindings_toml: Option<String>,
+    pub(crate) latest_release_notes_available: bool,
+    pub(crate) integration_updates_available: bool,
+    pub(crate) worktree_directory: String,
+    pub(crate) release_notes: Option<ClientShellReleaseNotes>,
+    pub(crate) focused_workspace_id: Option<String>,
+    pub(crate) focused_tab_id: Option<String>,
+    pub(crate) focused_pane_id: Option<String>,
+    pub(crate) tab_bar_right: Vec<ClientShellTabStatusSegment>,
+    pub(crate) tab_bar_right_separator: String,
+    pub(crate) agent_view_label: Option<String>,
+    pub(crate) agent_order: Vec<String>,
+    pub(crate) workspaces: Vec<ClientShellWorkspace>,
+    pub(crate) tabs: Vec<ClientShellTab>,
+    pub(crate) panes: Vec<ClientShellPane>,
+    pub(crate) agents: Vec<ClientShellAgent>,
+    pub(crate) commands: Vec<ClientShellCommand>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellProductAnnouncement {
+    pub(crate) version: String,
+    pub(crate) id: String,
+    pub(crate) title: String,
+    pub(crate) body: String,
+    pub(crate) preview: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellReleaseNotes {
+    pub(crate) version: String,
+    pub(crate) body: String,
+    pub(crate) preview: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientShellCommandAction {
+    Shell,
+    Pane,
+    Popup,
+    PluginAction,
+    /// A future endpoint action kind that this client cannot execute.
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellCommand {
+    pub(crate) command_id: String,
+    pub(crate) binding_label: String,
+    pub(crate) binding_labels: Vec<String>,
+    pub(crate) action: ClientShellCommandAction,
+    pub(crate) description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellTabStatusSegment {
+    pub(crate) text: String,
+    pub(crate) accent: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellWorkspace {
+    pub(crate) workspace_id: String,
+    pub(crate) active_tab_id: String,
+    pub(crate) new_workspace_cwd: String,
+    pub(crate) number: usize,
+    pub(crate) label: String,
+    pub(crate) custom_label: bool,
+    pub(crate) branch: Option<String>,
+    pub(crate) git_ahead_behind: Option<(usize, usize)>,
+    pub(crate) tokens: Vec<(String, String)>,
+    pub(crate) worktree: Option<ClientShellWorktree>,
+    pub(crate) focused: bool,
+    pub(crate) agent_status: AgentStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellWorktree {
+    pub(crate) key: String,
+    pub(crate) label: String,
+    pub(crate) is_linked_worktree: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellTab {
+    pub(crate) tab_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) number: usize,
+    pub(crate) label: String,
+    pub(crate) custom_label: bool,
+    pub(crate) zoomed: bool,
+    pub(crate) focused: bool,
+    pub(crate) agent_status: AgentStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellPane {
+    pub(crate) pane_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) tab_id: String,
+    pub(crate) label: Option<String>,
+    pub(crate) cwd: Option<String>,
+    pub(crate) foreground_cwd: Option<String>,
+    pub(crate) focused: bool,
+    pub(crate) right_click_passthrough: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellAgent {
+    pub(crate) pane_id: String,
+    pub(crate) workspace_id: String,
+    pub(crate) tab_id: String,
+    pub(crate) name: Option<String>,
+    pub(crate) display_agent: Option<String>,
+    pub(crate) agent: Option<String>,
+    pub(crate) title: Option<String>,
+    pub(crate) terminal_title: Option<String>,
+    pub(crate) terminal_title_stripped: Option<String>,
+    pub(crate) agent_status: AgentStatus,
+    pub(crate) state_change_seq: u64,
+    pub(crate) state_labels: Vec<(String, String)>,
+    pub(crate) tokens: Vec<(String, String)>,
+    pub(crate) focused: bool,
+}
+
+/// Origin-relative geometry for one pane in a rendered pane surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PaneSurfacePane {
+    pub(crate) pane_id: String,
+    pub(crate) content_revision: u64,
+    pub(crate) rect: SurfaceRect,
+    pub(crate) inner_rect: SurfaceRect,
+    pub(crate) scrollbar_rect: Option<SurfaceRect>,
+    pub(crate) scroll: Option<PaneSurfaceScrollMetrics>,
+    pub(crate) focused: bool,
+    pub(crate) mouse_reporting: bool,
+    pub(crate) sgr_pixel_mouse: bool,
+    pub(crate) alternate_screen_active: bool,
+    pub(crate) pixel_width: u32,
+    pub(crate) pixel_height: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PaneSurfaceScrollMetrics {
+    pub(crate) offset_from_bottom: u64,
+    pub(crate) max_offset_from_bottom: u64,
+    pub(crate) viewport_rows: u64,
+}
+
+/// One draggable BSP split handle relative to a pane surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PaneSurfaceSplit {
+    pub(crate) direction: PaneSurfaceSplitDirection,
+    pub(crate) pos: u16,
+    pub(crate) area: SurfaceRect,
+    pub(crate) hit_rect: SurfaceRect,
+    pub(crate) path: Vec<bool>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum PaneSurfaceSplitDirection {
+    Horizontal,
+    Vertical,
+}
+
+/// Wire-safe rectangle relative to a pane surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SurfaceRect {
+    pub(crate) x: u16,
+    pub(crate) y: u16,
+    pub(crate) width: u16,
+    pub(crate) height: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum SurfaceGraphicsTarget {
+    Pane { pane_id: String },
+    Popup { terminal_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum SurfaceGraphicsSource {
+    Terminal {
+        target: SurfaceGraphicsTarget,
+        image_id: u32,
+    },
+    PaneLayer {
+        pane_id: String,
+        layer_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum SurfaceGraphicsFormat {
+    Rgb,
+    Rgba,
+    Png,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct SurfaceGraphicsAssetKey {
+    pub(crate) source: SurfaceGraphicsSource,
+    pub(crate) image_width: u32,
+    pub(crate) image_height: u32,
+    pub(crate) format: SurfaceGraphicsFormat,
+    pub(crate) data_len: u64,
+    pub(crate) data_fingerprint: u64,
+}
+
+/// Image bytes newly needed by this connection's complete desired scene.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SurfaceGraphicsAsset {
+    pub(crate) key: SurfaceGraphicsAssetKey,
+    pub(crate) data: Vec<u8>,
+}
+
+/// One already-clipped desired placement relative to its target surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SurfaceGraphicsPlacement {
+    pub(crate) asset: SurfaceGraphicsAssetKey,
+    pub(crate) logical_placement_id: u32,
+    pub(crate) x: u16,
+    pub(crate) y: u16,
+    pub(crate) cols: u32,
+    pub(crate) rows: u32,
+    pub(crate) source_x: u32,
+    pub(crate) source_y: u32,
+    pub(crate) source_width: u32,
+    pub(crate) source_height: u32,
+    pub(crate) x_offset: u32,
+    pub(crate) y_offset: u32,
+    pub(crate) z: i32,
+    pub(crate) scrollback_offset: u32,
+}
+
+/// Complete desired placements plus only the image bytes not already sent for
+/// the current live scene on this connection.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SurfaceGraphicsScene {
+    pub(crate) assets: Vec<SurfaceGraphicsAsset>,
+    pub(crate) placements: Vec<SurfaceGraphicsPlacement>,
+    pub(crate) retained_assets: Vec<SurfaceGraphicsAssetKey>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ClientShellPopupSize {
+    Cells(u16),
+    Percent(u8),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ClientShellPopupSurface {
+    pub(crate) terminal_id: String,
+    pub(crate) title: String,
+    pub(crate) width: Option<ClientShellPopupSize>,
+    pub(crate) height: Option<ClientShellPopupSize>,
+    pub(crate) frame: FrameData,
+    pub(crate) mouse_reporting: bool,
+    pub(crate) sgr_pixel_mouse: bool,
+    pub(crate) pixel_width: u32,
+    pub(crate) pixel_height: u32,
+}
+
+/// One server-rendered active-tab surface without sidebar, tab bar, or overlays.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PaneSurfaceFrame {
+    pub(crate) boot_id: String,
+    pub(crate) projection_revision: u64,
+    pub(crate) surface_revision: u64,
+    pub(crate) frame: FrameData,
+    pub(crate) panes: Vec<PaneSurfacePane>,
+    pub(crate) splits: Vec<PaneSurfaceSplit>,
+    pub(crate) popup: Option<Box<ClientShellPopupSurface>>,
+    pub(crate) graphics: SurfaceGraphicsScene,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PaneSurfacePatchRow {
+    pub(crate) x: u16,
+    pub(crate) y: u16,
+    pub(crate) cells: Vec<CellData>,
+}
+
+/// Incremental terminal-cell update against one committed complete pane surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PaneSurfacePatch {
+    pub(crate) boot_id: String,
+    pub(crate) projection_revision: u64,
+    pub(crate) base_surface_revision: u64,
+    pub(crate) surface_revision: u64,
+    pub(crate) rows: Vec<PaneSurfacePatchRow>,
+    pub(crate) panes: Vec<PaneSurfacePane>,
+    pub(crate) cursor: Option<CursorState>,
+}
+
+/// Messages sent from the server to the client over the client protocol
+/// socket. Variant order mirrors herdr 0.9.0's `ServerMessage` exactly; the
+/// WebUI acts on `Welcome`, `Terminal`, `Graphics`, `ServerShutdown`,
+/// `Notify`, `Clipboard`, `WindowTitle`, and `TerminalBell`, and the rest
+/// exist so the proxy can decode and skip them.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum ServerMessage {
+    /// Handshake response: server acknowledges (or rejects) the client.
     Welcome {
         version: u32,
         encoding: RenderEncoding,
         error: Option<String>,
     },
-    Frame(FrameData),
+
+    /// Terminal bytes to write directly for a terminal-ANSI client.
     Terminal(TerminalFrame),
+
+    /// Client-local Kitty graphics bytes to write directly to the host terminal.
     Graphics {
         bytes: Vec<u8>,
     },
+
+    /// Server is shutting down. Clients should exit gracefully.
     ServerShutdown {
         reason: Option<String>,
     },
+
+    /// A notification event (sound/toast) to be rendered locally by the client.
     Notify {
         kind: NotifyKind,
         message: String,
         body: Option<String>,
     },
+
+    /// OSC 52 clipboard data forwarded from a PTY through the server.
     Clipboard {
         data: String,
     },
+
+    /// Set the foreground client's outer terminal window title.
     WindowTitle {
         title: Option<String>,
     },
+
+    /// Client-local runtime config changed on disk; refresh it without reconnecting.
     ReloadSoundConfig,
+
+    /// Whether the client should currently capture host mouse input.
     MouseCapture {
         enabled: bool,
         /// True only while the focused pane requests DEC SGR pixel mode 1016.
-        /// Added in protocol 20+ (graphics streaming). A web client does not
-        /// act on it, so we only need to deserialize it.
-        #[serde(default)]
         sgr_pixels: bool,
     },
-    /// Whether the focused terminal requests Kitty report-all keyboard input.
-    /// The backend sends this so the client can adjust its input handling;
-    /// a web client does not act on it, so we only need to deserialize it.
-    /// Added in protocol 18.
-    KittyKeyboardReportAll {
-        enabled: bool,
-    },
-    /// Forwarded macOS prefix-mode ASCII input-source switch request. The
-    /// backend sends this to the foreground client so it can swap the host
-    /// keyboard layout; a web client has no host keyboard to switch, so we
-    /// only need to deserialize it without acting on it. Added in protocol 16.
-    PrefixInputSource {
-        active: bool,
-    },
-    /// Ring the foreground client's outer terminal for pane-originated BEL
-    /// characters. A web client can play a sound or visual bell. Added in
-    /// protocol 20.
+
+    /// Ring the foreground client's outer terminal for pane-originated BEL characters.
     TerminalBell {
         count: u16,
     },
+
     /// One validated Herdr-owned Kitty regular-file RGBA transmission.
-    /// A web client does not process local graphics files, so this only
-    /// needs to deserialize. Added in protocol 20+ (graphics streaming).
     GraphicsFile {
         path: String,
         expected_len: u64,
@@ -356,11 +925,55 @@ pub(crate) enum ServerMessage {
         transfer_id: u64,
         leading: Vec<u8>,
         control: String,
+        /// ClientShell upload identity. `None` targets a direct terminal client.
+        surface_asset: Option<SurfaceGraphicsAssetKey>,
     },
+
     /// Suppress a direct command that expired before terminal delivery.
-    /// Added in protocol 20+ (graphics streaming).
     GraphicsTransmissionRetired {
         transfer_id: u64,
         image_id: u32,
+    },
+
+    /// Initial metadata for a client-owned shell.
+    ClientShellSnapshot(Box<ClientShellSnapshot>),
+
+    /// Active-tab pane content rendered at a client-requested origin-relative size.
+    PaneSurface(PaneSurfaceFrame),
+
+    /// Ephemeral semantic notification delivered over the private control lane.
+    SemanticNotification(SemanticNotification),
+
+    /// Immediate endpoint error that the client-rendered shell must show.
+    ClientShellError {
+        message: String,
+    },
+
+    /// Exact Kitty keyboard flags requested by a directly attached terminal.
+    DirectTerminalKeyboardProtocol {
+        flags: u16,
+        modify_other_keys_level: u8,
+    },
+
+    /// Whether the focused pane or popup needs the shell host to report every key.
+    ClientShellKeyboardReportAll {
+        enabled: bool,
+    },
+
+    /// One ordered chunk of the final response to an endpoint operation.
+    ClientShellEndpointResponseChunk {
+        boot_id: String,
+        request_id: String,
+        final_chunk: bool,
+        data: Vec<u8>,
+    },
+
+    /// Incremental terminal-cell update for a previously committed pane surface.
+    PaneSurfacePatch(PaneSurfacePatch),
+
+    /// Extensible named control message for the stable client-owned endpoint protocol.
+    EndpointControl {
+        kind: String,
+        data: String,
     },
 }


### PR DESCRIPTION
## Summary

- Port the backend protocol to herdr 0.9.0 / protocol 22 (bracketed paste input, `\r` Enter + kitty `13;2u`, pixel mouse resize, removed legacy multi-version fallback).
- Make built-in sessions the default backend (server default `builtin`, frontends adopt the server's backend once so stale localStorage can't lock in a broken choice).
- Graceful degradation on external herdr handshake failure: the terminal socket sends a structured `herdr_error` frame, disconnects, closes the broken session, and offers a built-in session (desktop askQuestion, mobile confirm).
- Only offer external herdr sessions when a detected herdr install is compatible: `herdr --version` detection with version-range classification exposed in `/api/sessions` (`herdr_available`, `herdr_compatible`, `herdr_version`) and `/api/versions` (`herdr_install`); the external launch endpoint rejects missing/incompatible installs with an actionable error; the session manager disables the New Herdr button with a version hint and `goSession`/`newSessionTarget` keep the browser on built-in.

## Testing

- 500 Rust tests pass (new: detection classification, launch gating for missing/incompatible installs).
- 435 JS tests pass (new: herdr button gating in session manager).
- Full e2e acceptance against a real herdr 0.9.0 server: 31/31 checks pass, including fresh-browser builtin default, herdr install detection (0.9.0 compatible), and external sessions gated on compatibility.
- Negative check: with herdr 0.8.0 detected, `compatible=false` and external sessions are omitted from the list.