### PR TITLE
Directory picker: incremental search results and Default dir button

### DIFF
--- a/src/assets/desktop/directory_picker.css
+++ b/src/assets/desktop/directory_picker.css
@@ -74,3 +74,8 @@
 .directory-picker-error span {
   min-width: 0;
 }
+.directory-picker-more {
+  display: flex;
+  justify-content: center;
+  padding: 8px 0;
+}

--- a/src/assets/desktop/directory_picker.js
+++ b/src/assets/desktop/directory_picker.js
@@ -1,6 +1,7 @@
 (function () {
   const Tree = window.HerdrFileTree;
-  const state = { input: null, root: "~", path: "", entries: [], error: "", permissionRequired: false, filter: "", filterTimer: null, gitStatus: null };
+  const SEARCH_PAGE_SIZE = 100;
+  const state = { input: null, root: "~", path: "", entries: [], error: "", permissionRequired: false, filter: "", filterTimer: null, filterOffset: 0, filterDone: true, filterLoading: false, gitStatus: null };
 
   function esc(value) { return Tree.esc(value); }
 
@@ -107,6 +108,9 @@
   async function load(path) {
     state.path = path || "";
     state.filter = "";
+    state.filterOffset = 0;
+    state.filterDone = true;
+    state.filterLoading = false;
     clearTimeout(state.filterTimer);
     state.error = "";
     state.permissionRequired = false;
@@ -123,16 +127,33 @@
     render();
   }
 
-  async function search() {
-    if (!state.filter.trim()) { load(state.path); return; }
+  async function search(append = false) {
+    const term = state.filter.trim();
+    if (!term) { load(state.path); return; }
+    const offset = append ? state.filterOffset : 0;
+    if (append && state.filterLoading) return;
+    state.filterLoading = true;
+    // Re-render before the fetch so the loading hint shows while paging in
+    // more results; skip when appending so the scroll position survives.
+    if (!append) render();
     try {
-      const data = await api(`/api/file-browser/tree?cwd=${encodeURIComponent(state.root)}&path=${encodeURIComponent(state.path)}&q=${encodeURIComponent(state.filter.trim())}&limit=100${gitStatusEnabled() ? "&include_git_status=true" : ""}`);
-      state.entries = data.entries || [];
+      const data = await api(`/api/file-browser/tree?cwd=${encodeURIComponent(state.root)}&path=${encodeURIComponent(state.path)}&q=${encodeURIComponent(term)}&offset=${offset}&limit=${SEARCH_PAGE_SIZE}${gitStatusEnabled() ? "&include_git_status=true" : ""}`);
+      const entries = data.entries || [];
+      state.entries = append ? state.entries.concat(entries) : entries;
       state.gitStatus = data.git_status || null;
+      state.filterOffset = offset + entries.length;
+      // The server walks the tree with a visit cap, so `truncated` can be
+      // true even when a page comes back short. Keep paging available as
+      // long as the server reports more matches.
+      state.filterDone = !data.truncated || entries.length === 0;
+      state.error = "";
+      state.permissionRequired = false;
     } catch (error) {
       setError(error);
-      state.entries = [];
+      if (!append) state.entries = [];
+      state.filterDone = true;
     }
+    state.filterLoading = false;
     render();
   }
 
@@ -175,6 +196,12 @@
     if (callback) callback();
   }
 
+  function goToDefaultFolder() {
+    const target = splitPath(configuredDefaultFolder());
+    state.root = target.root;
+    load(target.path || "");
+  }
+
   function render() {
     let modal = document.getElementById("directoryPickerModal");
     if (!modal) {
@@ -188,6 +215,9 @@
     const selStart = refocus ? active.selectionStart : null;
     const selEnd = refocus ? active.selectionEnd : null;
     const filtering = !!state.filter.trim();
+    const appending = filtering && state.filterLoading && state.filterOffset > 0;
+    const tree = modal.querySelector(".directory-picker-tree");
+    const previousScroll = appending && tree ? tree.scrollTop : null;
     const canGoUp = state.path || state.root !== "/";
     const entries = Tree.applyGitStatus(filtering
       ? Tree.searchTreeEntries(state.entries)
@@ -202,7 +232,10 @@
       title: currentPath,
       canGoUp,
     });
-    modal.innerHTML = `<div class="directory-picker"><div class="directory-picker-head"><strong>Choose folder</strong><button class="git-ui-btn" onclick="HerdrDirectoryPicker.close()">Close</button></div><div class="directory-picker-path">${esc(currentPath)}</div><div class="directory-picker-actions"><button class="git-ui-btn" onclick="HerdrDirectoryPicker.home()">Home</button><button class="git-ui-btn primary" onclick="HerdrDirectoryPicker.selectCurrent()">Select this folder</button></div>${renderAccessError()}<div class="directory-picker-search"><input id="directoryPickerSearchInput" type="text" placeholder="Type to search..." value="${esc(state.filter)}" oninput="HerdrDirectoryPicker.filter(this.value)"></div><div class="directory-picker-tree">${currentRow}${Tree.renderEntries(entries, { callback: "HerdrDirectoryPicker", selectedPath: state.path })}</div></div>`;
+    const moreRow = filtering && !state.filterDone
+      ? `<div class="directory-picker-more"><button class="git-ui-btn" ${state.filterLoading ? "disabled" : ""} onclick="HerdrDirectoryPicker.loadMore()">${state.filterLoading ? "Loading…" : "Load more"}</button></div>`
+      : "";
+    modal.innerHTML = `<div class="directory-picker"><div class="directory-picker-head"><strong>Choose folder</strong><button class="git-ui-btn" onclick="HerdrDirectoryPicker.close()">Close</button></div><div class="directory-picker-path">${esc(currentPath)}</div><div class="directory-picker-actions"><button class="git-ui-btn" onclick="HerdrDirectoryPicker.home()">Home</button><button class="git-ui-btn" onclick="HerdrDirectoryPicker.defaultFolder()">Default dir</button><button class="git-ui-btn primary" onclick="HerdrDirectoryPicker.selectCurrent()">Select this folder</button></div>${renderAccessError()}<div class="directory-picker-search"><input id="directoryPickerSearchInput" type="text" placeholder="Type to search..." value="${esc(state.filter)}" oninput="HerdrDirectoryPicker.filter(this.value)"></div><div class="directory-picker-tree" onscroll="HerdrDirectoryPicker.treeScroll(this)">${currentRow}${Tree.renderEntries(entries, { callback: "HerdrDirectoryPicker", selectedPath: state.path })}${moreRow}</div></div>`;
     if (refocus) {
       const input = document.getElementById("directoryPickerSearchInput");
       if (input) {
@@ -211,6 +244,10 @@
         const end = selEnd == null ? start : Math.min(selEnd, input.value.length);
         input.setSelectionRange(start, end);
       }
+    }
+    if (previousScroll != null) {
+      const nextTree = modal.querySelector(".directory-picker-tree");
+      if (nextTree) nextTree.scrollTop = previousScroll;
     }
   }
 
@@ -258,11 +295,20 @@
       load(parentPath(state.path));
     },
     home() { state.root = "~"; load(""); },
+    defaultFolder: goToDefaultFolder,
     root() { state.root = "/"; load(""); },
     filter(value) {
       state.filter = String(value || "");
       clearTimeout(state.filterTimer);
       state.filterTimer = setTimeout(() => search(), 200);
+    },
+    loadMore() { search(true); },
+    treeScroll(node) {
+      // Infinite scroll: when the user nears the bottom of the result
+      // list, fetch the next page of matches and append it.
+      if (!state.filter.trim() || state.filterLoading || state.filterDone) return;
+      if (node.scrollTop + node.clientHeight < node.scrollHeight - 80) return;
+      search(true);
     },
   };
 })();

--- a/src/assets/directory_picker.test.mjs
+++ b/src/assets/directory_picker.test.mjs
@@ -1,0 +1,230 @@
+// Functional tests for the desktop directory picker modal: incremental
+// search paging (infinite scroll) and the Default dir action.
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { equal, match } from "node:assert/strict";
+
+const pickerSource = readFileSync(new URL("./desktop/directory_picker.js", import.meta.url), "utf8");
+const treeSource = readFileSync(new URL("./shared/file_tree.js", import.meta.url), "utf8");
+
+// Minimal DOM good enough for the picker: createElement/getElementById,
+// innerHTML assignment (captured for assertions), appendChild, remove,
+// querySelector for the tree, activeElement, focus and selection.
+function makeElement(id = "") {
+  const el = {
+    id,
+    innerHTML: "",
+    className: "",
+    textContent: "",
+    value: "",
+    scrollTop: 0,
+    scrollHeight: 2000,
+    clientHeight: 500,
+    selectionStart: null,
+    selectionEnd: null,
+    dataset: {},
+    children: [],
+    style: {},
+    parentNode: { appendChild() {} },
+    appendChild(child) { this.children.push(child); },
+    insertAdjacentElement() {},
+    remove() { this.removed = true; },
+    focus() {},
+    setSelectionRange() {},
+    dispatchEvent() {},
+    addEventListener() {},
+    querySelector() { return makeElement("tree"); },
+  };
+  return el;
+}
+
+function context({ fetchImpl } = {}) {
+  const elements = new Map();
+  const getElementById = (id) => {
+    if (!elements.has(id)) elements.set(id, makeElement(id));
+    return elements.get(id);
+  };
+  const ctx = {
+    console,
+    TextEncoder,
+    URLSearchParams,
+    clearTimeout() {},
+    setTimeout(fn) { if (typeof fn === "function") fn(); return 1; },
+    document: {
+      body: makeElement("body"),
+      title: "",
+      createElement: (tag) => makeElement(tag),
+      querySelector: () => makeElement("queried"),
+      querySelectorAll: () => [],
+      getElementById,
+      addEventListener() {},
+    },
+    localStorage: {
+      store: new Map(),
+      getItem(key) { return this.store.get(key) ?? null; },
+      setItem(key, value) { this.store.set(key, String(value)); },
+      removeItem(key) { this.store.delete(key); },
+    },
+    fetch: fetchImpl || (async () => ({ status: 200, json: async () => ({}) })),
+    addEventListener() {},
+    WebSocket: class {},
+  };
+  ctx.window = ctx;
+  ctx.globalThis = ctx;
+  return { ctx: vm.createContext(ctx), elements, getElementById };
+}
+
+// The picker keeps `state` and `render` inside its closure. Tests inject a
+// debug hook that exposes both so assertions can read module state.
+const debugPickerSource = pickerSource.replace(
+  "window.HerdrDirectoryPicker = {",
+  "window.__pickerDebug = { state, render };\n  window.HerdrDirectoryPicker = {",
+);
+
+function loadPicker({ fetchImpl, defaultFolder } = {}) {
+  const harness = context({ fetchImpl });
+  const { ctx } = harness;
+  if (defaultFolder != null) ctx.defaultFolderPath = () => defaultFolder;
+  vm.runInContext(treeSource, ctx);
+  vm.runInContext(debugPickerSource, ctx);
+  return harness;
+}
+
+function treeUrlCalls(ctx) {
+  return ctx.fetch.urls || [];
+}
+
+test("directory picker search appends pages on scroll and stops at the end", async () => {
+  const searchCalls = [];
+  let page = 0;
+  const pages = [
+    { entries: [{ name: "a1", path: "a/1", kind: "dir", level: 0 }], truncated: true },
+    { entries: [{ name: "a2", path: "a/2", kind: "dir", level: 0 }], truncated: true },
+    { entries: [{ name: "a3", path: "a/3", kind: "dir", level: 0 }], truncated: false },
+  ];
+  const { ctx, getElementById } = loadPicker({
+    fetchImpl: async (url) => {
+      const text = String(url);
+      if (!text.includes("q=")) {
+        return { ok: true, status: 200, json: async () => ({ path: "", entries: [], truncated: false }) };
+      }
+      searchCalls.push(text);
+      const pageData = pages[Math.min(searchCalls.length - 1, pages.length - 1)];
+      // The server's offset counts matches, so page N starts at the number
+      // of matched entries served so far.
+      pageData.path = "";
+      return { ok: true, status: 200, json: async () => pageData };
+    },
+  });
+
+  // Open the picker, then filter.
+  await vm.runInContext("HerdrDirectoryPicker.openInput('someInput')", ctx);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await vm.runInContext("HerdrDirectoryPicker.filter('a')", ctx);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  equal(searchCalls.length, 1, "first search issues one request");
+  match(searchCalls[0], /offset=0/);
+  equal(vm.runInContext("__pickerDebug.state.entries.length", ctx), 1);
+  equal(vm.runInContext("__pickerDebug.state.filterDone", ctx), false);
+
+  // Simulate the user scrolling near the bottom of the tree.
+  const tree = getElementById("directoryPickerModal").querySelector(".directory-picker-tree");
+  tree.scrollTop = 1500;
+  ctx.__tree = tree;
+  await vm.runInContext("HerdrDirectoryPicker.treeScroll(__tree)", ctx);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  equal(searchCalls.length, 2, "scroll near bottom fetches the next page");
+  match(searchCalls[1], /offset=1&/, "offset counts matched entries served so far");
+  equal(vm.runInContext("__pickerDebug.state.entries.length", ctx), 2, "appended page grows entries");
+
+  // Scroll again: third page arrives and marks the search done.
+  tree.scrollTop = 1500;
+  ctx.__tree = tree;
+  await vm.runInContext("HerdrDirectoryPicker.treeScroll(__tree)", ctx);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  equal(searchCalls.length, 3);
+  equal(vm.runInContext("__pickerDebug.state.entries.length", ctx), 3);
+  equal(vm.runInContext("__pickerDebug.state.filterDone", ctx), true, "truncated=false ends paging");
+
+  // No further fetches once done.
+  tree.scrollTop = 1500;
+  ctx.__tree = tree;
+  await vm.runInContext("HerdrDirectoryPicker.treeScroll(__tree)", ctx);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  equal(searchCalls.length, 3, "no fetch after the last page");
+});
+
+test("directory picker shows a Load more button while more results exist", async () => {
+  const { ctx } = loadPicker({
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ entries: [{ name: "b1", path: "b/1", kind: "dir", level: 0 }], truncated: true }),
+    }),
+  });
+  await vm.runInContext("HerdrDirectoryPicker.openInput('someInput')", ctx);
+  await ctx.HerdrDirectoryPicker.filter("b");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  vm.runInContext("__pickerDebug.render()", ctx);
+  const modal = ctx.document.getElementById("directoryPickerModal");
+  match(modal.innerHTML, /Load more/);
+  match(modal.innerHTML, /HerdrDirectoryPicker\.loadMore\(\)/);
+  match(modal.innerHTML, /HerdrDirectoryPicker\.treeScroll\(this\)/);
+});
+
+test("directory picker Default dir button loads the configured default folder", async () => {
+  const calls = [];
+  const { ctx } = loadPicker({
+    defaultFolder: "/Users/tester/projects",
+    fetchImpl: async (url) => {
+      calls.push(String(url));
+      const pathMatch = /path=([^&]*)/.exec(String(url));
+      const path = pathMatch ? decodeURIComponent(pathMatch[1].replace(/\+/g, " ")) : "";
+      return { ok: true, status: 200, json: async () => ({ path, entries: [], truncated: false }) };
+    },
+  });
+  await vm.runInContext("HerdrDirectoryPicker.openInput('someInput')", ctx);
+  vm.runInContext("HerdrDirectoryPicker.defaultFolder()", ctx);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  equal(vm.runInContext("__pickerDebug.state.root", ctx), "/");
+  equal(vm.runInContext("__pickerDebug.state.path", ctx), "Users/tester/projects");
+  match(calls[calls.length - 1], /cwd=%2F/);
+  match(calls[calls.length - 1], /path=Users%2Ftester%2Fprojects/);
+
+  // The action row renders the button next to Home and Select this folder.
+  vm.runInContext("__pickerDebug.render()", ctx);
+  const modal = ctx.document.getElementById("directoryPickerModal");
+  match(modal.innerHTML, /Home<\/button><button class="git-ui-btn" onclick="HerdrDirectoryPicker\.defaultFolder\(\)">Default dir<\/button>/);
+  // The tree scrolls are wired for incremental search results.
+  match(modal.innerHTML, /onscroll="HerdrDirectoryPicker\.treeScroll\(this\)"/);
+});
+
+test("directory picker search paging resets when the filter changes", async () => {
+  const calls = [];
+  const { ctx } = loadPicker({
+    fetchImpl: async (url) => {
+      calls.push(String(url));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ entries: [{ name: "x", path: "x", kind: "dir", level: 0 }], truncated: true }),
+      };
+    },
+  });
+  await vm.runInContext("HerdrDirectoryPicker.openInput('someInput')", ctx);
+  await vm.runInContext("HerdrDirectoryPicker.filter('first')", ctx);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await vm.runInContext("HerdrDirectoryPicker.loadMore()", ctx);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  // Each page served one match, so the offset advanced by two matches.
+  equal(vm.runInContext("__pickerDebug.state.filterOffset", ctx), 2);
+
+  await vm.runInContext("HerdrDirectoryPicker.filter('second')", ctx);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const lastCall = calls[calls.length - 1];
+  match(lastCall, /q=second/);
+  match(lastCall, /offset=0/);
+  equal(vm.runInContext("__pickerDebug.state.entries.length", ctx), 1, "entries reset for the new term");
+});


### PR DESCRIPTION
## Changes

**1. Search loads more results while you scroll**
- The picker previously fetched one fixed page of 100 matches and stopped.
- Now scrolling near the bottom of the result list fetches the next page
  (`offset` paging against the existing tree search API) and appends it,
  preserving the scroll position.
- A `Load more` fallback button renders while more results exist.
- Paging stops when the server reports `truncated: false`; changing the
  search term resets the pager.

**2. Default dir action**
- `Default dir` button next to Home and Select this folder jumps to the
  server-configured default folder (`window.defaultFolderPath()`, the same
  source the picker already uses as its initial path).

## Tests
- New `src/assets/directory_picker.test.mjs` (4 tests): scroll-triggered
  append across three pages with done-flag termination, Load more button +
  onscroll wiring, Default dir navigation + button rendering, pager reset
  on filter change.
- Full JS suite: 440 pass (436 + 4).
- Verified the served asset contains the new handlers on a dev server.