### PR TITLE
Session UX: backend colors, hidden herdr offer, session manager fixes

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,27 @@
 # Release notes
 
+## 0.4.18 Release Notes
+- Session backends now have distinct colors in the footer session button, the
+  session picker rows/status pills/current dot, and the mobile header badge:
+  built-in keeps the accent family and external Herdr uses mauve, in both dark
+  and light themes. The footer button label also shows the active backend
+  (e.g. `default · built-in`) and no longer gets clobbered by background
+  refreshes.
+- The session manager gained a ✕ close button and closes on backdrop click.
+  It only auto-hides itself when it was auto-opened; a manager opened
+  deliberately stays open across background refreshes.
+- The New Herdr session offer is now hidden (not disabled) when no compatible
+  herdr install is detected, with silent built-in fallback. A CSS rule now
+  enforces the hidden attribute so the offer cannot render while hidden.
+- Hardcoded `Herdr session offline` titles are gone: offline notices name the
+  backend actually in use.
+- The session UX e2e acceptance suite is wired into `run-e2e.sh`. It drives
+  the real served app in headless Chrome over CDP: backend-default checks,
+  color rendering in dark and light themes, picker close/backdrop behavior,
+  offer-hidden state for incompatible installs (fake herdr 0.8.0 probe), and
+  the mobile badge. It also catches CSS/hidden regressions the synthetic tests
+  cannot see.
+
 ## 0.4.17 Release Notes
 - Built-in `worktree.open` now implements Herdr's already-open semantics:
   opening a checkout that is already open as a workspace focuses that

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -28,7 +28,19 @@ What it does:
      really on disk**
    - locking a dirty file asks "Discard unsaved changes..." and discards
    - Cmd+S on a locked file makes no disk write
-6. Tears everything down (pass `--keep` to leave the stack up for debugging).
+6. Runs `session-ux-acceptance.mjs` over CDP against the same server:
+   - fresh browser lands on the built-in backend (`default · built-in` footer,
+     accent-family color, `backend-builtin` class)
+   - session manager opens via the footer button, shows the backend-aware
+     current label, and carries the ✕ close button
+   - session rows and status pills carry backend color classes
+   - ✕ button and backdrop click both close the manager
+   - picking an external herdr row (when a compatible install exists) flips
+     the footer to `· Herdr` with the mauve `backend-herdr` color
+   - the New Herdr offer's hidden state matches the detected install in the
+     real DOM (the `hidden` attribute must actually hide the button)
+   - the mobile layout renders the backend badge with matching colors
+7. Tears everything down (pass `--keep` to leave the stack up for debugging).
 
 ## Environment knobs
 

--- a/scripts/e2e/run-e2e.sh
+++ b/scripts/e2e/run-e2e.sh
@@ -110,3 +110,7 @@ wait_for "headless Chrome CDP" "http://127.0.0.1:$CDP/json/version" "" || exit 1
 echo "==> running acceptance checks"
 ACCEPT_REPO="$REPO" E2E_BASE_URL="https://127.0.0.1:$PORT/" CDP_PORT="$CDP" \
   node "$ROOT/scripts/e2e/acceptance.mjs"
+
+echo "==> running session UX acceptance checks"
+E2E_BASE_URL="https://127.0.0.1:$PORT/" CDP_PORT="$CDP" \
+  node "$ROOT/scripts/e2e/session-ux-acceptance.mjs"

--- a/scripts/e2e/session-ux-acceptance.mjs
+++ b/scripts/e2e/session-ux-acceptance.mjs
@@ -1,0 +1,208 @@
+// Session-management UX acceptance checks: drives the actually-served app in
+// headless Chrome over CDP and verifies the audited behaviors end to end:
+//   - fresh browser lands on built-in backend (mandatory default)
+//   - footer session button shows "session · built-in" with the accent color
+//   - session picker rows carry backend color classes
+//   - session manager opens/closes via the new ✕ button and backdrop click
+//   - external Herdr offer state matches the installed herdr (0.9.0 here)
+//   - switching to an external herdr session flips label + colors
+//   - mobile layout renders the backend badge with matching colors
+import { connectToPage } from './cdp-driver.mjs';
+
+const URL = process.env.E2E_BASE_URL || 'https://127.0.0.1:8899/';
+const results = [];
+function check(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ' :: ' + detail : ''}`);
+}
+
+const cdp = await connectToPage();
+await cdp.send('Page.enable');
+await cdp.send('Network.enable');
+await cdp.send('Security.enable');
+await cdp.send('Security.setIgnoreCertificateErrors', { ignore: true });
+
+// ---------- Desktop layout ----------
+await cdp.send('Page.navigate', { url: URL });
+await new Promise((r) => setTimeout(r, 2500));
+
+let title = await cdp.evalExpr('document.title');
+if (!title || title === 'Privacy error' || String(title).includes('Privacy')) {
+  await cdp.evalExpr('window.location.href = "' + URL + '"');
+  await new Promise((r) => setTimeout(r, 2000));
+}
+check('app loads (title present)', !!(await cdp.evalExpr('document.title')));
+
+// Fresh browser: no stored backend, must land on built-in with "session · built-in".
+const fresh = await cdp.evalExpr(`(async () => {
+  await new Promise((r) => setTimeout(r, 600));
+  const versions = await fetch('/api/versions').then((r) => r.json());
+  const button = document.getElementById('footerSessionButton');
+  const styles = button ? getComputedStyle(button) : null;
+  return {
+    stored: localStorage.getItem('herdr-session-backend'),
+    backendMode: versions.backend_mode,
+    currentBackend: versions.current_backend,
+    herdrInstall: versions.herdr_install || null,
+    footerText: button ? button.textContent : '',
+    footerClass: button ? button.className : '',
+    footerColor: styles ? styles.color : '',
+  };
+})()`, true);
+check(
+  'fresh browser lands on built-in and footer shows "default · built-in"',
+  fresh.stored === 'builtin'
+    && fresh.backendMode === 'builtin'
+    && /built-in/.test(fresh.footerText || ''),
+  `stored=${fresh.stored} mode=${fresh.backendMode} footer="${fresh.footerText}"`,
+);
+check(
+  'footer button carries backend-builtin class and non-default color',
+  /backend-builtin/.test(fresh.footerClass || '')
+    && !!fresh.footerColor && fresh.footerColor !== 'rgb(0, 0, 0)',
+  `class="${fresh.footerClass}" color=${fresh.footerColor}`,
+);
+
+// Session picker: open via the footer button's own onclick (real UI path).
+const manager = await cdp.evalExpr(`(async () => {
+  document.getElementById('footerSessionButton').click();
+  await new Promise((r) => setTimeout(r, 800));
+  const m = document.getElementById('sessionManager');
+  const rows = [...document.querySelectorAll('#sessionList .session-line')];
+  const herdrBtn = document.getElementById('newHerdrSessionTarget');
+  const closeBtn = document.getElementById('sessionManagerClose');
+  const builtinBtn = document.getElementById('newBuiltinSessionTarget');
+  return {
+    visible: m && getComputedStyle(m).display !== 'none',
+    title: document.getElementById('sessionManagerTitle').textContent,
+    currentLabel: document.getElementById('sessionCurrentLabel').textContent,
+    rowClasses: rows.map((r) => r.className),
+    pillClasses: [...document.querySelectorAll('#sessionList .status-pill')].map((p) => p.className),
+    herdrHidden: herdrBtn ? herdrBtn.hidden : null,
+    herdrDisabled: herdrBtn ? herdrBtn.disabled : null,
+    builtinHidden: builtinBtn ? builtinBtn.hidden : null,
+    closePresent: !!closeBtn,
+  };
+})()`, true);
+check(
+  'session manager opens with backend-aware current label and close button',
+  manager.visible === true
+    && /built-in/.test(manager.currentLabel || '')
+    && manager.closePresent === true,
+  `visible=${manager.visible} current="${manager.currentLabel}" close=${manager.closePresent}`,
+);
+const herdrCompatible = manager.herdrInstallCompatible
+  || (fresh.herdrInstall && fresh.herdrInstall.compatible);
+check(
+  'external Herdr offer matches installed herdr compatibility (0.9.0 => visible)',
+  manager.herdrHidden === !herdrCompatible,
+  `herdrHidden=${manager.herdrHidden} installCompatible=${herdrCompatible} install=${fresh.herdrInstall && fresh.herdrInstall.version}`,
+);
+check(
+  'session rows carry backend color classes',
+  manager.rowClasses.some((c) => /backend-builtin/.test(c)) === true,
+  `rows=[${manager.rowClasses.join(' | ')}]`,
+);
+check(
+  'backend pills carry backend color classes',
+  manager.pillClasses.some((c) => /backend-(builtin|herdr)/.test(c)) === true,
+  `pills=[${manager.pillClasses.join(' | ')}]`,
+);
+
+// Close via the new ✕ button.
+const closedByX = await cdp.evalExpr(`(async () => {
+  document.getElementById('sessionManagerClose').click();
+  await new Promise((r) => setTimeout(r, 200));
+  const m = document.getElementById('sessionManager');
+  return m && getComputedStyle(m).display === 'none';
+})()`, true);
+check('✕ button closes the session manager', closedByX === true);
+
+// Backdrop click closes (click on the manager itself, outside the card).
+const closedByBackdrop = await cdp.evalExpr(`(async () => {
+  document.getElementById('footerSessionButton').click();
+  await new Promise((r) => setTimeout(r, 600));
+  const m = document.getElementById('sessionManager');
+  const card = m.querySelector('.session-card');
+  const mRect = m.getBoundingClientRect();
+  const ev = new MouseEvent('click', { bubbles: true, clientX: mRect.left + 4, clientY: mRect.bottom - 4 });
+  Object.defineProperty(ev, 'target', { value: m });
+  m.dispatchEvent(ev);
+  await new Promise((r) => setTimeout(r, 200));
+  return getComputedStyle(m).display === 'none';
+})()`, true);
+check('backdrop click closes the session manager', closedByBackdrop === true);
+
+// Switch to an external herdr session through the real picker row (if offered).
+if (manager.herdrHidden === false) {
+  const switched = await cdp.evalExpr(`(async () => {
+    document.getElementById('footerSessionButton').click();
+    await new Promise((r) => setTimeout(r, 800));
+    const rows = [...document.querySelectorAll('#sessionList .session-line')];
+    const row = rows.find((r) => /backend-herdr/.test(r.className));
+    if (!row) return { found: false };
+    row.click();
+    await new Promise((r) => setTimeout(r, 2000));
+    const button = document.getElementById('footerSessionButton');
+    return {
+      found: true,
+      stored: localStorage.getItem('herdr-session-backend'),
+      footerText: button.textContent,
+      footerClass: button.className,
+    };
+  })()`, true);
+  check(
+    'picking an external herdr row switches footer label to "· Herdr" and class to backend-herdr',
+    switched.found === true
+      && switched.stored === 'external-herdr'
+      && /Herdr/.test(switched.footerText || '')
+      && /backend-herdr/.test(switched.footerClass || ''),
+    `stored=${switched.stored} footer="${switched.footerText}" class="${switched.footerClass}"`,
+  );
+  // Return to built-in so the run leaves a clean state.
+  await cdp.evalExpr(`(async () => {
+    document.getElementById('footerSessionButton').click();
+    await new Promise((r) => setTimeout(r, 800));
+    const rows = [...document.querySelectorAll('#sessionList .session-line')];
+    const row = rows.find((r) => /backend-builtin/.test(r.className));
+    if (row) row.click();
+    await new Promise((r) => setTimeout(r, 1500));
+  })()`, true);
+} else {
+  check('external herdr row not offered (no compatible install); skipped switch check', true, `herdrHidden=${manager.herdrHidden}`);
+}
+
+// ---------- Mobile layout ----------
+await cdp.evalExpr('localStorage.setItem("herdr-web-layout", "mobile")');
+await cdp.send('Page.navigate', { url: URL });
+await new Promise((r) => setTimeout(r, 2500));
+const mobile = await cdp.evalExpr(`(async () => {
+  await new Promise((r) => setTimeout(r, 800));
+  const badge = document.getElementById('mobileBackendBadge');
+  const styles = badge ? getComputedStyle(badge) : null;
+  return {
+    layout: document.documentElement.dataset.herdrLayout,
+    badgePresent: !!badge,
+    badgeText: badge ? badge.textContent : '',
+    badgeClass: badge ? badge.className : '',
+    badgeColor: styles ? styles.color : '',
+    borderColor: styles ? styles.borderColor : '',
+  };
+})()`, true);
+check(
+  'mobile layout renders backend badge "built-in" with accent-family color',
+  mobile.layout === 'mobile'
+    && mobile.badgePresent
+    && /built-in/.test(mobile.badgeText || '')
+    && /backend-builtin/.test(mobile.badgeClass || '')
+    && !!mobile.badgeColor,
+  `layout=${mobile.layout} text="${mobile.badgeText}" class="${mobile.badgeClass}" color=${mobile.badgeColor}`,
+);
+await cdp.evalExpr('localStorage.removeItem("herdr-web-layout")');
+
+// ---------- Summary ----------
+const failed = results.filter((r) => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} session UX acceptance checks passed`);
+if (failed.length) {
+  process.exit(1);
+}

--- a/scripts/e2e/session-ux-acceptance.mjs
+++ b/scripts/e2e/session-ux-acceptance.mjs
@@ -173,11 +173,19 @@ if (manager.herdrHidden === false) {
 }
 
 // ---------- Mobile layout ----------
+// The mobile bundle loads its script chain after navigation; poll for the
+// badge instead of fixed sleeps (fixed waits raced the bundle load and
+// produced a false FAIL).
 await cdp.evalExpr('localStorage.setItem("herdr-web-layout", "mobile")');
 await cdp.send('Page.navigate', { url: URL });
-await new Promise((r) => setTimeout(r, 2500));
+await new Promise((r) => setTimeout(r, 1500));
 const mobile = await cdp.evalExpr(`(async () => {
-  await new Promise((r) => setTimeout(r, 800));
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const badge = document.getElementById('mobileBackendBadge');
+    if (badge && document.documentElement.dataset.herdrLayout === 'mobile') break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
   const badge = document.getElementById('mobileBackendBadge');
   const styles = badge ? getComputedStyle(badge) : null;
   return {
@@ -186,7 +194,6 @@ const mobile = await cdp.evalExpr(`(async () => {
     badgeText: badge ? badge.textContent : '',
     badgeClass: badge ? badge.className : '',
     badgeColor: styles ? styles.color : '',
-    borderColor: styles ? styles.borderColor : '',
   };
 })()`, true);
 check(
@@ -197,6 +204,37 @@ check(
     && /backend-builtin/.test(mobile.badgeClass || '')
     && !!mobile.badgeColor,
   `layout=${mobile.layout} text="${mobile.badgeText}" class="${mobile.badgeClass}" color=${mobile.badgeColor}`,
+);
+// The hidden attribute must actually hide the New Herdr offer: a CSS
+// display rule on .session-button previously defeated it (real-browser
+// regression caught by this suite).
+const hiddenCheck = await cdp.evalExpr(`(async () => {
+  localStorage.setItem('herdr-web-layout', 'desktop');
+  location.reload();
+  return true;
+})()`, true);
+await new Promise((r) => setTimeout(r, 2000));
+const hidden = await cdp.evalExpr(`(async () => {
+  await new Promise((r) => setTimeout(r, 500));
+  const install = await fetch('/api/versions').then((r) => r.json());
+  const compatible = install.herdr_install && install.herdr_install.compatible;
+  const herdrBtn = document.getElementById('newHerdrSessionTarget');
+  if (!herdrBtn) return { present: false };
+  document.getElementById('footerSessionButton').click();
+  await new Promise((r) => setTimeout(r, 900));
+  return {
+    present: true,
+    compatible,
+    hiddenAttr: herdrBtn.hidden,
+    computedHidden: getComputedStyle(herdrBtn).display === 'none',
+  };
+})()`, true);
+check(
+  'New Herdr offer hidden state matches herdr compatibility in the real DOM',
+  hidden.present === true
+    && hidden.hiddenAttr === !hidden.compatible
+    && (hidden.compatible || hidden.computedHidden === true),
+  `compatible=${hidden.compatible} hiddenAttr=${hidden.hiddenAttr} computedHidden=${hidden.computedHidden}`,
 );
 await cdp.evalExpr('localStorage.removeItem("herdr-web-layout")');
 

--- a/scripts/e2e/session-ux-acceptance.mjs
+++ b/scripts/e2e/session-ux-acceptance.mjs
@@ -7,6 +7,7 @@
 //   - external Herdr offer state matches the installed herdr (0.9.0 here)
 //   - switching to an external herdr session flips label + colors
 //   - mobile layout renders the backend badge with matching colors
+//   - light (latte) theme renders the backend colors with its own palette
 import { connectToPage } from './cdp-driver.mjs';
 
 const URL = process.env.E2E_BASE_URL || 'https://127.0.0.1:8899/';
@@ -238,9 +239,99 @@ check(
 );
 await cdp.evalExpr('localStorage.removeItem("herdr-web-layout")');
 
+// ---------- Light theme (latte) ----------
+// The --backend-* palette has separate dark (mocha) and light (latte) values;
+// verify the light variants actually render in the real browser.
+await cdp.send('Page.navigate', { url: URL });
+await new Promise((r) => setTimeout(r, 1500));
+await cdp.evalExpr('localStorage.setItem("herdr-web-theme", "light")');
+await cdp.send('Page.navigate', { url: URL });
+await new Promise((r) => setTimeout(r, 2500));
+const lightBuiltin = await cdp.evalExpr(`(async () => {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    if (document.getElementById('footerSessionButton')) break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  const button = document.getElementById('footerSessionButton');
+  const styles = button ? getComputedStyle(button) : null;
+  return {
+    light: document.body.classList.contains('light'),
+    footerText: button ? button.textContent : '',
+    footerColor: styles ? styles.color : '',
+  };
+})()`, true);
+check(
+  'light theme: body.light active and builtin footer keeps latte accent rgb(25, 87, 210)',
+  lightBuiltin.light === true
+    && /built-in/.test(lightBuiltin.footerText || '')
+    && lightBuiltin.footerColor === 'rgb(25, 87, 210)',
+  `light=${lightBuiltin.light} footer="${lightBuiltin.footerText}" color=${lightBuiltin.footerColor}`,
+);
+const lightHerdr = await cdp.evalExpr(`(async () => {
+  document.getElementById('footerSessionButton').click();
+  await new Promise((r) => setTimeout(r, 900));
+  const rows = [...document.querySelectorAll('#sessionList .session-line')];
+  const row = rows.find((r) => /backend-herdr/.test(r.className));
+  if (!row) return { found: false };
+  row.click();
+  await new Promise((r) => setTimeout(r, 2500));
+  const button = document.getElementById('footerSessionButton');
+  const styles = button ? getComputedStyle(button) : null;
+  return { found: true, text: button.textContent, color: styles ? styles.color : '' };
+})()`, true);
+check(
+  'light theme: herdr footer switches to latte mauve rgb(136, 57, 239)',
+  lightHerdr.found === true
+    && /Herdr/.test(lightHerdr.text || '')
+    && lightHerdr.color === 'rgb(136, 57, 239)',
+  `found=${lightHerdr.found} text="${lightHerdr.text}" color=${lightHerdr.color}`,
+);
+const lightMobile = await cdp.evalExpr(`(async () => {
+  document.getElementById('footerSessionButton').click();
+  await new Promise((r) => setTimeout(r, 800));
+  const rows = [...document.querySelectorAll('#sessionList .session-line')];
+  const row = rows.find((r) => /backend-builtin/.test(r.className));
+  if (row) row.click();
+  await new Promise((r) => setTimeout(r, 1500));
+  localStorage.setItem('herdr-web-layout', 'mobile');
+  location.reload();
+  return true;
+})()`, true);
+await new Promise((r) => setTimeout(r, 2500));
+const lightMobileBadge = await cdp.evalExpr(`(async () => {
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const badge = document.getElementById('mobileBackendBadge');
+    if (badge && document.documentElement.dataset.herdrLayout === 'mobile') break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  const badge = document.getElementById('mobileBackendBadge');
+  const styles = badge ? getComputedStyle(badge) : null;
+  return {
+    light: document.body.classList.contains('light'),
+    text: badge ? badge.textContent : '',
+    color: styles ? styles.color : '',
+  };
+})()`, true);
+check(
+  'light theme: mobile badge renders builtin in latte accent rgb(25, 87, 210)',
+  lightMobileBadge.light === true
+    && /built-in/.test(lightMobileBadge.text || '')
+    && lightMobileBadge.color === 'rgb(25, 87, 210)',
+  `light=${lightMobileBadge.light} text="${lightMobileBadge.text}" color=${lightMobileBadge.color}`,
+);
+// Restore theme/layout/backend so the run leaves a clean state.
+await cdp.evalExpr(`(async () => {
+  localStorage.setItem('herdr-web-theme', 'auto');
+  localStorage.removeItem('herdr-web-layout');
+  return true;
+})()`, true);
+
 // ---------- Summary ----------
 const failed = results.filter((r) => !r.ok);
 console.log(`\n${results.length - failed.length}/${results.length} session UX acceptance checks passed`);
+await cdp.close();
 if (failed.length) {
   process.exit(1);
 }

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -2115,8 +2115,9 @@ describe("app bundle load", () => {
 
     await ctx.showSessionManager();
 
-    // The New Herdr button is disabled with a version hint.
+    // The New Herdr button is hidden (not merely disabled) with a version hint.
     const button = ctx.document.getElementById("newHerdrSessionTarget");
+    equal(button.hidden, true);
     equal(button.disabled, true);
     match(button.title, /not compatible/);
 
@@ -2151,10 +2152,158 @@ describe("app bundle load", () => {
 
     const button = ctx.document.getElementById("newHerdrSessionTarget");
     equal(button.disabled, false);
+    equal(button.hidden, false);
     match(button.title, /0\.9\.0/);
 
     ctx.goSession("work", "external-herdr");
     equal(vm.runInContext("state.sessionBackend", ctx), "external-herdr");
+  });
+
+  it("switches footer session button label and backend color class across backends", async () => {
+    const ctx = context();
+    ctx.fetch = async (url) => {
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            current_backend: "builtin",
+            herdr_available: true,
+            herdr_compatible: true,
+            herdr_version: "0.9.0",
+            sessions: [
+              { name: "default", backend: "builtin", backend_label: "built-in", running: true },
+            ],
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    vm.runInContext(source, ctx);
+    ctx.setupSessionChrome();
+
+    ctx.updateFooterSessionButton();
+    const button = ctx.document.getElementById("footerSessionButton");
+    equal(button.textContent, "default · built-in");
+
+    vm.runInContext('state.sessionBackend = "external-herdr"', ctx);
+    ctx.updateFooterSessionButton();
+    equal(button.textContent, "default · Herdr");
+
+    vm.runInContext('state.sessionBackend = "builtin"', ctx);
+    ctx.updateFooterSessionButton();
+    equal(button.textContent, "default · built-in");
+  });
+
+  it("gives the session manager a close button and backdrop-click close", () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+    ctx.setupSessionChrome();
+
+    match(source, /id="sessionManagerClose"/);
+    match(source, /el\("sessionManagerClose"\)\.onclick = hideSessionManager/);
+    // Backdrop close: a click on the manager (outside the card) hides it.
+    match(source, /if \(e\.target === m\) hideSessionManager\(\)/);
+  });
+
+  it("does not clobber the footer session label on background refresh", async () => {
+    const ctx = context();
+    ctx.fetch = async () => ({ ok: true, status: 200, json: async () => ({ result: { workspaces: [] } }) });
+    vm.runInContext(source, ctx);
+    ctx.setupSessionChrome();
+
+    vm.runInContext(`
+      state.session = "work";
+      state.sessionBackend = "external-herdr";
+      state.herdrCompatible = true;
+    `, ctx);
+    ctx.location.pathname = "/session/work";
+    ctx.updateFooterSessionButton();
+    const button = ctx.document.getElementById("footerSessionButton");
+    equal(button.textContent, "work · Herdr");
+
+    await ctx.refresh();
+    equal(button.textContent, "work · Herdr");
+  });
+
+  it("only auto-hides an auto-opened session manager on background refresh", async () => {
+    const ctx = context();
+    let fail = true;
+    ctx.fetch = async () => {
+      if (fail) throw Error("offline");
+      return { ok: true, status: 200, json: async () => ({ result: { workspaces: [] } }) };
+    };
+    vm.runInContext(source, ctx);
+    ctx.setupSessionChrome();
+    const manager = ctx.document.getElementById("sessionManager");
+
+    // Failed refresh auto-opens the manager with a backend-aware title.
+    await ctx.refresh();
+    equal(manager.style.display, "block");
+    equal(ctx.document.getElementById("sessionManagerTitle").textContent, "built-in session offline");
+    ok(!source.includes('"Herdr session offline"'));
+
+    // A user-opened manager survives a later successful refresh.
+    fail = false;
+    await ctx.showSessionManager("Session manager");
+    await ctx.refresh();
+    equal(manager.style.display, "block");
+
+    // An auto-opened manager is hidden again by a successful refresh.
+    await ctx.showSessionManager("Session manager", undefined, { auto: true });
+    await ctx.refresh();
+    equal(manager.style.display, "none");
+  });
+
+  it("uses backend-aware colors for session rows and the footer button", () => {
+    const chromeCss = readFileSync(new URL("./desktop/app_css/chrome.css", import.meta.url), "utf8");
+    const workspacesCss = desktopWorkspacesCss;
+    const terminalCss = readFileSync(new URL("./desktop/app_css/terminal.css", import.meta.url), "utf8");
+    const baseCss = readFileSync(new URL("./desktop/app_css/base.css", import.meta.url), "utf8");
+
+    // Herdr keeps a distinct mauve hue; built-in stays in the accent family.
+    match(baseCss, /--backend-builtin: var\(--accent\)/);
+    match(baseCss, /--backend-herdr: #cba6f7/);
+    match(baseCss, /--backend-herdr: #8839ef/);
+    match(chromeCss, /\.footer-session-button\.backend-builtin \{[\s\S]*?color: var\(--backend-builtin\)/);
+    match(chromeCss, /\.footer-session-button\.backend-herdr \{[\s\S]*?color: var\(--backend-herdr\)/);
+    match(workspacesCss, /\.status-pill\.backend-builtin \{[\s\S]*?color: var\(--backend-builtin\)/);
+    match(workspacesCss, /\.status-pill\.backend-herdr \{[\s\S]*?color: var\(--backend-herdr\)/);
+    match(workspacesCss, /\.session-line\.backend-herdr\.active \{[\s\S]*?background: color-mix\(in srgb, var\(--backend-herdr\), transparent 88%\)/);
+    match(workspacesCss, /\.session-current \.dot\.backend-herdr \{[\s\S]*?background: var\(--backend-herdr\)/);
+    match(terminalCss, /\.session-manager \{[\s\S]*?background: #000a/);
+  });
+
+  it("renders backend color classes on session rows", async () => {
+    const ctx = context();
+    ctx.fetch = async (url) => {
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            current_backend: "builtin",
+            herdr_available: true,
+            herdr_compatible: true,
+            herdr_version: "0.9.0",
+            sessions: [
+              { name: "default", backend: "builtin", backend_label: "built-in", running: true },
+              { name: "work", backend: "external-herdr", backend_label: "Herdr", running: true },
+            ],
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    vm.runInContext(source, ctx);
+
+    await ctx.showSessionManager();
+    const html = ctx.document.getElementById("sessionList").innerHTML;
+
+    match(html, /class="session-line backend-builtin/);
+    match(html, /class="session-line backend-herdr/);
+    match(html, /status-pill backend-builtin/);
+    match(html, /status-pill backend-herdr/);
   });
 
   it("defines grouped settings sections", () => {

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -2272,6 +2272,9 @@ describe("app bundle load", () => {
     match(workspacesCss, /\.session-line\.backend-herdr\.active \{[\s\S]*?background: color-mix\(in srgb, var\(--backend-herdr\), transparent 88%\)/);
     match(workspacesCss, /\.session-current \.dot\.backend-herdr \{[\s\S]*?background: var\(--backend-herdr\)/);
     match(terminalCss, /\.session-manager \{[\s\S]*?background: #000a/);
+    // The hidden attribute must beat .session-button's display rule, or the
+    // hidden New Herdr offer still renders (real-browser regression).
+    match(workspacesCss, /\.session-button\[hidden\] \{[\s\S]*?display: none/);
   });
 
   it("renders backend color classes on session rows", async () => {

--- a/src/assets/desktop/app_css/base.css
+++ b/src/assets/desktop/app_css/base.css
@@ -28,6 +28,8 @@ body {
   --border2: #45475a;
   --muted: #a6adc8;
   --accent: #89b4fa;
+  --backend-builtin: var(--accent);
+  --backend-herdr: #cba6f7;
   --editor-caret: #f2f5ff;
   --editor-caret-dim: #a6adc8;
   --git-modified-color: #e9d07a;
@@ -69,6 +71,8 @@ body.light {
   --border2: #7a8296;
   --muted: #525769;
   --accent: #1957d2;
+  --backend-builtin: var(--accent);
+  --backend-herdr: #8839ef;
   --editor-caret: #25253d;
   --editor-caret-dim: #525769;
   --git-modified-color: #7a4d00;

--- a/src/assets/desktop/app_css/chrome.css
+++ b/src/assets/desktop/app_css/chrome.css
@@ -88,6 +88,12 @@
 .footer-session-button:focus {
   color: var(--accent-1);
 }
+.footer-session-button.backend-builtin {
+  color: var(--backend-builtin);
+}
+.footer-session-button.backend-herdr {
+  color: var(--backend-herdr);
+}
 .side-footer {
   color: var(--muted);
   font-size: 8.5px;

--- a/src/assets/desktop/app_css/terminal.css
+++ b/src/assets/desktop/app_css/terminal.css
@@ -277,7 +277,7 @@ input {
   position: absolute;
   inset: 52px 0 0 0;
   z-index: 20;
-  background: var(--bg);
+  background: #000a;
   padding: 32px;
 }
 .session-manager h1 {

--- a/src/assets/desktop/app_css/workspaces.css
+++ b/src/assets/desktop/app_css/workspaces.css
@@ -331,7 +331,7 @@ body.light .agent-sort-chip.blue {
 }
 .session-manager {
   padding: 0;
-  background: linear-gradient(135deg, var(--bg), var(--panel));
+  background: #000a;
 }
 .session-card {
   margin: 32px auto;
@@ -395,6 +395,9 @@ body.light .agent-sort-chip.blue {
   border-color: var(--accent);
   background: color-mix(in srgb, var(--accent), transparent 88%);
 }
+.session-line.backend-herdr:not(.active) {
+  border-color: color-mix(in srgb, var(--backend-herdr), transparent 55%);
+}
 .session-line > span:first-child {
   min-width: 0;
 }
@@ -456,6 +459,31 @@ body.light .agent-sort-chip.blue {
 }
 .status-pill.offline {
   color: var(--muted);
+}
+.status-pill.backend-builtin {
+  border-color: var(--backend-builtin);
+  color: var(--backend-builtin);
+}
+.status-pill.backend-herdr {
+  border-color: var(--backend-herdr);
+  color: var(--backend-herdr);
+}
+.session-line.backend-herdr:hover {
+  border-color: var(--backend-herdr);
+}
+.session-line.backend-herdr.active {
+  border-color: var(--backend-herdr);
+  background: color-mix(in srgb, var(--backend-herdr), transparent 88%);
+}
+.session-current .dot.backend-builtin {
+  background: var(--backend-builtin);
+}
+.session-current .dot.backend-herdr {
+  background: var(--backend-herdr);
+}
+.session-hero .settings-close {
+  margin-left: 12px;
+  flex: none;
 }
 .session-new {
   margin-top: 14px;

--- a/src/assets/desktop/app_css/workspaces.css
+++ b/src/assets/desktop/app_css/workspaces.css
@@ -432,6 +432,11 @@ body.light .agent-sort-chip.blue {
     color 0.15s;
   white-space: nowrap;
 }
+/* The hidden attribute must win over .session-button's display rule, or a
+   hidden New Herdr offer still renders. */
+.session-button[hidden] {
+  display: none;
+}
 .session-button:hover,
 .session-button:focus {
   background: var(--control-hover);

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -2497,8 +2497,11 @@ function setupSessionChrome() {
     b.id = "footerSessionButton";
     b.className = "footer-session-button";
     b.title = "Session manager";
-    b.textContent = state.session || "default";
-    b.onclick = () => showSessionManager(state.backendOnline ? "Session manager" : "Herdr session offline");
+    b.textContent = footerSessionButtonLabel();
+    b.onclick = () =>
+      showSessionManager(
+        state.backendOnline ? "Session manager" : `${sessionBackendLabel(currentSessionBackend())} session offline`,
+      );
     const brandText = brand && brand.querySelector(".brand-text");
     if (brandText) brandText.appendChild(b);
     else footer.appendChild(b);
@@ -2508,6 +2511,7 @@ function setupSessionChrome() {
     if (button && brandText && button.parentNode !== brandText)
       brandText.appendChild(button);
   }
+  updateFooterSessionButton();
   if (versionsEl && versionsEl.parentNode !== footer) {
     versionsEl.remove();
     versionsEl.classList.add("side-footer", "footer-meta");
@@ -2537,8 +2541,14 @@ function setupSessionChrome() {
     m.className = "session-manager";
     m.id = "sessionManager";
     m.innerHTML =
-      '<div class="session-card"><div class="session-hero"><div><h1 id="sessionManagerTitle">Sessions</h1><p id="sessionManagerText">Choose a built-in or Herdr backend session to open.</p></div><div class="session-current"><span class="dot unknown"></span><span id="sessionCurrentLabel">default · built-in</span></div></div><div class="session-actions"><div class="session-list" id="sessionList"></div><div class="session-line session-new"><span><strong>Create or target session</strong><small>Choose where to create/open it. Built-in starts inside WebUI. Herdr starts external daemon.</small></span><span class="session-controls"><button class="session-button primary" id="newBuiltinSessionTarget">New built-in</button><button class="session-button" id="newHerdrSessionTarget">New Herdr</button></span></div></div></div>';
+      '<div class="session-card"><div class="session-hero"><div><h1 id="sessionManagerTitle">Sessions</h1><p id="sessionManagerText">Choose a built-in or Herdr backend session to open.</p></div><div class="session-current"><span class="dot unknown"></span><span id="sessionCurrentLabel">default · built-in</span></div><button class="mini settings-close" id="sessionManagerClose" title="Close" aria-label="Close session manager">✕</button></div><div class="session-actions"><div class="session-list" id="sessionList"></div><div class="session-line session-new"><span><strong>Create or target session</strong><small>Choose where to create/open it. Built-in starts inside WebUI. Herdr starts external daemon.</small></span><span class="session-controls"><button class="session-button primary" id="newBuiltinSessionTarget">New built-in</button><button class="session-button" id="newHerdrSessionTarget">New Herdr</button></span></div></div></div>';
     document.querySelector(".main").prepend(m);
+    // Backdrop click closes: only clicks on the manager itself (outside the
+    // card) dismiss it.
+    m.addEventListener("click", (e) => {
+      if (e.target === m) hideSessionManager();
+    });
+    el("sessionManagerClose").onclick = hideSessionManager;
     el("newBuiltinSessionTarget").onclick = () => newSessionTarget("builtin");
     el("newHerdrSessionTarget").onclick = () => newSessionTarget("external-herdr");
   }
@@ -2546,6 +2556,20 @@ function setupSessionChrome() {
 }
 function sessionBackendLabel(backend) {
   return backend === "external-herdr" ? "Herdr" : "built-in";
+}
+function sessionBackendClass(backend) {
+  return backend === "external-herdr" ? "backend-herdr" : "backend-builtin";
+}
+function footerSessionButtonLabel() {
+  const backend = currentSessionBackend();
+  return `${state.session || "default"} · ${sessionBackendLabel(backend)}`;
+}
+function updateFooterSessionButton() {
+  const button = el("footerSessionButton");
+  if (!button) return;
+  button.textContent = footerSessionButtonLabel();
+  button.classList.remove("backend-builtin", "backend-herdr");
+  button.classList.add(sessionBackendClass(currentSessionBackend()));
 }
 function currentSessionBackend() {
   return state.sessionBackend || state.backendMode || "builtin";
@@ -2596,7 +2620,7 @@ function renderSessionRows() {
       const backend = s.backend || "external-herdr";
       const active = s.name === state.session && backend === currentSessionBackend();
       const status = `<span class="status-pill ${s.running ? "running" : "offline"}">${s.running ? "running" : "offline"}</span>`;
-      const backendPill = `<span class="status-pill">${escapeHtml(s.backend_label || sessionBackendLabel(backend))}</span>`;
+      const backendPill = `<span class="status-pill ${sessionBackendClass(backend)}">${escapeHtml(s.backend_label || sessionBackendLabel(backend))}</span>`;
       const controls = active
         ? `<span class="session-controls">${backendPill}<button class="session-button primary" onclick="event.stopPropagation();launchBackend('${escapeAttr(s.name)}','${escapeAttr(backend)}')">Launch</button><button class="session-button" onclick="event.stopPropagation();refresh()">Retry</button><button class="session-button" onclick="event.stopPropagation();resetSession()">Reset workspaces</button><button class="session-button danger" onclick="event.stopPropagation();closeCurrentSession()">Close</button></span>`
         : `<span class="session-controls">${backendPill}${status}</span>`;
@@ -2605,27 +2629,37 @@ function renderSessionRows() {
         : s.running
           ? `click to switch to this ${sessionBackendLabel(backend)} session`
           : `click to target this offline ${sessionBackendLabel(backend)} session`;
-      return `<div class="session-line ${active ? "active" : ""}" onclick="goSession('${escapeAttr(s.name)}','${escapeAttr(backend)}')"><span><strong>${escapeHtml(s.name)}</strong><small>${escapeHtml(hint)}</small></span>${controls}</div>`;
+      return `<div class="session-line ${sessionBackendClass(backend)} ${active ? "active" : ""}" onclick="goSession('${escapeAttr(s.name)}','${escapeAttr(backend)}')"><span><strong>${escapeHtml(s.name)}</strong><small>${escapeHtml(hint)}</small></span>${controls}</div>`;
     })
     .join("");
 }
-async function showSessionManager(title, text) {
+// Tracks whether the session manager was auto-opened by a failed refresh
+// (as opposed to opened by the user). Background refreshes only auto-hide
+// an auto-opened manager; a user-opened one stays visible.
+let sessionManagerAutoOpened = false;
+async function showSessionManager(title, text, { auto = false } = {}) {
   await loadSessions();
   const titleEl = el("sessionManagerTitle"),
     textEl = el("sessionManagerText"),
     manager = el("sessionManager"),
     list = el("sessionList"),
-    current = el("sessionCurrentLabel");
+    current = el("sessionCurrentLabel"),
+    currentDot = manager && manager.querySelector(".session-current .dot");
   if (titleEl) titleEl.textContent = title || "Session manager";
   if (textEl)
     textEl.textContent =
       text || `Current target: ${state.session || "default"} · ${sessionBackendLabel(currentSessionBackend())}`;
   if (current)
     current.textContent = `${state.session || "default"} · ${sessionBackendLabel(currentSessionBackend())}`;
+  if (currentDot) {
+    currentDot.className = `dot ${sessionBackendClass(currentSessionBackend())}`;
+  }
   if (list) list.innerHTML = renderSessionRows();
-  // Gate the external-Herdr offer on a detected, compatible herdr install.
+  // Hide (not disable) the external-Herdr offer when no compatible herdr
+  // install exists so the manager stays clean; built-in remains the default.
   const herdrButton = el("newHerdrSessionTarget");
   if (herdrButton) {
+    herdrButton.hidden = !state.herdrCompatible;
     if (state.herdrCompatible) {
       herdrButton.disabled = false;
       herdrButton.title = state.herdrVersion
@@ -2639,10 +2673,12 @@ async function showSessionManager(title, text) {
       herdrButton.title = "No compatible herdr install detected; install herdr to use external Herdr sessions";
     }
   }
+  sessionManagerAutoOpened = !!auto;
   if (manager) manager.style.display = "block";
 }
 function hideSessionManager() {
   const manager = el("sessionManager");
+  sessionManagerAutoOpened = false;
   if (manager) manager.style.display = "none";
 }
 async function launchBackend(session = state.session, backend = currentSessionBackend()) {
@@ -2944,12 +2980,10 @@ async function loadVersions() {
       if (state.herdrAvailable && !state.herdrCompatible)
         versionsEl.title += ` · herdr ${state.herdrVersion || "?"} is not compatible with this WebUI build`;
     }
-    const button = el("footerSessionButton");
-    if (button) button.textContent = `${state.session || session} · ${sessionBackendLabel(currentSessionBackend())}`;
+    updateFooterSessionButton();
   } catch (e) {
     if (versionsEl) versionsEl.textContent = "webui - · backend offline";
-    const button = el("footerSessionButton");
-    if (button) button.textContent = `${state.session || "default"} · ${sessionBackendLabel(currentSessionBackend())}`;
+    updateFooterSessionButton();
   }
 }
 function sessionPrefix() {
@@ -3294,9 +3328,10 @@ async function refresh() {
     await refreshOnline(seq);
     if (seq !== refreshSeq) return;
     state.backendOnline = true;
-    hideSessionManager();
-    const button = el("footerSessionButton");
-    if (button) button.textContent = state.session || "default";
+    // Only auto-hide the session manager when it was auto-opened by a
+    // previous failed refresh; a user-opened manager must stay visible.
+    if (sessionManagerAutoOpened) hideSessionManager();
+    updateFooterSessionButton();
   } catch (e) {
     state.backendOnline = false;
     state.workspaces = [];
@@ -3304,12 +3339,12 @@ async function refresh() {
     state.panes = [];
     state.agents = [];
     render();
-    showSessionManager(
-      "Herdr session offline",
+    await showSessionManager(
+      `${sessionBackendLabel(currentSessionBackend())} session offline`,
       `No backend reachable for session ${state.session || "default"}: ${e.message || e}`,
+      { auto: true },
     );
-    const button = el("footerSessionButton");
-    if (button) button.textContent = (state.session || "default") + " offline";
+    updateFooterSessionButton();
   }
 }
 function scheduleRefresh(delay = 500) {

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -36,6 +36,8 @@ body {
   --git-conflict-color: #fab387;
   --accent-fg: #11111b;
   --accent-1: var(--accent);
+  --backend-builtin: var(--accent);
+  --backend-herdr: #cba6f7;
   --accent-soft: color-mix(in srgb, var(--accent), transparent 84%);
   --accent-2: var(--accent-soft);
   --accent-border: color-mix(in srgb, var(--accent), transparent 45%);
@@ -82,6 +84,8 @@ body.light {
   --git-conflict-color: #8a4708;
   --accent-fg: #eff1f5;
   --accent-1: var(--accent);
+  --backend-builtin: var(--accent);
+  --backend-herdr: #8839ef;
   --accent-soft: color-mix(in srgb, var(--accent), transparent 84%);
   --accent-2: var(--accent-soft);
   --accent-border: color-mix(in srgb, var(--accent), transparent 45%);
@@ -141,6 +145,30 @@ body.light {
   color: var(--muted);
   font-size: 12px;
   margin-top: 2px;
+}
+.mobile-context .mobile-backend-badge {
+  align-self: flex-start;
+  border: 1px solid var(--border2);
+  border-radius: 999px;
+  color: var(--muted);
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+  margin-top: 4px;
+  overflow: visible;
+  padding: 3px 7px;
+  text-overflow: clip;
+  white-space: nowrap;
+  width: auto;
+}
+.mobile-context .mobile-backend-badge.backend-builtin {
+  border-color: var(--backend-builtin);
+  color: var(--backend-builtin);
+}
+.mobile-context .mobile-backend-badge.backend-herdr {
+  border-color: var(--backend-herdr);
+  color: var(--backend-herdr);
 }
 .mobile-btn {
   min-width: 44px;

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -254,6 +254,12 @@
     if (state.backendMode === "builtin") return "builtin";
     return "";
   }
+  function sessionBackendLabel(backend) {
+    return backend === "external-herdr" ? "Herdr" : "built-in";
+  }
+  function sessionBackendClass(backend) {
+    return backend === "external-herdr" ? "backend-herdr" : "backend-builtin";
+  }
 
   function currentWorkspace() {
     return state.workspaces.find((w) => w.workspace_id === state.ws) || null;
@@ -376,12 +382,22 @@
     return parts.filter(Boolean).join(" · ");
   }
 
+  // Backend badge: Herdr sessions get a distinct mauve hue; built-in keeps
+  // the accent family. Rendered next to the header meta line.
+  function syncBackendBadge() {
+    const badge = el("mobileBackendBadge");
+    if (!badge) return;
+    const backend = currentSessionBackend() || "builtin";
+    badge.className = `mobile-backend-badge ${sessionBackendClass(backend)}`;
+    badge.textContent = sessionBackendLabel(backend);
+  }
+
   function renderShell() {
     document.body.innerHTML = `
       <div id="mobileApp" class="mobile-app">
         <header class="mobile-header">
           <button class="mobile-btn" id="mobileBack" title="Home">←</button>
-          <div class="mobile-context"><strong id="mobileTitle">Herdr</strong><span id="mobileMeta">Loading</span></div>
+          <div class="mobile-context"><strong id="mobileTitle">Herdr</strong><span id="mobileMeta">Loading</span><span id="mobileBackendBadge" class="mobile-backend-badge backend-builtin">built-in</span></div>
           <button class="mobile-btn" id="mobileSearch" title="Search">⌕</button>
           <button class="mobile-btn" id="mobileSettings" title="Settings">⚙</button>
           <button class="mobile-btn temp-terminal-toggle" id="mobileTempTerminal" title="Temporary terminal" aria-label="Temporary terminal"><span class="temp-terminal-icon" aria-hidden="true"><span class="temp-terminal-icon-glyph"></span><span class="temp-terminal-icon-label">T</span></span></button>
@@ -430,6 +446,7 @@
     const workspace = currentWorkspace();
     el("mobileTitle").textContent = workspaceTitle(workspace);
     el("mobileMeta").textContent = contextMeta(workspace);
+    syncBackendBadge();
     const searchButton = el("mobileSearch");
     if (searchButton) {
       const disabled = headerSearchDisabled();

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -518,6 +518,33 @@ describe("mobile bundle load", () => {
     match(source, /state\.backendMode === "builtin"/);
   });
 
+  it("shows a backend badge with distinct herdr and built-in colors in the mobile header", async () => {
+    const mobileCss = readFileSync(new URL("./mobile/app.css", import.meta.url), "utf8");
+    match(source, /id="mobileBackendBadge"/);
+    match(source, /function syncBackendBadge\(\)/);
+    match(source, /badge\.className = `mobile-backend-badge \$\{sessionBackendClass\(backend\)\}`/);
+    match(mobileCss, /\.mobile-context \.mobile-backend-badge\.backend-builtin \{[\s\S]*?color: var\(--backend-builtin\)/);
+    match(mobileCss, /\.mobile-context \.mobile-backend-badge\.backend-herdr \{[\s\S]*?color: var\(--backend-herdr\)/);
+    // Herdr keeps a distinct mauve hue; built-in stays in the accent family.
+    match(mobileCss, /--backend-builtin: var\(--accent\)/);
+    match(mobileCss, /--backend-herdr: #cba6f7/);
+    match(mobileCss, /--backend-herdr: #8839ef/);
+
+    // The badge switches label and class when the backend changes. The fallback
+    // to built-in on refresh is covered elsewhere; here we exercise the badge
+    // itself without the sessions-gating (the mock /api/sessions reports no
+    // herdr install, so refresh alone would always land on built-in).
+    for (const [storedBackend, label, cls] of [["builtin", "built-in", "backend-builtin"], ["external-herdr", "Herdr", "backend-herdr"]]) {
+      const ctx = context("/session/default/workspace/w1");
+      ctx.localStorage.setItem("herdr-session-backend", storedBackend);
+      vm.runInContext(source, ctx);
+      ctx.HerdrMobile.showScreen("home");
+      const badge = ctx.document.getElementById("mobileBackendBadge");
+      equal(badge.textContent, label);
+      ok(badge.className.includes(cls));
+    }
+  });
+
 
   it("coalesces mobile event socket refreshes and pauses reconnect while hidden", async () => {
     const ctx = context("/session/default/workspace/w1/tab/t1/pane/p1");


### PR DESCRIPTION
## Summary
- Distinct backend colors (built-in = accent family, external Herdr = mauve, dark + light themes) in the footer session button, session picker rows/pills/current dot, and mobile header badge
- Footer session button label shows the active backend (e.g. `default · built-in`) and no longer gets clobbered by background refreshes
- Session manager: ✕ close button, backdrop-click close, auto-hide only when auto-opened
- New Herdr offer hidden (not disabled) when no compatible install, silent built-in fallback; CSS enforces the hidden attribute (real-browser regression the synthetic tests missed)
- Backend-aware offline titles (no more hardcoded `Herdr session offline`)
- Session UX e2e acceptance suite wired into `run-e2e.sh`: drives the real served app in headless Chrome over CDP, covers backend defaults, dark/light colors, close/backdrop behavior, incompatible-install probe (fake herdr 0.8.0), mobile badge

## Test plan
- `run-e2e.sh`: 31/31 main + 15/15 session UX (observed, exit 0)
- Incompatible-install probe: 4/4
- JS: 447/447; `cargo test` 5 targets ok; `cargo fmt --check` clean
- Theme 15/15, mobile edit 52/52, git/content-search acceptance PASSED, LSP 20/20
- Pre-existing clippy dead-code lints unchanged (verified identical at parent commit via baseline worktree)