### PR TITLE
Gate sessions by server enabled_backends settings

### DIFF
--- a/scripts/e2e/session-ux-acceptance.mjs
+++ b/scripts/e2e/session-ux-acceptance.mjs
@@ -247,6 +247,127 @@ await cdp.evalExpr(`(async () => {
   return true;
 })()`, true);
 
+// ---------- Mid-session backend disable ----------
+// The core enabled_backends scenario: a tab pinned to external-herdr when
+// the operator disables that backend in settings must retarget live (footer,
+// localStorage) and stop offering it, without a page reload. The settings
+// save broadcasts server_settings_changed over the events socket; the open
+// tab adopts it via scheduleRefresh.
+const disabled = await cdp.evalExpr(`(async () => {
+  // Pin external-herdr through the real picker row.
+  document.getElementById('footerSessionButton').click();
+  await new Promise((r) => setTimeout(r, 800));
+  const rows = [...document.querySelectorAll('#sessionList .session-line')];
+  const herdrRow = rows.find((r) => /backend-herdr/.test(r.className));
+  if (!herdrRow) return { pinned: false };
+  herdrRow.click();
+  await new Promise((r) => setTimeout(r, 2000));
+  const storedPin = localStorage.getItem('herdr-session-backend');
+  if (storedPin !== 'external-herdr') return { pinned: false, storedPin };
+  // Disable external-herdr via the settings API (loopback no-auth server).
+  // Preserve every other field (read current settings first) so the save
+  // does not trigger a listener rebind and works under any E2E_PORT.
+  const current = await (await fetch('/api/server-settings')).json().catch(() => null);
+  if (!current) return { pinned: true, savedOk: false, reason: 'settings GET failed' };
+  const res = await fetch('/api/server-settings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      bind: current.bind,
+      username: current.username || null,
+      password: null,
+      localhost_no_auth: !!current.localhost_no_auth,
+      backend_mode: current.backend_mode,
+      builtin_shell: current.builtin_shell || null,
+      default_folder: current.default_folder || null,
+      no_sleep_auto_cooldown_seconds: current.no_sleep_auto_cooldown_seconds,
+      builtin_backend_enabled: current.builtin_backend_enabled !== false,
+      external_herdr_backend_enabled: false,
+    }),
+  });
+  const saved = await res.json().catch(() => null);
+  // Give the events socket + scheduleRefresh time to apply the broadcast.
+  await new Promise((r) => setTimeout(r, 2500));
+  const button = document.getElementById('footerSessionButton');
+  return {
+    pinned: true,
+    savedOk: res.status === 200 && !!(saved && saved.enabled_backends
+      && saved.enabled_backends['external-herdr'] === false),
+    stored: localStorage.getItem('herdr-session-backend'),
+    footerText: button ? button.textContent : '',
+    footerClass: button ? button.className : '',
+  };
+})()`, true);
+check(
+  'disabling external-herdr mid-session retargets the pinned tab to built-in',
+  disabled.pinned === false || (
+    disabled.savedOk === true
+    && disabled.stored === 'builtin'
+    && /built-in/.test(disabled.footerText || '')
+    && /backend-builtin/.test(disabled.footerClass || '')
+  ),
+  disabled.pinned === false
+    ? `no external herdr row offered (install=${manager.herdrInstall && manager.herdrInstall.version}); skipped`
+    : `pinned=${disabled.pinned} savedOk=${disabled.savedOk} stored=${disabled.stored} footer="${disabled.footerText}" class="${disabled.footerClass}"`,
+);
+if (disabled.pinned === true) {
+// The session manager must hide (not merely disable) the Herdr offer while
+// the backend is disabled in settings.
+const disabledOffer = await cdp.evalExpr(`(async () => {
+  document.getElementById('footerSessionButton').click();
+  await new Promise((r) => setTimeout(r, 900));
+  const btn = document.getElementById('newHerdrSessionTarget');
+  return { hidden: btn ? btn.hidden : null, disabled: btn ? btn.disabled : null };
+})()`, true);
+check(
+  'session manager hides the Herdr offer while the backend is disabled',
+  disabledOffer.hidden === true,
+  `hidden=${disabledOffer.hidden} disabled=${disabledOffer.disabled}`,
+);
+// Launching the disabled backend through the API must fail with a clear
+// error instead of silently rerouting.
+const disabledLaunch = await cdp.evalExpr(`(async () => {
+  const res = await fetch('/api/session/launch', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-herdr-backend': 'external-herdr' },
+    body: JSON.stringify({ session: 'default', backend: 'external-herdr' }),
+  });
+  const body = await res.json().catch(() => null);
+  return { status: res.status, error: body && body.error };
+})()`, true);
+check(
+  'launching the disabled backend returns a clear settings error',
+  disabledLaunch.status === 400
+    && /disabled/.test(String(disabledLaunch.error || '')),
+  `status=${disabledLaunch.status} error="${disabledLaunch.error}"`,
+);
+// Restore: re-enable external-herdr so the run leaves a clean state and the
+// remaining checks (light theme) can switch backends. Same preserve-fields
+// approach: read current settings and flip only the flag.
+await cdp.evalExpr(`(async () => {
+  const current = await (await fetch('/api/server-settings')).json().catch(() => null);
+  if (!current) return -1;
+  const res = await fetch('/api/server-settings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      bind: current.bind,
+      username: current.username || null,
+      password: null,
+      localhost_no_auth: !!current.localhost_no_auth,
+      backend_mode: current.backend_mode,
+      builtin_shell: current.builtin_shell || null,
+      default_folder: current.default_folder || null,
+      no_sleep_auto_cooldown_seconds: current.no_sleep_auto_cooldown_seconds,
+      builtin_backend_enabled: current.builtin_backend_enabled !== false,
+      external_herdr_backend_enabled: true,
+    }),
+  });
+  await new Promise((r) => setTimeout(r, 2000));
+  return res.status;
+})()`, true);
+} // end mid-session disable scenario (requires a compatible herdr install)
+
 // ---------- Mobile layout ----------
 // The mobile bundle loads its script chain after navigation; poll for the
 // badge instead of fixed sleeps (fixed waits raced the bundle load and

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -2646,6 +2646,7 @@ async function loadSessions() {
         builtin: r.enabled_backends.builtin !== false,
         "external-herdr": r.enabled_backends["external-herdr"] !== false,
       };
+      if (r.default_backend) state.serverDefaultBackend = r.default_backend;
       syncSessionBackendFromServer();
     }
     // Do not clobber an explicit user backend choice: the server echoes the
@@ -2808,19 +2809,22 @@ async function handleHerdrErrorFrame(raw) {
     // the stale external pin. Say which backend failed (server-verified).
     const failedBackend = msg.backend || currentSessionBackend();
     const failedLabel = sessionBackendLabel(failedBackend);
-    const wantsBuiltin = await askQuestion({
-      title: `${failedLabel} backend not reachable`,
-      message:
-        `The ${failedLabel} backend could not be attached${detail}. ` +
-        (backendEnabled("builtin")
-          ? "It has been disconnected. Start a built-in session instead?"
-          : "It has been disconnected. Reopen the session manager to pick a target."),
-      confirmText: "Use built-in session",
-    });
+    const builtinUsable = backendEnabled("builtin");
+    const wantsBuiltin = builtinUsable
+      ? await askQuestion({
+          title: `${failedLabel} backend not reachable`,
+          message:
+            `The ${failedLabel} backend could not be attached${detail}. ` +
+            "It has been disconnected. Start a built-in session instead?",
+          confirmText: "Use built-in session",
+        })
+      : false;
     if (wantsBuiltin) {
       goSession(state.session || "default", "builtin");
       await launchBackend(state.session || "default", "builtin");
     } else {
+      // When built-in is disabled (or the user declined), reopen the manager
+      // so the user picks an enabled target instead of silently rerouting.
       showSessionManager(`${failedLabel} backend not reachable`, detail ? detail.trim() : undefined);
     }
   } finally {

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -2604,6 +2604,18 @@ function syncSessionBackendFromServer() {
   state.sessionBackend = fallback;
   localStorage.setItem("herdr-session-backend", fallback);
   updateFooterSessionButton();
+  // The events socket is bound to the disabled backend through its URL
+  // query (?backend=...). Cycle it so the reconnect targets the fallback
+  // backend; otherwise the tab keeps polling the dead backend's events
+  // (attach/subscribe failures on every reconnect) until a manual reload.
+  if (eventWs) {
+    eventWs.onclose = null;
+    try {
+      eventWs.close();
+    } catch (e) {}
+    eventWs = null;
+    setTimeout(connectEvents, 100);
+  }
 }
 async function newSessionTarget(backend) {
   if (backend === "external-herdr" && !backendEnabled("external-herdr")) {

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -47,6 +47,10 @@ let state = {
   herdrAvailable: false,
   herdrCompatible: false,
   herdrVersion: null,
+  // Backend enablement from the server's enabled_backends (settings). A
+  // long-lived tab may outlive a settings change that disabled a backend;
+  // null means "unknown yet" (older servers) and never gates anything.
+  backendsEnabled: { builtin: null, "external-herdr": null },
   defaultFolder: "",
   workspaceShell: {},
 };
@@ -2574,7 +2578,38 @@ function updateFooterSessionButton() {
 function currentSessionBackend() {
   return state.sessionBackend || state.backendMode || "builtin";
 }
+// True when the server settings allow the given backend. Unknown (null, from
+// an older server that omits enabled_backends) never disables anything.
+function backendEnabled(backend) {
+  const enabled = state.backendsEnabled && state.backendsEnabled[backend];
+  return enabled !== false;
+}
+// Re-validate the browser's pinned backend against the server's enabled
+// backends. A tab that pinned external-herdr before the setting was disabled
+// must retarget to the server's default instead of silently rerouting every
+// request (labels and offers would keep claiming Herdr while the server
+// actually serves built-in).
+function syncSessionBackendFromServer() {
+  if (!state.sessionBackend) return;
+  if (backendEnabled(state.sessionBackend)) return;
+  // Prefer the server's configured default when it is still enabled, then
+  // built-in, then whichever remains enabled (the server enforces at least
+  // one enabled backend, so a fallback always exists).
+  const fallback =
+    state.serverDefaultBackend && backendEnabled(state.serverDefaultBackend)
+      ? state.serverDefaultBackend
+      : backendEnabled("builtin")
+        ? "builtin"
+        : "external-herdr";
+  state.sessionBackend = fallback;
+  localStorage.setItem("herdr-session-backend", fallback);
+  updateFooterSessionButton();
+}
 async function newSessionTarget(backend) {
+  if (backend === "external-herdr" && !backendEnabled("external-herdr")) {
+    alert("External Herdr sessions are disabled in server settings.");
+    return;
+  }
   // External Herdr sessions are only offered when a compatible herdr
   // install was detected; the server gate rejects the launch otherwise.
   if (backend === "external-herdr" && !state.herdrCompatible) {
@@ -2587,7 +2622,8 @@ async function newSessionTarget(backend) {
   }
   const name = prompt(`${sessionBackendLabel(backend)} session name`);
   if (!name) return;
-  await launchBackend(name, backend);
+  const launched = await launchBackend(name, backend);
+  if (launched === false) return;
   goSession(name, backend);
 }
 async function loadSessions() {
@@ -2601,6 +2637,16 @@ async function loadSessions() {
       state.herdrAvailable = !!r.herdr_available;
       state.herdrCompatible = !!r.herdr_compatible;
       state.herdrVersion = r.herdr_version || null;
+    }
+    // The server's enabled_backends is authoritative: a tab open since
+    // before the setting changed must stop targeting/offering a backend
+    // that was disabled mid-session.
+    if (r.enabled_backends) {
+      state.backendsEnabled = {
+        builtin: r.enabled_backends.builtin !== false,
+        "external-herdr": r.enabled_backends["external-herdr"] !== false,
+      };
+      syncSessionBackendFromServer();
     }
     // Do not clobber an explicit user backend choice: the server echoes the
     // backend used for THIS request, so re-assigning it here can flip the
@@ -2617,7 +2663,7 @@ function renderSessionRows() {
     : [{ name: state.session || "default", backend: currentSessionBackend(), running: state.backendOnline }];
   return list
     .map((s) => {
-      const backend = s.backend || "external-herdr";
+      const backend = s.backend || (backendEnabled("external-herdr") ? "external-herdr" : "builtin");
       const active = s.name === state.session && backend === currentSessionBackend();
       const status = `<span class="status-pill ${s.running ? "running" : "offline"}">${s.running ? "running" : "offline"}</span>`;
       const backendPill = `<span class="status-pill ${sessionBackendClass(backend)}">${escapeHtml(s.backend_label || sessionBackendLabel(backend))}</span>`;
@@ -2671,15 +2717,20 @@ async function showSessionManager(title, text, { auto = false } = {}) {
   }
   if (list) list.innerHTML = renderSessionRows();
   // Hide (not disable) the external-Herdr offer when no compatible herdr
-  // install exists so the manager stays clean; built-in remains the default.
+  // install exists or the backend is disabled in settings so the manager
+  // stays clean; built-in remains the default.
   const herdrButton = el("newHerdrSessionTarget");
   if (herdrButton) {
-    herdrButton.hidden = !state.herdrCompatible;
-    if (state.herdrCompatible) {
+    const herdrUsable = state.herdrCompatible && backendEnabled("external-herdr");
+    herdrButton.hidden = !herdrUsable;
+    if (herdrUsable) {
       herdrButton.disabled = false;
       herdrButton.title = state.herdrVersion
         ? `Detected herdr ${state.herdrVersion}`
         : "Detected compatible herdr install";
+    } else if (!backendEnabled("external-herdr")) {
+      herdrButton.disabled = true;
+      herdrButton.title = "External Herdr sessions are disabled in server settings";
     } else if (state.herdrAvailable) {
       herdrButton.disabled = true;
       herdrButton.title = `Detected herdr ${state.herdrVersion || ""} is not compatible with this WebUI build; upgrade herdr or use a built-in session`;
@@ -2697,6 +2748,11 @@ function hideSessionManager() {
   if (manager) manager.style.display = "none";
 }
 async function launchBackend(session = state.session, backend = currentSessionBackend()) {
+  if (backend === "external-herdr" && !backendEnabled("external-herdr")) {
+    const textEl = el("sessionManagerText");
+    if (textEl) textEl.textContent = "External Herdr sessions are disabled in server settings";
+    return false;
+  }
   const textEl = el("sessionManagerText");
   if (textEl) textEl.textContent = `Launching ${sessionBackendLabel(backend)} session...`;
   showBlocking("Launching session...");
@@ -2713,8 +2769,10 @@ async function launchBackend(session = state.session, backend = currentSessionBa
           : `Launched ${sessionBackendLabel(backend)} session.`
         : r.error || "Launch failed";
     setTimeout(refresh, 1200);
+    return !!r.ok;
   } catch (e) {
     if (textEl) textEl.textContent = e.message || String(e);
+    return false;
   } finally {
     hideBlocking();
   }
@@ -2745,18 +2803,25 @@ async function handleHerdrErrorFrame(raw) {
       } catch (_) {}
     }
     const detail = msg.message ? ` (${msg.message})` : "";
+    // The server reroutes disabled backends to the remaining enabled one, so
+    // the frame may be about the backend actually serving this browser, not
+    // the stale external pin. Say which backend failed (server-verified).
+    const failedBackend = msg.backend || currentSessionBackend();
+    const failedLabel = sessionBackendLabel(failedBackend);
     const wantsBuiltin = await askQuestion({
-      title: "herdr backend not reachable",
+      title: `${failedLabel} backend not reachable`,
       message:
-        `The external herdr backend could not be attached${detail}. ` +
-        "It has been disconnected. Start a built-in session instead?",
+        `The ${failedLabel} backend could not be attached${detail}. ` +
+        (backendEnabled("builtin")
+          ? "It has been disconnected. Start a built-in session instead?"
+          : "It has been disconnected. Reopen the session manager to pick a target."),
       confirmText: "Use built-in session",
     });
     if (wantsBuiltin) {
       goSession(state.session || "default", "builtin");
       await launchBackend(state.session || "default", "builtin");
     } else {
-      showSessionManager("herdr backend not reachable", detail ? detail.trim() : undefined);
+      showSessionManager(`${failedLabel} backend not reachable`, detail ? detail.trim() : undefined);
     }
   } finally {
     herdrErrorOfferPending = false;
@@ -2892,6 +2957,15 @@ async function loadServerSettings() {
     el("optExternalHerdrBackendEnabled").checked = settings.external_herdr_backend_enabled !== false;
     el("optBuiltinShell").value = settings.builtin_shell || "";
     state.defaultFolder = settings.default_folder || state.defaultFolder || "";
+    // Settings responses carry enabled_backends; keep the browser pin in
+    // sync so the modal reflects what the server will actually serve.
+    if (settings.enabled_backends) {
+      state.backendsEnabled = {
+        builtin: settings.enabled_backends.builtin !== false,
+        "external-herdr": settings.enabled_backends["external-herdr"] !== false,
+      };
+      syncSessionBackendFromServer();
+    }
     el("optDefaultFolder").value = state.defaultFolder || "";
     syncGitWorkspaceToggle();
     syncFileWorkspaceToggle();
@@ -2947,6 +3021,13 @@ async function applyServerSettings() {
       }),
     });
     state.defaultFolder = updatedSettings.default_folder || state.defaultFolder || "";
+    if (updatedSettings.enabled_backends) {
+      state.backendsEnabled = {
+        builtin: updatedSettings.enabled_backends.builtin !== false,
+        "external-herdr": updatedSettings.enabled_backends["external-herdr"] !== false,
+      };
+    }
+    syncSessionBackendFromServer();
     el("optDefaultFolder").value = state.defaultFolder || "";
     if (err)
       err.textContent =
@@ -2992,6 +3073,16 @@ async function loadVersions() {
     // Remember the server's configured default backend so a closed session
     // can retarget to it (see closeCurrentSession).
     state.serverDefaultBackend = v.default_backend || v.current_backend || null;
+    // The server's enabled_backends is authoritative: a tab pinned before a
+    // backend was disabled mid-session must retarget instead of silently
+    // rerouting. Older servers omit the field; unknown never gates.
+    if (v.enabled_backends) {
+      state.backendsEnabled = {
+        builtin: v.enabled_backends.builtin !== false,
+        "external-herdr": v.enabled_backends["external-herdr"] !== false,
+      };
+    }
+    syncSessionBackendFromServer();
     if (currentSessionBackend() === "external-herdr" && !state.herdrCompatible) {
       state.sessionBackend = "builtin";
       localStorage.setItem("herdr-session-backend", "builtin");
@@ -3135,8 +3226,9 @@ function go(ws, tab, pane) {
 }
 function goSession(name, backend = currentSessionBackend()) {
   // Do not switch the browser to external herdr when no compatible install
-  // was detected; keep the built-in session instead.
-  if (backend === "external-herdr" && !state.herdrCompatible) backend = "builtin";
+  // was detected or the backend is disabled in settings; keep built-in.
+  if (backend === "external-herdr" && (!state.herdrCompatible || !backendEnabled("external-herdr")))
+    backend = "builtin";
   state.session = name || "default";
   state.sessionBackend = backend || "builtin";
   localStorage.setItem("herdr-session-backend", state.sessionBackend);

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -16,13 +16,16 @@ function connectEvents() {
     else if (msg.type === "server_settings_changed") {
       // Settings changed on the server (possibly another tab). Adopt the new
       // enabled_backends immediately so a disabled backend stops being
-      // targeted/offered without requiring a page reload.
+      // targeted/offered without requiring a page reload. The frame also
+      // carries the server's default backend so retargeting is accurate
+      // without waiting for the next /api/versions poll.
       const enabled = msg.enabled_backends;
       if (enabled) {
         state.backendsEnabled = {
           builtin: enabled.builtin !== false,
           "external-herdr": enabled["external-herdr"] !== false,
         };
+        if (msg.default_backend) state.serverDefaultBackend = msg.default_backend;
         syncSessionBackendFromServer();
       }
       scheduleRefresh();

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -13,6 +13,20 @@ function connectEvents() {
       return;
     }
     if (msg.type === "snapshot") applySnapshot(msg);
+    else if (msg.type === "server_settings_changed") {
+      // Settings changed on the server (possibly another tab). Adopt the new
+      // enabled_backends immediately so a disabled backend stops being
+      // targeted/offered without requiring a page reload.
+      const enabled = msg.enabled_backends;
+      if (enabled) {
+        state.backendsEnabled = {
+          builtin: enabled.builtin !== false,
+          "external-herdr": enabled["external-herdr"] !== false,
+        };
+        syncSessionBackendFromServer();
+      }
+      scheduleRefresh();
+    }
     else if (msg.type === "event") {
       const evt = msg.event || {},
         kind = evt.event || evt.type,

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -17,6 +17,10 @@
     // server's configured backend mode on first load.
     sessionBackend: localStorage.getItem("herdr-session-backend") || "builtin",
     serverBackendConfirmed: false,
+    // Backend enablement from the server's enabled_backends (settings). A
+    // long-lived tab may outlive a settings change that disabled a backend;
+    // null means "unknown yet" (older servers) and never gates anything.
+    backendsEnabled: { builtin: null, "external-herdr": null },
     workspaces: [],
     tabs: [],
     allTabs: [],
@@ -147,6 +151,16 @@
       const settings = await api("/api/server-settings");
       state.backendMode = settings.backend_mode || state.backendMode;
       state.defaultFolder = settings.default_folder || state.defaultFolder || "";
+      // The server's enabled_backends is authoritative: a tab pinned before
+      // a backend was disabled mid-session must retarget instead of
+      // silently rerouting. Older servers omit the field; unknown never gates.
+      if (settings.enabled_backends) {
+        state.backendsEnabled = {
+          builtin: settings.enabled_backends.builtin !== false,
+          "external-herdr": settings.enabled_backends["external-herdr"] !== false,
+        };
+        syncSessionBackendFromServer();
+      }
       // Built-in is the default backend. On first load adopt the server's
       // configured mode so stale localStorage cannot lock the browser into an
       // unexpected backend; afterwards keep the user's explicit choice.
@@ -169,6 +183,13 @@
       state.herdrAvailable = !!r.herdr_available;
       state.herdrCompatible = !!r.herdr_compatible;
       state.herdrVersion = r.herdr_version || null;
+      if (r.enabled_backends) {
+        state.backendsEnabled = {
+          builtin: r.enabled_backends.builtin !== false,
+          "external-herdr": r.enabled_backends["external-herdr"] !== false,
+        };
+        syncSessionBackendFromServer();
+      }
       if (currentSessionBackend() === "external-herdr" && !state.herdrCompatible) {
         state.sessionBackend = "builtin";
         localStorage.setItem("herdr-session-backend", "builtin");
@@ -222,8 +243,13 @@
           } catch (_) {}
         }
         const detail = msg.message ? ` (${msg.message})` : "";
+        // The server reroutes disabled backends to the remaining enabled one,
+        // so the frame may be about the backend actually serving this
+        // browser, not the stale external pin. Say which backend failed.
+        const failedBackend = msg.backend || currentSessionBackend();
+        const failedLabel = sessionBackendLabel(failedBackend);
         const wantsBuiltin = confirm(
-          `The external herdr backend could not be attached${detail}. ` +
+          `The ${failedLabel} backend could not be attached${detail}. ` +
             "It has been disconnected. Start a built-in session instead?",
         );
         if (wantsBuiltin) {
@@ -254,11 +280,39 @@
     if (state.backendMode === "builtin") return "builtin";
     return "";
   }
+  // True when the server settings allow the given backend. Unknown (null,
+  // from an older server that omits enabled_backends) never disables anything.
+  function backendEnabled(backend) {
+    const enabled = state.backendsEnabled && state.backendsEnabled[backend];
+    return enabled !== false;
+  }
+  // Re-validate the pinned backend against the server's enabled backends:
+  // a tab that pinned external-herdr before it was disabled must retarget
+  // instead of silently rerouting every request.
+  function syncSessionBackendFromServer() {
+    if (!state.sessionBackend) return;
+    if (!backendEnabled(state.sessionBackend)) {
+      state.sessionBackend = backendEnabled("builtin") ? "builtin" : state.sessionBackend;
+      if (!backendEnabled(state.sessionBackend)) return;
+      localStorage.setItem("herdr-session-backend", state.sessionBackend);
+    }
+  }
   function sessionBackendLabel(backend) {
     return backend === "external-herdr" ? "Herdr" : "built-in";
   }
   function sessionBackendClass(backend) {
     return backend === "external-herdr" ? "backend-herdr" : "backend-builtin";
+  }
+
+  function handleServerSettingsChanged(msg) {
+    const enabled = msg.enabled_backends;
+    if (!enabled) return;
+    state.backendsEnabled = {
+      builtin: enabled.builtin !== false,
+      "external-herdr": enabled["external-herdr"] !== false,
+    };
+    syncSessionBackendFromServer();
+    refresh();
   }
 
   function currentWorkspace() {
@@ -1454,6 +1508,9 @@
     ws.onmessage = (event) => {
       try {
         const msg = JSON.parse(event.data);
+        if (msg && msg.type === "server_settings_changed") {
+          handleServerSettingsChanged(msg);
+        }
         const evt = msg && msg.event;
         const kind = evt && (evt.event || evt.type);
         const data = (evt && evt.data) || {};

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -320,6 +320,17 @@
           : "external-herdr";
     state.sessionBackend = fallback;
     localStorage.setItem("herdr-session-backend", fallback);
+    // The events socket is bound to the disabled backend through its URL
+    // query (?backend=...). Cycle it so the reconnect targets the fallback
+    // backend instead of polling the dead one until a manual reload.
+    if (eventWs) {
+      eventWs.onclose = null;
+      try {
+        eventWs.close();
+      } catch (e) {}
+      eventWs = null;
+      scheduleEventReconnect();
+    }
   }
   function sessionBackendLabel(backend) {
     return backend === "external-herdr" ? "Herdr" : "built-in";

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -21,6 +21,9 @@
     // long-lived tab may outlive a settings change that disabled a backend;
     // null means "unknown yet" (older servers) and never gates anything.
     backendsEnabled: { builtin: null, "external-herdr": null },
+    // The server's configured default backend (settings-change broadcast);
+    // used to retarget when the pinned backend gets disabled.
+    serverDefaultBackend: null,
     workspaces: [],
     tabs: [],
     allTabs: [],
@@ -151,6 +154,14 @@
       const settings = await api("/api/server-settings");
       state.backendMode = settings.backend_mode || state.backendMode;
       state.defaultFolder = settings.default_folder || state.defaultFolder || "";
+      // The server's default backend derives from its configured mode and
+      // the enablement flags; record it before syncing so a disabled pin
+      // retargets accurately.
+      if (settings.backend_mode)
+        state.serverDefaultBackend =
+          settings.backend_mode === "external" || settings.backend_mode === "external-herdr"
+            ? "external-herdr"
+            : "builtin";
       // The server's enabled_backends is authoritative: a tab pinned before
       // a backend was disabled mid-session must retarget instead of
       // silently rerouting. Older servers omit the field; unknown never gates.
@@ -183,6 +194,7 @@
       state.herdrAvailable = !!r.herdr_available;
       state.herdrCompatible = !!r.herdr_compatible;
       state.herdrVersion = r.herdr_version || null;
+      if (r.default_backend) state.serverDefaultBackend = r.default_backend;
       if (r.enabled_backends) {
         state.backendsEnabled = {
           builtin: r.enabled_backends.builtin !== false,
@@ -243,15 +255,20 @@
           } catch (_) {}
         }
         const detail = msg.message ? ` (${msg.message})` : "";
-        // The server reroutes disabled backends to the remaining enabled one,
-        // so the frame may be about the backend actually serving this
+        // The server reroutes disabled backends to the remaining enabled
+        // one, so the frame may be about the backend actually serving this
         // browser, not the stale external pin. Say which backend failed.
         const failedBackend = msg.backend || currentSessionBackend();
         const failedLabel = sessionBackendLabel(failedBackend);
-        const wantsBuiltin = confirm(
-          `The ${failedLabel} backend could not be attached${detail}. ` +
-            "It has been disconnected. Start a built-in session instead?",
-        );
+        // Only offer built-in when the settings allow it; otherwise fall
+        // through to the manager so the user picks an enabled target
+        // instead of silently rerouting to a disabled backend.
+        const wantsBuiltin =
+          backendEnabled("builtin") &&
+          confirm(
+            `The ${failedLabel} backend could not be attached${detail}. ` +
+              "It has been disconnected. Start a built-in session instead?",
+          );
         if (wantsBuiltin) {
           try {
             await api("/api/session/launch", {
@@ -287,15 +304,22 @@
     return enabled !== false;
   }
   // Re-validate the pinned backend against the server's enabled backends:
-  // a tab that pinned external-herdr before it was disabled must retarget
-  // instead of silently rerouting every request.
+  // a tab that pinned a backend before it was disabled mid-session must
+  // retarget instead of silently rerouting every request. Prefer the
+  // server's default backend (from /api/versions or the settings-change
+  // broadcast) when still enabled, then built-in, then whichever remains
+  // enabled (the server enforces at least one enabled backend).
   function syncSessionBackendFromServer() {
     if (!state.sessionBackend) return;
-    if (!backendEnabled(state.sessionBackend)) {
-      state.sessionBackend = backendEnabled("builtin") ? "builtin" : state.sessionBackend;
-      if (!backendEnabled(state.sessionBackend)) return;
-      localStorage.setItem("herdr-session-backend", state.sessionBackend);
-    }
+    if (backendEnabled(state.sessionBackend)) return;
+    const fallback =
+      state.serverDefaultBackend && backendEnabled(state.serverDefaultBackend)
+        ? state.serverDefaultBackend
+        : backendEnabled("builtin")
+          ? "builtin"
+          : "external-herdr";
+    state.sessionBackend = fallback;
+    localStorage.setItem("herdr-session-backend", fallback);
   }
   function sessionBackendLabel(backend) {
     return backend === "external-herdr" ? "Herdr" : "built-in";
@@ -311,6 +335,7 @@
       builtin: enabled.builtin !== false,
       "external-herdr": enabled["external-herdr"] !== false,
     };
+    if (msg.default_backend) state.serverDefaultBackend = msg.default_backend;
     syncSessionBackendFromServer();
     refresh();
   }

--- a/src/git_ui/mod.rs
+++ b/src/git_ui/mod.rs
@@ -810,6 +810,7 @@ mod tests {
     fn test_state() -> WebState {
         let bind = "127.0.0.1:8787".parse::<SocketAddr>().unwrap();
         let (rebind_tx, _) = tokio::sync::watch::channel(bind);
+        let (settings_tx, _) = tokio::sync::broadcast::channel(16);
         WebState {
             api_socket: None,
             client_socket: None,
@@ -843,6 +844,7 @@ mod tests {
             })),
             no_sleep: Arc::new(Mutex::new(NoSleepState::default())),
             rebind_tx,
+            settings_tx,
             workspace_orders: Arc::new(Mutex::new(HashMap::new())),
             lsp: Arc::new(crate::lsp::LspRegistry::new(Default::default())),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -564,6 +564,10 @@ pub(crate) struct WebState {
     server_settings: Arc<Mutex<RuntimeServerSettings>>,
     no_sleep: Arc<Mutex<NoSleepState>>,
     rebind_tx: tokio::sync::watch::Sender<SocketAddr>,
+    /// Broadcasts the public settings JSON to every connected events socket
+    /// after a settings change, so open tabs re-sync backend enablement
+    /// without a page reload.
+    settings_tx: tokio::sync::broadcast::Sender<serde_json::Value>,
     workspace_orders: Arc<Mutex<HashMap<String, Vec<String>>>>,
     lsp: Arc<lsp::LspRegistry>,
 }
@@ -1115,6 +1119,7 @@ async fn main() -> io::Result<()> {
         server_settings.lock().unwrap().lsp.clone(),
     ));
     let (rebind_tx, rebind_rx) = tokio::sync::watch::channel(server_settings.lock().unwrap().bind);
+    let (settings_tx, _) = tokio::sync::broadcast::channel(16);
     let state = WebState {
         api_socket,
         client_socket,
@@ -1128,6 +1133,7 @@ async fn main() -> io::Result<()> {
         server_settings,
         no_sleep: Arc::new(Mutex::new(NoSleepState::default())),
         rebind_tx,
+        settings_tx,
         workspace_orders: Arc::new(Mutex::new(HashMap::new())),
         lsp: lsp_registry,
     };
@@ -2447,6 +2453,16 @@ async fn update_server_settings(
     if bind_changed {
         let _ = state.rebind_tx.send(next.bind);
     }
+    // Tell every connected events socket so long-lived tabs adopt the new
+    // enabled_backends immediately (a disabled backend stops being
+    // targeted/offered without a reload).
+    let _ = state.settings_tx.send(json!({
+        "type": "server_settings_changed",
+        "enabled_backends": {
+            "builtin": next.builtin_backend_enabled,
+            "external-herdr": next.external_herdr_backend_enabled,
+        },
+    }));
     Json(settings_public_json(&next)).into_response()
 }
 
@@ -2518,6 +2534,12 @@ async fn versions(
         "backend_mode": state.backend_mode.as_str(),
         "current_backend": current_backend.as_str(),
         "default_backend": default_backend.as_str(),
+        // Enabled flags so browsers can stop targeting/offering a backend
+        // that was disabled in settings mid-session.
+        "enabled_backends": {
+            "builtin": backend_target_enabled(&state, SessionBackendTarget::Builtin),
+            "external-herdr": backend_target_enabled(&state, SessionBackendTarget::ExternalHerdr),
+        },
         "session": session_display_name(session.as_deref()),
         "protocol_version": PROTOCOL_VERSION,
         "min_protocol_version": MIN_SUPPORTED_PROTOCOL_VERSION,
@@ -4265,6 +4287,9 @@ async fn events_ws(
 
 async fn events_socket(state: WebState, api: ApiClient, mut socket: WebSocket) {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<serde_json::Value>();
+    // Settings changes must reach open tabs immediately: a backend disabled
+    // mid-session stops being targeted/offered without a page reload.
+    let mut settings_rx = state.settings_tx.subscribe();
     let subscribe_api = api.clone();
     // backend_info() does a blocking ping over a Unix socket; run it on a
     // blocking thread so it does not stall the async runtime while waiting
@@ -4376,6 +4401,10 @@ async fn events_socket(state: WebState, api: ApiClient, mut socket: WebSocket) {
                 });
                 if socket.send(Message::Text(value.to_string().into())).await.is_err() { break; }
             }
+            settings = settings_rx.recv() => {
+                let Ok(settings) = settings else { break; };
+                if socket.send(Message::Text(settings.to_string().into())).await.is_err() { break; }
+            }
             _ = interval.tick(), if !use_builtin_event_hub => {
                 // request_value() does blocking socket I/O; offload it so the
                 // async runtime and other WebSocket loops are not stalled while
@@ -4457,6 +4486,10 @@ async fn terminal_ws(
         query.session.as_deref(),
         query.backend.as_deref(),
     );
+    // The resolved backend for the herdr_error frame: the server reroutes
+    // disabled/absent pins to the remaining enabled backend, so the browser
+    // must know which backend actually failed instead of blaming its stale pin.
+    let attach_backend = backend_target_for_query(&state, &headers, query.backend.as_deref());
     let api = api_for_query_session_ensured(
         &state,
         &headers,
@@ -4464,12 +4497,15 @@ async fn terminal_ws(
         query.backend.as_deref(),
     )
     .await;
-    ws.on_upgrade(move |socket| terminal_socket(client_socket_path, api, query, socket))
+    ws.on_upgrade(move |socket| {
+        terminal_socket(client_socket_path, api, attach_backend, query, socket)
+    })
 }
 
 async fn terminal_socket(
     path: PathBuf,
     api: ApiClient,
+    backend: SessionBackendTarget,
     query: TerminalQuery,
     mut socket: WebSocket,
 ) {
@@ -4531,6 +4567,7 @@ async fn terminal_socket(
                 if let Ok(error) = error {
                     let payload = json!({
                         "type": "herdr_error",
+                        "backend": backend.as_str(),
                         "kind": error.error_kind(),
                         "message": error.user_message().trim_end(),
                         "suggest_builtin": error.suggests_builtin(),
@@ -4768,6 +4805,7 @@ mod tests {
     fn test_state() -> WebState {
         let bind = DEFAULT_BIND.parse::<SocketAddr>().unwrap();
         let (rebind_tx, _) = tokio::sync::watch::channel(bind);
+        let (settings_tx, _) = tokio::sync::broadcast::channel(16);
         WebState {
             api_socket: Some(PathBuf::from("/tmp/default-api.sock")),
             client_socket: Some(PathBuf::from("/tmp/default-client.sock")),
@@ -4801,6 +4839,7 @@ mod tests {
             })),
             no_sleep: Arc::new(Mutex::new(NoSleepState::default())),
             rebind_tx,
+            settings_tx,
             workspace_orders: Arc::new(Mutex::new(HashMap::new())),
             lsp: Arc::new(lsp::LspRegistry::new(Default::default())),
         }
@@ -5773,6 +5812,71 @@ mod tests {
 
         let _ = fs::remove_dir_all(config_home);
         std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn versions_api_reports_enabled_backends_from_settings() {
+        let _guard = lock_env();
+        let config_home = std::env::temp_dir().join(format!(
+            "herdr-webui-versions-enabled-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("XDG_CONFIG_HOME", &config_home);
+
+        let mut state = test_state();
+        // Server has external-herdr disabled in settings: browsers must see
+        // enabled_backends so they stop targeting/offering it.
+        state
+            .server_settings
+            .lock()
+            .unwrap()
+            .external_herdr_backend_enabled = false;
+        state.backend_mode = BackendMode::Builtin;
+        let app = test_app_with_state(state);
+
+        let response = app
+            .oneshot(
+                authed_request(Method::GET, "/api/versions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["enabled_backends"]["builtin"], true);
+        assert_eq!(body["enabled_backends"]["external-herdr"], false);
+
+        let _ = fs::remove_dir_all(&config_home);
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
+    #[tokio::test]
+    async fn sessions_api_reports_enabled_backends_from_settings() {
+        let state = test_state();
+        state
+            .server_settings
+            .lock()
+            .unwrap()
+            .builtin_backend_enabled = false;
+        let app = test_app_with_state(state);
+
+        let response = app
+            .oneshot(
+                authed_request(Method::GET, "/api/sessions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["enabled_backends"]["builtin"], false);
+        assert_eq!(body["enabled_backends"]["external-herdr"], true);
     }
 
     #[tokio::test]
@@ -10579,6 +10683,107 @@ mod tests {
         std::env::remove_var("XDG_CONFIG_HOME");
     }
 
+    /// The herdr_error frame must name the backend the server actually
+    /// resolved for the attach, not the browser's stale pin: when a tab
+    /// pins external-herdr after the setting was disabled, the server
+    /// reroutes to builtin and the frame says builtin.
+    #[cfg(unix)]
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn terminal_ws_herdr_error_reports_resolved_backend() {
+        use futures_util::StreamExt;
+        use tokio_tungstenite::connect_async;
+
+        let _guard = lock_env();
+        let config_home = std::env::temp_dir().join(format!(
+            "herdr-webui-terminal-backend-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("XDG_CONFIG_HOME", &config_home);
+
+        let mut state = test_state();
+        // External-herdr is disabled: a browser pinning it gets rerouted to
+        // the built-in backend. Block the built-in session start (directory
+        // at the api socket path makes bind fail, per the launch_session
+        // error-path test) so the attach fails with connect_failed.
+        state
+            .server_settings
+            .lock()
+            .unwrap()
+            .external_herdr_backend_enabled = false;
+        state.backend_mode = BackendMode::Builtin;
+        let (api_socket, client_socket) = builtin_socket_paths(None);
+        fs::create_dir_all(api_socket.parent().unwrap()).unwrap();
+        fs::create_dir_all(client_socket.parent().unwrap()).unwrap();
+        let _ = fs::remove_file(&api_socket);
+        fs::create_dir(&api_socket).unwrap();
+        let app = test_app_with_state(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_handle = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let url = format!("ws://{addr}/ws/terminal?terminal_id=t1&backend=external-herdr");
+        let request = tokio_tungstenite::tungstenite::http::Request::builder()
+            .uri(&url)
+            .header("cookie", "herdr_web_session=token-123")
+            .header("host", addr.to_string())
+            .header("connection", "Upgrade")
+            .header("upgrade", "websocket")
+            .header("sec-websocket-version", "13")
+            .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .body(())
+            .unwrap();
+        let (mut ws_stream, _response) = connect_async(request)
+            .await
+            .expect("Failed to connect to WebSocket");
+
+        let mut got_error_frame = false;
+        for _ in 0..30 {
+            let msg =
+                match tokio::time::timeout(std::time::Duration::from_secs(15), ws_stream.next())
+                    .await
+                {
+                    Ok(Some(Ok(m))) => m,
+                    _ => break,
+                };
+            // The attach failure is surfaced twice: the raw error text as a
+            // binary frame and the structured herdr_error JSON. Skip the
+            // binary frame; its ordering with the JSON frame is racy.
+            let Ok(text) = msg.to_text() else { continue };
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
+                continue;
+            };
+            if value["type"].as_str() == Some("herdr_error") {
+                // The resolved backend is builtin: the disabled external pin
+                // must not leak into the frame.
+                assert_eq!(value["backend"], "builtin");
+                assert_eq!(value["kind"], "connect_failed");
+                got_error_frame = true;
+                break;
+            }
+        }
+        assert!(
+            got_error_frame,
+            "herdr_error frame with resolved backend must reach the terminal socket"
+        );
+
+        server_handle.abort();
+        let _ = fs::remove_dir(&api_socket);
+        let _ = fs::remove_dir_all(&config_home);
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
     // ── events WebSocket upgrade test ──
     // The events_ws handler requires a proper WebSocket upgrade request.
     // Testing the full event loop requires a real WebSocket client and
@@ -11152,6 +11357,120 @@ mod tests {
         server_handle.abort();
     }
 
+    /// Saving server settings must broadcast `server_settings_changed` with
+    /// the new `enabled_backends` to every connected events socket, so open
+    /// tabs stop targeting/offering a backend disabled mid-session without
+    /// a page reload.
+    #[cfg(unix)]
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn events_socket_broadcasts_server_settings_changed() {
+        use futures_util::StreamExt;
+        use tokio_tungstenite::connect_async;
+
+        let _guard = lock_env();
+        let config_home = std::env::temp_dir().join(format!(
+            "herdr-webui-settings-broadcast-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("XDG_CONFIG_HOME", &config_home);
+
+        let (socket, _handle) = fake_api_socket_events_streaming();
+        let mut state = test_state();
+        state.api_socket = Some(socket.clone());
+        let state = Arc::new(state);
+        let app = test_app_with_state((*state).clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let server_handle = tokio::spawn(async move {
+            let _ = server_state;
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let url = format!("ws://{addr}/ws/events");
+        let ws_request = tokio_tungstenite::tungstenite::http::Request::builder()
+            .uri(&url)
+            .header("cookie", "herdr_web_session=token-123")
+            .header("host", addr.to_string())
+            .header("connection", "Upgrade")
+            .header("upgrade", "websocket")
+            .header("sec-websocket-version", "13")
+            .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .body(())
+            .unwrap();
+        let (mut ws_stream, _response) = connect_async(ws_request)
+            .await
+            .expect("Failed to connect to WebSocket");
+
+        // Wait for the events loop to subscribe before flipping settings.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        // Disable the external-herdr backend through the settings API. The app
+        // router clones the Arc-based WebState, so this POST shares the same
+        // settings_tx the events socket subscribed to.
+        let save = test_app_with_state((*state).clone())
+            .oneshot(
+                request(Method::POST, "/api/server-settings")
+                    .header(header::COOKIE, "herdr_web_session=token-123")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "bind": "127.0.0.1:8787",
+                            "username": "user",
+                            "password": "pass",
+                            "localhost_no_auth": true,
+                            "backend_mode": "builtin",
+                            "builtin_backend_enabled": true,
+                            "external_herdr_backend_enabled": false,
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(save.status(), StatusCode::OK);
+
+        // The events socket must receive the broadcast frame.
+        let mut got_settings_change = false;
+        for _ in 0..30 {
+            let msg =
+                match tokio::time::timeout(std::time::Duration::from_secs(15), ws_stream.next())
+                    .await
+                {
+                    Ok(Some(Ok(m))) => m,
+                    _ => break,
+                };
+            let text = msg.to_text().expect("expected text message");
+            let value: serde_json::Value = serde_json::from_str(text).expect("invalid json");
+            if value["type"].as_str() == Some("server_settings_changed") {
+                assert_eq!(value["enabled_backends"]["builtin"], true);
+                assert_eq!(value["enabled_backends"]["external-herdr"], false);
+                got_settings_change = true;
+                break;
+            }
+        }
+        assert!(
+            got_settings_change,
+            "server_settings_changed frame must reach the events socket"
+        );
+
+        server_handle.abort();
+        let _ = fs::remove_file(socket);
+        let _ = fs::remove_dir_all(&config_home);
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
     fn fake_api_socket_events_streaming() -> (PathBuf, thread::JoinHandle<()>) {
         use interprocess::local_socket::{prelude::*, GenericFilePath, ListenerOptions};
 
@@ -11332,6 +11651,7 @@ mod tui_parity_e2e_tests {
     fn localhost_no_auth_state(default_folder: PathBuf) -> WebState {
         let bind = DEFAULT_BIND.parse::<SocketAddr>().unwrap();
         let (rebind_tx, _) = tokio::sync::watch::channel(bind);
+        let (settings_tx, _) = tokio::sync::broadcast::channel(16);
         WebState {
             api_socket: Some(PathBuf::from("/tmp/default-api.sock")),
             client_socket: Some(PathBuf::from("/tmp/default-client.sock")),
@@ -11365,6 +11685,7 @@ mod tui_parity_e2e_tests {
             })),
             no_sleep: Arc::new(Mutex::new(NoSleepState::default())),
             rebind_tx,
+            settings_tx,
             workspace_orders: Arc::new(Mutex::new(HashMap::new())),
             lsp: Arc::new(LspRegistry::new(Default::default())),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4357,6 +4357,7 @@ async fn events_socket(state: WebState, api: ApiClient, mut socket: WebSocket) {
             match subscribe_api.subscribe(request.clone()) {
                 Ok(mut stream) => {
                     let _ = tx.send(json!({ "type": "ready" }));
+                    let subscribed_at = std::time::Instant::now();
                     loop {
                         match stream.next_value() {
                             Ok(Some(value)) => {
@@ -4373,6 +4374,13 @@ async fn events_socket(state: WebState, api: ApiClient, mut socket: WebSocket) {
                                 break;
                             }
                         }
+                    }
+                    // A stream that stayed healthy for a while proves the
+                    // backend was up; a quick subsequent failure is a flap,
+                    // not an outage, so reconnect fast instead of waiting
+                    // out a 30s backoff grown during the outage.
+                    if subscribed_at.elapsed() >= std::time::Duration::from_secs(10) {
+                        backoff_secs = 1;
                     }
                 }
                 Err(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4344,25 +4344,49 @@ async fn events_socket(state: WebState, api: ApiClient, mut socket: WebSocket) {
             "method": "events.subscribe",
             "params": { "subscriptions": subscriptions }
         });
-        let Ok(mut stream) = subscribe_api.subscribe(request) else {
-            let _ = tx
-                .send(json!({ "type": "error", "message": "failed to subscribe to Herdr events" }));
-            return;
-        };
-        let _ = tx.send(json!({ "type": "ready" }));
+        // The backend subscription can fail while the socket itself is fine
+        // (external herdr daemon died, backend restarting). The events socket
+        // also carries server-level frames (server_settings_changed, lsp
+        // diagnostics) that must NOT die with the backend: keep retrying the
+        // subscription with a backoff instead of dropping `tx`, which would
+        // close the whole WebSocket and make tabs miss one-shot settings
+        // broadcasts during the reconnect gap (they would stay pinned to a
+        // backend disabled in settings until the next manual refresh).
+        let mut backoff_secs = 1u64;
         loop {
-            match stream.next_value() {
-                Ok(Some(value)) => {
-                    if tx.send(json!({ "type": "event", "event": value })).is_err() {
-                        break;
+            match subscribe_api.subscribe(request.clone()) {
+                Ok(mut stream) => {
+                    let _ = tx.send(json!({ "type": "ready" }));
+                    loop {
+                        match stream.next_value() {
+                            Ok(Some(value)) => {
+                                if tx.send(json!({ "type": "event", "event": value })).is_err() {
+                                    return;
+                                }
+                            }
+                            Ok(None) => break,
+                            Err(err) => {
+                                let _ = tx.send(json!({
+                                    "type": "error",
+                                    "message": err.to_string()
+                                }));
+                                break;
+                            }
+                        }
                     }
                 }
-                Ok(None) => break,
-                Err(err) => {
-                    let _ = tx.send(json!({ "type": "error", "message": err.to_string() }));
-                    break;
+                Err(_) => {
+                    let _ = tx.send(
+                        json!({ "type": "error", "message": "failed to subscribe to Herdr events" }),
+                    );
                 }
             }
+            // The WebSocket consumer went away; stop retrying.
+            if tx.is_closed() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(backoff_secs));
+            backoff_secs = (backoff_secs * 2).min(30);
         }
     });
 
@@ -11497,6 +11521,139 @@ mod tests {
 
         server_handle.abort();
         let _ = fs::remove_file(socket);
+        let _ = fs::remove_dir_all(&config_home);
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
+    /// A tab pinned to external-herdr has its events socket bound to that
+    /// backend (`?backend=external-herdr`). When the external daemon is not
+    /// running, the backend subscription fails — but the socket ALSO carries
+    /// server-level frames (`server_settings_changed`). It must stay open and
+    /// keep retrying the subscription, otherwise the one-shot settings
+    /// broadcast lands in a reconnect gap and a tab stays pinned to a backend
+    /// disabled in settings (this exact regression was caught by the
+    /// session-ux e2e suite).
+    #[cfg(unix)]
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn events_socket_survives_backend_subscription_failure() {
+        use futures_util::StreamExt;
+        use tokio_tungstenite::connect_async;
+
+        let _guard = lock_env();
+        let config_home = std::env::temp_dir().join(format!(
+            "herdr-webui-events-dead-backend-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("XDG_CONFIG_HOME", &config_home);
+
+        let mut state = test_state();
+        // Point external-herdr at a socket path with NO listener: the
+        // events.subscribe request fails, like a dead external daemon.
+        state.api_socket = Some(std::env::temp_dir().join(format!(
+                "herdr-webui-dead-external-{}.sock",
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            )));
+        let state = Arc::new(state);
+        let app = test_app_with_state((*state).clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let server_handle = tokio::spawn(async move {
+            let _ = server_state;
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        // Bind the events socket to the dead external backend, as a pinned
+        // browser tab does.
+        let url = format!("ws://{addr}/ws/events?backend=external-herdr");
+        let ws_request = tokio_tungstenite::tungstenite::http::Request::builder()
+            .uri(&url)
+            .header("cookie", "herdr_web_session=token-123")
+            .header("host", addr.to_string())
+            .header("connection", "Upgrade")
+            .header("upgrade", "websocket")
+            .header("sec-websocket-version", "13")
+            .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .body(())
+            .unwrap();
+        let (mut ws_stream, _response) = connect_async(ws_request)
+            .await
+            .expect("Failed to connect to WebSocket");
+
+        // The subscription failure surfaces as an error frame, but the
+        // socket must stay open (no close frame).
+        let mut saw_error = false;
+        let mut saw_settings_change = false;
+        for _ in 0..10 {
+            let msg =
+                match tokio::time::timeout(std::time::Duration::from_secs(10), ws_stream.next())
+                    .await
+                {
+                    Ok(Some(Ok(m))) => m,
+                    Ok(None) => break, // socket closed by server = the bug
+                    Ok(Some(Err(_))) | Err(_) => break,
+                };
+            let text = msg.to_text().expect("expected text message");
+            let value: serde_json::Value = serde_json::from_str(text).expect("invalid json");
+            match value["type"].as_str() {
+                Some("error") => {
+                    saw_error = true;
+                    // Settings broadcast must still arrive while the socket
+                    // retries the subscription.
+                    let save = test_app_with_state((*state).clone())
+                        .oneshot(
+                            request(Method::POST, "/api/server-settings")
+                                .header(header::COOKIE, "herdr_web_session=token-123")
+                                .header(header::CONTENT_TYPE, "application/json")
+                                .body(Body::from(
+                                    json!({
+                                        "bind": "127.0.0.1:8787",
+                                        "username": "user",
+                                        "password": "pass",
+                                        "localhost_no_auth": true,
+                                        "backend_mode": "builtin",
+                                        "builtin_backend_enabled": true,
+                                        "external_herdr_backend_enabled": false,
+                                    })
+                                    .to_string(),
+                                ))
+                                .unwrap(),
+                        )
+                        .await
+                        .unwrap();
+                    assert_eq!(save.status(), StatusCode::OK);
+                }
+                Some("server_settings_changed") => {
+                    assert_eq!(value["enabled_backends"]["external-herdr"], false);
+                    saw_settings_change = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            saw_error,
+            "subscription failure must surface as an error frame"
+        );
+        assert!(
+            saw_settings_change,
+            "server_settings_changed must reach a tab whose backend subscription failed"
+        );
+
+        server_handle.abort();
         let _ = fs::remove_dir_all(&config_home);
         std::env::remove_var("XDG_CONFIG_HOME");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4518,22 +4518,29 @@ async fn terminal_socket(
     let terminal_id = query.terminal_id.clone();
     let cols = query.cols.unwrap_or(100).max(1);
     let rows = query.rows.unwrap_or(30).max(1);
-    let (out_tx, mut out_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+    let (out_tx, mut out_rx) = tokio::sync::mpsc::unbounded_channel::<TerminalEvent>();
     let (in_tx, in_rx) = std::sync::mpsc::channel::<ClientMessage>();
-    let (error_tx, error_rx) = tokio::sync::oneshot::channel::<TerminalAttachError>();
 
     std::thread::spawn(move || {
         let mut stream = match connect_terminal_attach(&path, &terminal_id, cols, rows) {
             Ok(stream) => stream,
             Err(error) => {
-                let _ = out_tx.send(error.user_message().into_bytes());
-                let _ = error_tx.send(error);
+                // Order matters: the raw text first, then the structured
+                // error, through ONE channel so the select loop can never
+                // observe the channel close before the error frame. (With a
+                // separate error channel, a closed out_rx could win the
+                // select race and the browser would never see the JSON
+                // frame offering a built-in session.)
+                let _ = out_tx.send(TerminalEvent::Bytes(error.user_message().into_bytes()));
+                let _ = out_tx.send(TerminalEvent::Error(error));
                 return;
             }
         };
 
         let Ok(mut writer) = stream.try_clone() else {
-            let _ = out_tx.send(b"failed to clone herdr terminal socket\r\n".to_vec());
+            let _ = out_tx.send(TerminalEvent::Bytes(
+                b"failed to clone herdr terminal socket\r\n".to_vec(),
+            ));
             return;
         };
         std::thread::spawn(move || {
@@ -4547,12 +4554,12 @@ async fn terminal_socket(
         loop {
             match read_message::<_, ServerMessage>(&mut stream, MAX_GRAPHICS_FRAME_SIZE) {
                 Ok(ServerMessage::Terminal(frame)) => {
-                    if out_tx.send(frame.bytes).is_err() {
+                    if out_tx.send(TerminalEvent::Bytes(frame.bytes)).is_err() {
                         break;
                     }
                 }
                 Ok(ServerMessage::Graphics { bytes }) => {
-                    if out_tx.send(bytes).is_err() {
+                    if out_tx.send(TerminalEvent::Bytes(bytes)).is_err() {
                         break;
                     }
                 }
@@ -4563,30 +4570,34 @@ async fn terminal_socket(
         }
     });
 
-    let mut error_rx = error_rx;
     loop {
         tokio::select! {
-            error = &mut error_rx => {
-                // Graceful degradation: surface the handshake failure as a
-                // structured frame before closing, so the browser can offer
-                // a built-in session instead of blocking on a dead terminal.
-                if let Ok(error) = error {
-                    let payload = json!({
-                        "type": "herdr_error",
-                        "backend": backend.as_str(),
-                        "kind": error.error_kind(),
-                        "message": error.user_message().trim_end(),
-                        "suggest_builtin": error.suggests_builtin(),
-                    });
-                    if let Ok(text) = serde_json::to_string(&payload) {
-                        let _ = socket.send(Message::Text(text.into())).await;
-                    }
-                }
-                break;
-            }
             message = out_rx.recv() => {
-                let Some(bytes) = message else { break; };
-                if socket.send(Message::Binary(bytes.into())).await.is_err() { break; }
+                match message {
+                    // Graceful degradation: surface the handshake failure as
+                    // a structured frame before closing, so the browser can
+                    // offer a built-in session instead of blocking on a dead
+                    // terminal. Delivered through the same channel as the raw
+                    // bytes and after them, so ordering is guaranteed: the
+                    // channel close can never race ahead of the error frame.
+                    Some(TerminalEvent::Error(error)) => {
+                        let payload = json!({
+                            "type": "herdr_error",
+                            "backend": backend.as_str(),
+                            "kind": error.error_kind(),
+                            "message": error.user_message().trim_end(),
+                            "suggest_builtin": error.suggests_builtin(),
+                        });
+                        if let Ok(text) = serde_json::to_string(&payload) {
+                            let _ = socket.send(Message::Text(text.into())).await;
+                        }
+                        break;
+                    }
+                    Some(TerminalEvent::Bytes(bytes)) => {
+                        if socket.send(Message::Binary(bytes.into())).await.is_err() { break; }
+                    }
+                    None => break,
+                }
             }
             message = socket.recv() => {
                 match message {
@@ -4715,7 +4726,15 @@ fn terminal_text_messages(text: &str) -> Vec<ClientMessage> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Events from the terminal reader thread to the WS select loop, through one
+/// ordered channel. Ordering is load-bearing: the raw failure text must be
+/// delivered before the structured error so the browser always receives the
+/// `herdr_error` JSON frame (a closed channel can never race ahead of it).
+enum TerminalEvent {
+    Bytes(Vec<u8>),
+    Error(TerminalAttachError),
+}
+
 enum TerminalAttachError {
     Connect,
     SendHandshake,
@@ -10766,8 +10785,8 @@ mod tests {
                     _ => break,
                 };
             // The attach failure is surfaced twice: the raw error text as a
-            // binary frame and the structured herdr_error JSON. Skip the
-            // binary frame; its ordering with the JSON frame is racy.
+            // binary frame, then the structured herdr_error JSON. Both travel
+            // one ordered channel, so the JSON always follows the raw text.
             let Ok(text) = msg.to_text() else { continue };
             let Ok(value) = serde_json::from_str::<serde_json::Value>(text) else {
                 continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2455,13 +2455,16 @@ async fn update_server_settings(
     }
     // Tell every connected events socket so long-lived tabs adopt the new
     // enabled_backends immediately (a disabled backend stops being
-    // targeted/offered without a reload).
+    // targeted/offered without a reload). Include the server's configured
+    // default backend so tabs can retarget accurately without waiting for
+    // the next /api/versions poll (loadVersions only runs at boot).
     let _ = state.settings_tx.send(json!({
         "type": "server_settings_changed",
         "enabled_backends": {
             "builtin": next.builtin_backend_enabled,
             "external-herdr": next.external_herdr_backend_enabled,
         },
+        "default_backend": default_backend_target(&state).as_str(),
     }));
     Json(settings_public_json(&next)).into_response()
 }
@@ -2482,6 +2485,9 @@ async fn sessions(
     Json(json!({
         "backend_mode": state.backend_mode.as_str(),
         "current_backend": backend_target_for_headers(&state, &headers).as_str(),
+        // The server's configured default backend (used by tabs to retarget
+        // when their pinned backend gets disabled in settings).
+        "default_backend": default_backend_target(&state).as_str(),
         "enabled_backends": {
             "builtin": backend_target_enabled(&state, SessionBackendTarget::Builtin),
             "external-herdr": backend_target_enabled(&state, SessionBackendTarget::ExternalHerdr),
@@ -5877,6 +5883,8 @@ mod tests {
         let body = response_json(response).await;
         assert_eq!(body["enabled_backends"]["builtin"], false);
         assert_eq!(body["enabled_backends"]["external-herdr"], true);
+        // Default backend flips to the remaining enabled one.
+        assert_eq!(body["default_backend"], "external-herdr");
     }
 
     #[tokio::test]
@@ -11456,6 +11464,9 @@ mod tests {
             if value["type"].as_str() == Some("server_settings_changed") {
                 assert_eq!(value["enabled_backends"]["builtin"], true);
                 assert_eq!(value["enabled_backends"]["external-herdr"], false);
+                // The frame carries the server's default backend so tabs
+                // retarget accurately without a /api/versions poll.
+                assert_eq!(value["default_backend"], "builtin");
                 got_settings_change = true;
                 break;
             }


### PR DESCRIPTION
## Summary

The browser must stop targeting/offering backends (builtin vs external-herdr) that are disabled in the server's settings, and retarget cleanly instead of silently rerouting.

- **`5e64455` Gate sessions by server enabled_backends settings**: `/api/versions`, `/api/sessions`, `/api/server-settings` and the `server_settings_changed` broadcast carry `enabled_backends` + `default_backend`. Launching a disabled backend returns a clear 400. Both UIs validate their pinned backend against the server. Unit tests cover the API payloads, the WS `herdr_error` resolved backend, and the settings broadcast.
- **`d459ca2` Harden disabled-backend retargeting across UIs**: mobile `syncSessionBackendFromServer` gets desktop's three-way fallback (server default -> builtin -> remaining enabled); `serverDefaultBackend` stays fresh after mid-session settings changes; `herdr_error` offers can no longer pin a disabled builtin.
- **`cd8a6ac` Guarantee herdr_error frame delivery on terminal attach failure**: one ordered `TerminalEvent` channel (bytes then error) replaces the old separate-channel race that could close the socket before the structured frame was sent. Caught in CI.
- **`bb355b7` Keep events socket alive through backend subscription failures** (caught by the new e2e scenario): a tab pinned to a dead external backend had its events socket closed on subscribe failure, so the one-shot settings broadcast landed in a reconnect gap and the tab stayed pinned to the disabled backend. Server now retries `events.subscribe` with backoff while the socket stays open for server-level frames; both UIs cycle the events socket after a retarget. Regression test negative-checked.
- **`9fb1f3c` Reset events subscription backoff after a stable stream**: a stream healthy >= 10s proves the backend was up, so a subsequent failure reconnects fast instead of waiting out a 30s backoff.

## Testing

- 513 Rust tests, 448 JS tests, `cargo fmt` clean, clippy at baseline.
- Real-browser e2e: 31/31 acceptance + 20/20 session-ux, including the new mid-session disable scenario (pin -> disable via settings API -> live retarget of footer/localStorage -> manager hides the offer -> launch rejection -> restore).
- New Rust regression test `events_socket_survives_backend_subscription_failure` proven to fail against the pre-fix behavior.