### PR TITLE
Close stale sessions cleanly and keep the close message visible

### DIFF
--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -39,6 +39,10 @@ What it does:
      the footer to `· Herdr` with the mauve `backend-herdr` color
    - the New Herdr offer's hidden state matches the detected install in the
      real DOM (the `hidden` attribute must actually hide the button)
+   - closing a stale session (backend died without removing its socket, so
+     the row has no live backend) returns `ok + already_stopped` instead of
+     a 502 ENOENT error, and the UI shows the clean already-stopped message
+     without the offline auto-open manager overwriting it
    - the mobile layout renders the backend badge with matching colors
 7. Tears everything down (pass `--keep` to leave the stack up for debugging).
 

--- a/scripts/e2e/run-e2e.sh
+++ b/scripts/e2e/run-e2e.sh
@@ -70,6 +70,11 @@ git -C "$REPO" init -q
 git -C "$REPO" add -A
 git -C "$REPO" -c user.name=e2e -c user.email=e2e@local commit -qm init
 
+# Stale external-session fixture: a known session row whose socket file is
+# gone (backend crashed / kill -9). The session-ux acceptance checks verify
+# that closing it succeeds instead of returning a 502 ENOENT error.
+mkdir -p "$WORK/xdg/herdr/sessions/stale-probe"
+
 wait_for() {
   # wait_for <desc> <url> [-k]
   local desc="$1" url="$2" kflag="$3"

--- a/scripts/e2e/session-ux-acceptance.mjs
+++ b/scripts/e2e/session-ux-acceptance.mjs
@@ -6,6 +6,8 @@
 //   - session manager opens/closes via the new ✕ button and backdrop click
 //   - external Herdr offer state matches the installed herdr (0.9.0 here)
 //   - switching to an external herdr session flips label + colors
+//   - closing a stale session (socket gone) returns ok + already_stopped and
+//     the UI keeps the clean close message (no offline auto-open overwrite)
 //   - mobile layout renders the backend badge with matching colors
 //   - light (latte) theme renders the backend colors with its own palette
 import { connectToPage } from './cdp-driver.mjs';
@@ -172,6 +174,78 @@ if (manager.herdrHidden === false) {
 } else {
   check('external herdr row not offered (no compatible install); skipped switch check', true, `herdrHidden=${manager.herdrHidden}`);
 }
+
+// ---------- Stale session close ----------
+// A session whose backend died without removing its row (crash, kill -9 ->
+// socket file gone) must close cleanly instead of returning a 502 ENOENT
+// error, and the UI must show the clean already-stopped message. The runner
+// creates the stale session directory as a fixture (run-e2e.sh); the server
+// discovers it as a known external session row with no live socket.
+const staleApi = await cdp.evalExpr(`(async () => {
+  // API check first: closing the stale row through the server API must
+  // report ok + already_stopped, not a 502 ENOENT error.
+  const res = await fetch('/api/session/close', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ session: 'stale-probe', backend: 'external-herdr' }),
+  });
+  const body = await res.json().catch(() => null);
+  return { status: res.status, body };
+})()`, true);
+check(
+  'closing a stale (socket gone) external session returns ok already_stopped',
+  staleApi.status === 200
+    && !!(staleApi.body && staleApi.body.ok)
+    && staleApi.body.already_stopped === true,
+  `status=${staleApi.status} body=${JSON.stringify(staleApi.body)}`,
+);
+
+// UI check: target the stale row through the real picker, press its Close
+// button (the real closeCurrentSession path), and the manager must show the
+// clean already-stopped message. The follow-up refresh must not overwrite
+// it with the offline manager (the app retargets the server's default
+// backend after closing).
+const staleUi = await cdp.evalExpr(`(async () => {
+  document.getElementById('footerSessionButton').click();
+  await new Promise((r) => setTimeout(r, 900));
+  const rows = [...document.querySelectorAll('#sessionList .session-line')];
+  const row = rows.find((r) => /stale-probe/.test(r.textContent));
+  if (!row) return { found: false };
+  row.click();
+  await new Promise((r) => setTimeout(r, 1500));
+  const buttons = [...document.querySelectorAll('#sessionList .session-button.danger')];
+  const closeBtn = buttons.find((b) => /Close/.test(b.textContent));
+  if (!closeBtn) return { found: true, closeBtn: false };
+  window.confirm = () => true;
+  closeBtn.click();
+  await new Promise((r) => setTimeout(r, 1200));
+  const m = document.getElementById('sessionManager');
+  return {
+    found: true,
+    closeBtn: true,
+    visible: m && getComputedStyle(m).display !== 'none',
+    title: document.getElementById('sessionManagerTitle').textContent,
+    text: document.getElementById('sessionManagerText').textContent,
+    stored: localStorage.getItem('herdr-session-backend'),
+  };
+})()`, true);
+check(
+  'closing a stale session via the UI shows the clean already-stopped message',
+  staleUi.found === true
+    && staleUi.closeBtn === true
+    && staleUi.visible === true
+    && staleUi.title === 'Session closed'
+    && /not running/.test(staleUi.text || ''),
+  `found=${staleUi.found} title="${staleUi.title}" text="${staleUi.text}" stored=${staleUi.stored}`,
+);
+// Return to the built-in session so later checks run on the default backend.
+await cdp.evalExpr(`(async () => {
+  const rows = [...document.querySelectorAll('#sessionList .session-line')];
+  const row = rows.find((r) => /backend-builtin/.test(r.className) && !/stale-probe/.test(r.textContent));
+  if (row) row.click();
+  await new Promise((r) => setTimeout(r, 1200));
+  return true;
+})()`, true);
 
 // ---------- Mobile layout ----------
 // The mobile bundle loads its script chain after navigation; poll for the

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -2091,6 +2091,87 @@ describe("app bundle load", () => {
     });
   });
 
+  it("treats closing a stale (not running) session as success with already_stopped", async () => {
+    const ctx = context();
+    const calls = [];
+    ctx.fetch = async (url, opt = {}) => {
+      calls.push({ url, opt });
+      if (url === "/api/session/close") {
+        // The backend died without removing its row: the server reports
+        // ok + already_stopped instead of a 502 ENOENT error.
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, already_stopped: true }),
+        };
+      }
+      if (url === "/api/versions") {
+        // The server's configured default backend, used to retarget after
+        // closing the current session.
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            webui: "test",
+            current_backend: "builtin",
+            default_backend: "builtin",
+            herdr_install: { available: false, compatible: false },
+          }),
+        };
+      }
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            current_backend: "builtin",
+            herdr_available: false,
+            herdr_compatible: false,
+            sessions: [
+              { name: "default", backend: "builtin", backend_label: "built-in", running: false },
+            ],
+          }),
+        };
+      }
+      // refresh() runs synchronously via the harness setTimeout after the
+      // close; give it the canonical empty-workspaces shape so it completes
+      // instead of auto-opening the manager over our assertion state.
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ result: { workspaces: [] } }),
+      };
+    };
+    vm.runInContext(source, ctx);
+
+    await ctx.closeCurrentSession();
+    // closeCurrentSession fires showSessionManager without awaiting it;
+    // flush pending microtasks before asserting on the manager text.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const closeCall = calls.find((call) => call.url === "/api/session/close");
+    ok(closeCall, "closeCurrentSession must call /api/session/close");
+    deepEqual(JSON.parse(closeCall.opt.body), {
+      session: "default",
+      backend: "builtin",
+    });
+    equal(
+      ctx.document.getElementById("sessionManagerTitle").textContent,
+      "Session closed",
+    );
+    match(
+      ctx.document.getElementById("sessionManagerText").textContent,
+      /not running/,
+    );
+    // Closing must retarget the server's default backend so the next
+    // refresh cannot hit the just-closed session's dead socket and
+    // re-open the offline manager over the clean close message.
+    equal(
+      ctx.localStorage.getItem("herdr-session-backend"),
+      "builtin",
+    );
+  });
+
   it("hides the external Herdr offer when no compatible herdr install is detected", async () => {
     const ctx = context();
     ctx.fetch = async (url) => {
@@ -2249,7 +2330,16 @@ describe("app bundle load", () => {
     await ctx.refresh();
     equal(manager.style.display, "block");
 
+    // A user-opened manager is not overwritten by a later auto-open: the
+    // failed-refresh path must keep the message the user is reading.
+    fail = true;
+    await ctx.refresh();
+    equal(manager.style.display, "block");
+    equal(ctx.document.getElementById("sessionManagerTitle").textContent, "Session manager");
+    fail = false;
+
     // An auto-opened manager is hidden again by a successful refresh.
+    await ctx.hideSessionManager();
     await ctx.showSessionManager("Session manager", undefined, { auto: true });
     await ctx.refresh();
     equal(manager.style.display, "none");

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -2637,7 +2637,22 @@ function renderSessionRows() {
 // (as opposed to opened by the user). Background refreshes only auto-hide
 // an auto-opened manager; a user-opened one stays visible.
 let sessionManagerAutoOpened = false;
+// True when the session manager is showing a user-triggered message (the
+// user opened it, or a flow like close/launch just set its text). Auto-opened
+// offline managers must not overwrite those.
+function managerShownForUser() {
+  const manager = el("sessionManager");
+  // Inline "block" means the app showed it (CSS keeps it hidden otherwise);
+  // the initial inline value is "" while the manager is closed.
+  if (!manager) return false;
+  if (manager.style.display !== "block") return false;
+  return !sessionManagerAutoOpened;
+}
 async function showSessionManager(title, text, { auto = false } = {}) {
+  // An auto-opened manager must never overwrite a message the user is
+  // reading (e.g. the "Session closed" confirmation right after closing a
+  // session while the closed backend's refresh is still failing).
+  if (auto && managerShownForUser()) return;
   await loadSessions();
   const titleEl = el("sessionManagerTitle"),
     textEl = el("sessionManagerText"),
@@ -2752,15 +2767,32 @@ async function closeCurrentSession() {
   if (!confirm(`Close current ${sessionBackendLabel(currentSessionBackend())} session?`)) return;
   showBlocking("Closing session...");
   try {
-    await api("/api/session/close", {
+    const result = await api("/api/session/close", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ session: state.session || "default", backend: currentSessionBackend() }),
     });
-    showSessionManager(
-      "Session closed",
-      "Session stopped. You can launch it again.",
-    );
+    // A stale row (backend died without a live socket) closes cleanly too:
+    // the server reports already_stopped so the UI can dismiss it.
+    if (result && result.already_stopped) {
+      showSessionManager(
+        "Session closed",
+        "That session was not running; its stale entry was cleared. You can launch it again.",
+      );
+    } else {
+      showSessionManager(
+        "Session closed",
+        "Session stopped. You can launch it again.",
+      );
+    }
+    // The browser no longer has a live backend to talk to: the just-closed
+    // session is gone (a stale socket would only return ENOENT errors on the
+    // next refresh). Retarget the server's configured default backend so the
+    // delayed refresh() below lands on a working session (the server
+    // auto-starts the built-in backend on demand) instead of re-opening the
+    // offline manager and overwriting the clean close message above.
+    state.sessionBackend = state.serverDefaultBackend || "builtin";
+    localStorage.setItem("herdr-session-backend", state.sessionBackend);
     setTimeout(refresh, 800);
   } catch (e) {
     showSessionManager("Close failed", e.message || String(e));
@@ -2957,6 +2989,9 @@ async function loadVersions() {
         localStorage.setItem("herdr-session-backend", state.sessionBackend);
       }
     }
+    // Remember the server's configured default backend so a closed session
+    // can retarget to it (see closeCurrentSession).
+    state.serverDefaultBackend = v.default_backend || v.current_backend || null;
     if (currentSessionBackend() === "external-herdr" && !state.herdrCompatible) {
       state.sessionBackend = "builtin";
       localStorage.setItem("herdr-session-backend", "builtin");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2795,13 +2795,21 @@ async fn proxy_server_stop(api: ApiClient) -> Response {
     match tokio::task::spawn_blocking(move || api.request_value(request)).await {
         Ok(Ok(value)) => Json(value).into_response(),
         Ok(Err(err)) => {
+            // The backend may have died without removing its socket file
+            // (crash, kill -9). Removing a stale session row must still
+            // count as success: there is nothing left to stop. LocalStream
+            // connect surfaces a missing socket path as ENOENT ("No such
+            // file or directory").
+            let is_missing_socket = err.contains("No such file or directory");
             let is_connection_drop = err.contains("empty response")
                 || err.contains("UnexpectedEof")
                 || err.contains("ConnectionReset")
                 || err.contains("Connection reset")
                 || err.contains("broken pipe")
                 || err.contains("Broken pipe");
-            if is_connection_drop {
+            if is_missing_socket {
+                Json(json!({ "ok": true, "already_stopped": true })).into_response()
+            } else if is_connection_drop {
                 Json(json!({ "ok": true })).into_response()
             } else {
                 (StatusCode::BAD_GATEWAY, Json(json!({ "error": err }))).into_response()
@@ -7571,8 +7579,9 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn close_session_returns_bad_gateway_on_real_error() {
-        // Point to a socket path that doesn't exist, so the connection itself fails.
+    async fn close_session_returns_ok_and_already_stopped_on_missing_socket() {
+        // A stale session row: the backend died and its socket file is gone.
+        // Close must succeed so the UI can dismiss the row, not 502.
         let mut state = test_state();
         state.api_socket = Some(PathBuf::from("/tmp/nonexistent-herdr-test-socket.sock"));
         let app = test_app_with_state(state);
@@ -7590,7 +7599,127 @@ mod tests {
             .await
             .unwrap();
 
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["already_stopped"], true);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn close_session_builtin_with_missing_socket_reports_already_stopped() {
+        // Same stale-row class for the built-in backend: the session
+        // directory reports a session that no longer has a live socket
+        // (crashed child). Closing it must be ok + already_stopped, and the
+        // registry entry must be dropped.
+        let _guard = lock_env();
+        let config_home = std::env::temp_dir().join(format!(
+            "herdr-webui-builtin-stale-close-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        std::env::set_var("XDG_CONFIG_HOME", &config_home);
+        let session_name = "gone-builtin";
+        // Registry entries hold live handles; a real (throwaway) handle keeps
+        // the map shape honest. Its sockets live in /tmp and are never the ones
+        // close_session contacts (that path comes from XDG_CONFIG_HOME), so the
+        // proxy sees ENOENT, the stale-row case under test.
+        let stale_handle = Arc::new(
+            builtin_backend::BuiltinBackendHandle::start(builtin_backend::BuiltinBackendConfig {
+                api_socket: std::env::temp_dir().join(format!(
+                    "herdr-webui-stale-close-api-{}.sock",
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_nanos(),
+                )),
+                client_socket: std::env::temp_dir().join(format!(
+                    "herdr-webui-stale-close-client-{}.sock",
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_nanos(),
+                )),
+                cwd: std::env::temp_dir(),
+                shell: None,
+                jcode_detection_variant: JcodeDetectionVariant::Vanilla,
+            })
+            .unwrap(),
+        );
+        let mut state = test_state();
+        state.builtin_sessions = Arc::new(Mutex::new(HashMap::new()));
+        state
+            .builtin_sessions
+            .lock()
+            .unwrap()
+            .insert(session_name.to_string(), stale_handle);
+        let sessions_registry = state.builtin_sessions.clone();
+        let app = test_app_with_state(state);
+
+        let response = app
+            .oneshot(
+                request(Method::POST, "/api/session/close")
+                    .header(header::COOKIE, "herdr_web_session=token-123")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({ "session": session_name, "backend": "builtin" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["already_stopped"], true);
+        // close_session must also drop the registry entry so the stale
+        // session cannot linger in the built-in registry.
+        assert!(
+            !sessions_registry.lock().unwrap().contains_key(session_name),
+            "registry entry must be removed after closing a stale built-in session"
+        );
+        let _ = fs::remove_dir_all(config_home);
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn close_session_returns_bad_gateway_on_real_error() {
+        // A socket file that exists but refuses connections (not a stale
+        // ENOENT row) is a real failure and must surface as 502.
+        let path = std::env::temp_dir().join(format!(
+            "herdr-webui-test-refused-{}.sock",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        // A regular file is not a socket: connect fails with
+        // "Connection refused"/"Socket type not supported", not ENOENT.
+        fs::write(&path, b"").unwrap();
+
+        let mut state = test_state();
+        state.api_socket = Some(path.clone());
+        let app = test_app_with_state(state);
+
+        let response = app
+            .oneshot(
+                request(Method::POST, "/api/session/close")
+                    .header(header::COOKIE, "herdr_web_session=token-123")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({ "session": "default", "backend": "external-herdr" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
         assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let _ = fs::remove_file(path);
     }
 
     // ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Fixes closing a stale session (backend died without removing its socket file, e.g. crash or kill -9): it now succeeds instead of returning a 502 `No such file or directory (os error 2)` error.

## Server
- `proxy_server_stop`: a missing socket path (ENOENT) closes with `ok + already_stopped`; connection drops still close with `ok`; other errors still return 502.

## UI (desktop)
- `closeCurrentSession` distinguishes `already_stopped` and shows a clean "That session was not running; its stale entry was cleared" message.
- After a successful close the browser retargets the server's configured default backend, so the delayed refresh lands on a live session (built-in auto-starts on demand) instead of hitting the dead socket and re-opening the offline manager over the close message.
- An auto-opened session manager can no longer overwrite a user-facing manager message (guards any offline follow-up, including when the server default backend is external).

## Tests
- Rust: close_session suite covers external ENOENT, built-in missing socket (real BuiltinBackendHandle start + registry drop), and a real 502 on non-ENOENT errors.
- JS: 448/448 node tests pass, incl. new already_stopped branch, backend retarget, and auto-open guard tests.
- E2E: run-e2e.sh creates a stale session dir fixture; session-ux-acceptance.mjs verifies (1) API close returns `ok + already_stopped` and (2) the real UI close shows the clean message without the offline manager overwriting it. Full e2e green: 31/31 + 17/17.

Verified on the real acceptance path (isolated server on 8899 + headless Chrome over CDP) before folding the checks into the committed suite.