### PR TITLE
Search palette section toggle background

### DIFF
--- a/src/assets/desktop/search.css
+++ b/src/assets/desktop/search.css
@@ -99,6 +99,7 @@
   padding: 8px 10px;
 }
 .search-section-toggle {
+  background: var(--panel2);
   border: 0;
   cursor: pointer;
   font: inherit;


### PR DESCRIPTION
The collapsible section header buttons in the search palette (Recent workspaces, etc.) had a transparent background and looked like plain text over the palette. Give .search-section-toggle a var(--panel2) background so the header reads as a button row, consistent with the other panel2 surfaces in the palette.

One-line CSS change, no behavior change.