### PR TITLE
Add applied confirmation feedback to settings across layouts

### DIFF
--- a/scripts/e2e/session-ux-acceptance.mjs
+++ b/scripts/e2e/session-ux-acceptance.mjs
@@ -10,6 +10,8 @@
 //     the UI keeps the clean close message (no offline auto-open overwrite)
 //   - mobile layout renders the backend badge with matching colors
 //   - light (latte) theme renders the backend colors with its own palette
+//   - settings changes flash a green ✓ Applied badge on the changed row that
+//     clears itself, and server settings show a green saved vs red error state
 import { connectToPage } from './cdp-driver.mjs';
 
 const URL = process.env.E2E_BASE_URL || 'https://127.0.0.1:8899/';
@@ -520,6 +522,118 @@ check(
 await cdp.evalExpr(`(async () => {
   localStorage.setItem('herdr-web-theme', 'auto');
   localStorage.removeItem('herdr-web-layout');
+  return true;
+})()`, true);
+
+// ---------- Settings applied feedback ----------
+// Desktop settings: a real click on a checkbox triggers saveOptions() and must
+// flash a green ✓ Applied badge next to the changed row, then clear itself.
+await cdp.evalExpr(`(async () => {
+  localStorage.removeItem('herdr-web-options');
+  location.reload();
+  return true;
+})()`, true);
+await new Promise((r) => setTimeout(r, 2500));
+const appliedBadge = await cdp.evalExpr(`(async () => {
+  document.getElementById('settingsToggle').click();
+  await new Promise((r) => setTimeout(r, 500));
+  const box = document.getElementById('optShowTabActivity');
+  const before = box.checked;
+  box.click();
+  await new Promise((r) => setTimeout(r, 300));
+  const row = box.closest('.option');
+  const badge = row ? row.querySelector('.settings-applied') : null;
+  const styles = badge ? getComputedStyle(badge) : null;
+  return {
+    changed: box.checked !== before,
+    badgeText: badge ? badge.textContent : '',
+    badgeState: badge ? badge.dataset.state : '',
+    badgeColor: styles ? styles.color : '',
+    saved: JSON.parse(localStorage.getItem('herdr-web-options') || '{}').showTabActivity,
+  };
+})()`, true);
+check(
+  'settings checkbox change flashes green ✓ Applied badge',
+  appliedBadge.changed === true
+    && /Applied/.test(appliedBadge.badgeText || '')
+    && appliedBadge.badgeState === 'settings-applied-ok'
+    && /a6e3a1|40, 224, 122|46, 213, 117/.test(appliedBadge.badgeColor || ''),
+  `text="${appliedBadge.badgeText}" state=${appliedBadge.badgeState} color=${appliedBadge.badgeColor} saved=${appliedBadge.saved}`,
+);
+check(
+  'applied badge reflects the persisted option value',
+  appliedBadge.saved === true,
+  `showTabActivity=${appliedBadge.saved}`,
+);
+const badgeCleared = await cdp.evalExpr(`(async () => {
+  await new Promise((r) => setTimeout(r, 3000));
+  const box = document.getElementById('optShowTabActivity');
+  if (box) box.click(); // restore default
+  await new Promise((r) => setTimeout(r, 300));
+  const badge = document.querySelector('#settingsModal .settings-applied');
+  return badge === null || badge === undefined || badge.isConnected === false;
+})()`, true);
+check(
+  'applied badge clears itself after the timeout',
+  badgeCleared === true,
+  '',
+);
+
+// Server settings: Apply succeeds on loopback no-auth and turns the status line
+// green; a validation error (public bind without credentials) stays red.
+const serverSaved = await cdp.evalExpr(`(async () => {
+  const apply = document.getElementById('serverSettingsApply');
+  apply.click();
+  await new Promise((r) => setTimeout(r, 1500));
+  const err = document.getElementById('serverSettingsError');
+  const styles = err ? getComputedStyle(err) : null;
+  return {
+    text: err ? err.textContent : '',
+    savedClass: err ? err.classList.contains('saved') : false,
+    color: styles ? styles.color : '',
+  };
+})()`, true);
+check(
+  'server settings Apply shows green saved state',
+  /Saved/.test(serverSaved.text || '')
+    && serverSaved.savedClass === true
+    && /a6e3a1|40, 224, 122|46, 213, 117/.test(serverSaved.color || ''),
+  `text="${serverSaved.text}" saved=${serverSaved.savedClass} color=${serverSaved.color}`,
+);
+const serverError = await cdp.evalExpr(`(async () => {
+  const bind = document.getElementById('optServerBind');
+  const user = document.getElementById('optServerUser');
+  const pass = document.getElementById('optServerPassword');
+  bind.value = '0.0.0.0:8787';
+  user.value = '';
+  pass.value = '';
+  const stored = JSON.parse(localStorage.getItem('herdr-web-options') || '{}');
+  document.getElementById('serverSettingsApply').click();
+  await new Promise((r) => setTimeout(r, 700));
+  const err = document.getElementById('serverSettingsError');
+  const styles = err ? getComputedStyle(err) : null;
+  // Restore the loopback bind for subsequent checks.
+  bind.value = '127.0.0.1:8787';
+  document.getElementById('serverSettingsApply').click();
+  await new Promise((r) => setTimeout(r, 1200));
+  return {
+    text: err ? err.textContent : '',
+    savedClass: err ? err.classList.contains('saved') : false,
+    color: styles ? styles.color : '',
+  };
+})()`, true);
+check(
+  'server settings validation error stays red without saved state',
+  /required/.test(serverError.text || '')
+    && serverError.savedClass === false
+    && /243, 139, 168|f38ba8/.test(serverError.color || ''),
+  `text="${serverError.text}" saved=${serverError.savedClass} color=${serverError.color}`,
+);
+
+// Close the settings modal and restore a clean state.
+await cdp.evalExpr(`(async () => {
+  document.getElementById('settingsClose').click();
+  localStorage.removeItem('herdr-web-options');
   return true;
 })()`, true);
 

--- a/scripts/e2e/session-ux-acceptance.mjs
+++ b/scripts/e2e/session-ux-acceptance.mjs
@@ -526,58 +526,81 @@ await cdp.evalExpr(`(async () => {
 })()`, true);
 
 // ---------- Settings applied feedback ----------
-// Desktop settings: a real click on a checkbox triggers saveOptions() and must
-// flash a green ✓ Applied badge next to the changed row, then clear itself.
+// Desktop settings: a real mouse click on a checkbox (via CDP Input domain,
+// so the control actually gets focus, like a user click) triggers
+// saveOptions() and must flash a green ✓ Applied badge next to the changed
+// row, then clear itself.
+const GREEN = 'rgb\\(166, 227, 161\\)|rgb\\(15, 98, 16\\)'; // dark + light --git-added-color
 await cdp.evalExpr(`(async () => {
   localStorage.removeItem('herdr-web-options');
   location.reload();
   return true;
 })()`, true);
 await new Promise((r) => setTimeout(r, 2500));
-const appliedBadge = await cdp.evalExpr(`(async () => {
+await cdp.evalExpr(`(async () => {
   document.getElementById('settingsToggle').click();
   await new Promise((r) => setTimeout(r, 500));
   const box = document.getElementById('optShowTabActivity');
-  const before = box.checked;
-  box.click();
-  await new Promise((r) => setTimeout(r, 300));
-  const row = box.closest('.option');
-  const badge = row ? row.querySelector('.settings-applied') : null;
-  const styles = badge ? getComputedStyle(badge) : null;
+  box.scrollIntoView({ block: 'center' });
+  await new Promise((r) => setTimeout(r, 200));
+  const rect = box.getBoundingClientRect();
+  const visible = rect.width > 0 && rect.height > 0;
+  const inModal = box.closest('#settingsModal') !== null || document.body.contains(box);
   return {
-    changed: box.checked !== before,
-    badgeText: badge ? badge.textContent : '',
-    badgeState: badge ? badge.dataset.state : '',
-    badgeColor: styles ? styles.color : '',
-    saved: JSON.parse(localStorage.getItem('herdr-web-options') || '{}').showTabActivity,
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+    before: box.checked,
+    visible,
+    inModal,
+    modalOpen: getComputedStyle(document.getElementById('settingsModal')).display !== 'none',
   };
-})()`, true);
-check(
-  'settings checkbox change flashes green ✓ Applied badge',
-  appliedBadge.changed === true
-    && /Applied/.test(appliedBadge.badgeText || '')
-    && appliedBadge.badgeState === 'settings-applied-ok'
-    && /a6e3a1|40, 224, 122|46, 213, 117/.test(appliedBadge.badgeColor || ''),
-  `text="${appliedBadge.badgeText}" state=${appliedBadge.badgeState} color=${appliedBadge.badgeColor} saved=${appliedBadge.saved}`,
-);
-check(
-  'applied badge reflects the persisted option value',
-  appliedBadge.saved === true,
-  `showTabActivity=${appliedBadge.saved}`,
-);
-const badgeCleared = await cdp.evalExpr(`(async () => {
-  await new Promise((r) => setTimeout(r, 3000));
-  const box = document.getElementById('optShowTabActivity');
-  if (box) box.click(); // restore default
-  await new Promise((r) => setTimeout(r, 300));
-  const badge = document.querySelector('#settingsModal .settings-applied');
-  return badge === null || badge === undefined || badge.isConnected === false;
-})()`, true);
-check(
-  'applied badge clears itself after the timeout',
-  badgeCleared === true,
-  '',
-);
+})()`, true).then(async (pos) => {
+  check(
+    'settings modal opened and target row visible for the badge checks',
+    pos.modalOpen === true && pos.visible === true,
+    `modalOpen=${pos.modalOpen} visible=${pos.visible}`,
+  );
+  await cdp.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x: pos.x, y: pos.y });
+  await cdp.send('Input.dispatchMouseEvent', { type: 'mousePressed', x: pos.x, y: pos.y, button: 'left', clickCount: 1 });
+  await cdp.send('Input.dispatchMouseEvent', { type: 'mouseReleased', x: pos.x, y: pos.y, button: 'left', clickCount: 1 });
+  await new Promise((r) => setTimeout(r, 400));
+  const appliedBadge = await cdp.evalExpr(`(async () => {
+    const box = document.getElementById('optShowTabActivity');
+    const row = box.closest('.option');
+    const badge = row ? row.querySelector('.settings-applied') : null;
+    const styles = badge ? getComputedStyle(badge) : null;
+    return {
+      changed: box.checked !== ${JSON.stringify(false)},
+      badgeText: badge ? badge.textContent : '',
+      badgeState: badge ? badge.dataset.state : '',
+      badgeColor: styles ? styles.color : '',
+      saved: JSON.parse(localStorage.getItem('herdr-web-options') || '{}').showTabActivity,
+    };
+  })()`, true);
+  check(
+    'settings checkbox change flashes green ✓ Applied badge',
+    appliedBadge.changed === true
+      && /Applied/.test(appliedBadge.badgeText || '')
+      && appliedBadge.badgeState === 'settings-applied-ok'
+      && new RegExp(GREEN).test(appliedBadge.badgeColor || ''),
+    `text="${appliedBadge.badgeText}" state=${appliedBadge.badgeState} color=${appliedBadge.badgeColor}`,
+  );
+  check(
+    'applied badge reflects the persisted option value',
+    appliedBadge.saved === true,
+    `showTabActivity=${appliedBadge.saved}`,
+  );
+  const badgeCleared = await cdp.evalExpr(`(async () => {
+    await new Promise((r) => setTimeout(r, 3000));
+    const badge = document.querySelector('#settingsModal .settings-applied');
+    return badge === null || badge === undefined || badge.isConnected === false;
+  })()`, true);
+  check(
+    'applied badge clears itself after the timeout',
+    badgeCleared === true,
+    '',
+  );
+});
 
 // Server settings: Apply succeeds on loopback no-auth and turns the status line
 // green; a validation error (public bind without credentials) stays red.
@@ -597,7 +620,7 @@ check(
   'server settings Apply shows green saved state',
   /Saved/.test(serverSaved.text || '')
     && serverSaved.savedClass === true
-    && /a6e3a1|40, 224, 122|46, 213, 117/.test(serverSaved.color || ''),
+    && new RegExp(GREEN).test(serverSaved.color || ''),
   `text="${serverSaved.text}" saved=${serverSaved.savedClass} color=${serverSaved.color}`,
 );
 const serverError = await cdp.evalExpr(`(async () => {
@@ -607,20 +630,20 @@ const serverError = await cdp.evalExpr(`(async () => {
   bind.value = '0.0.0.0:8787';
   user.value = '';
   pass.value = '';
-  const stored = JSON.parse(localStorage.getItem('herdr-web-options') || '{}');
   document.getElementById('serverSettingsApply').click();
   await new Promise((r) => setTimeout(r, 700));
   const err = document.getElementById('serverSettingsError');
   const styles = err ? getComputedStyle(err) : null;
-  // Restore the loopback bind for subsequent checks.
-  bind.value = '127.0.0.1:8787';
-  document.getElementById('serverSettingsApply').click();
-  await new Promise((r) => setTimeout(r, 1200));
-  return {
+  const result = {
     text: err ? err.textContent : '',
     savedClass: err ? err.classList.contains('saved') : false,
     color: styles ? styles.color : '',
   };
+  // Restore the loopback bind for subsequent checks.
+  bind.value = '127.0.0.1:8787';
+  document.getElementById('serverSettingsApply').click();
+  await new Promise((r) => setTimeout(r, 1200));
+  return result;
 })()`, true);
 check(
   'server settings validation error stays red without saved state',

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -19,6 +19,7 @@ const SHARED_FILE_TREE_JS: &str = include_str!("assets/shared/file_tree.js");
 const SHARED_FILE_CONTENT_SEARCH_JS: &str = include_str!("assets/shared/file_content_search.js");
 const SHARED_LINE_CONTEXT_JS: &str = include_str!("assets/shared/line_context.js");
 const SHARED_WORKSPACE_SEARCH_JS: &str = include_str!("assets/shared/workspace_search.js");
+const SHARED_SETTINGS_FEEDBACK_JS: &str = include_str!("assets/shared/settings_feedback.js");
 const SHARED_EDITOR_JS: &str = include_str!("assets/shared/editor.js");
 const SHARED_LSP_JS: &str = include_str!("assets/shared/lsp.js");
 const SHARED_MARKDOWN_PREVIEW_JS: &str = include_str!("assets/shared/markdown_preview.js");
@@ -203,6 +204,13 @@ pub(crate) async fn shared_line_context_js() -> Response {
 pub(crate) async fn shared_workspace_search_js() -> Response {
     static_text(
         SHARED_WORKSPACE_SEARCH_JS,
+        "application/javascript; charset=utf-8",
+    )
+}
+
+pub(crate) async fn shared_settings_feedback_js() -> Response {
+    static_text(
+        SHARED_SETTINGS_FEEDBACK_JS,
         "application/javascript; charset=utf-8",
     )
 }

--- a/src/assets/app_boot.js
+++ b/src/assets/app_boot.js
@@ -75,6 +75,7 @@
       "/assets/shared/line-context.js",
       "/assets/shared/file-content-search.js",
       "/assets/shared/workspace-search.js",
+      "/assets/shared/settings-feedback.js",
       "/assets/vendor/codemirror.js",
       "/assets/vendor/wterm.js",
       "/assets/shared/markdown-preview.js",

--- a/src/assets/app_boot.test.mjs
+++ b/src/assets/app_boot.test.mjs
@@ -26,6 +26,7 @@ const SHARED_SCRIPTS = [
   "/assets/shared/line-context.js",
   "/assets/shared/file-content-search.js",
   "/assets/shared/workspace-search.js",
+  "/assets/shared/settings-feedback.js",
   "/assets/vendor/codemirror.js",
   "/assets/vendor/wterm.js",
   "/assets/shared/markdown-preview.js",

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -3372,6 +3372,126 @@ describe("app bundle load", () => {
     equal(ctx.serverSettingsValidationError("127.0.0.1:8787", "", "", false), "");
   });
 
+  it("flashes a settings applied badge on saveOptions", async () => {
+    const ctx = context();
+    // The feedback module is a separate shared bundle file; load it like
+    // app_boot does so saveOptions() can reach it.
+    vm.runInContext(
+      readFileSync(new URL("./shared/settings_feedback.js", import.meta.url), "utf8"),
+      ctx,
+    );
+    vm.runInContext(source, ctx);
+
+    const control = ctx.document.getElementById("optFit");
+    control.classList = {
+      _set: new Set(),
+      add(...names) {
+        for (const name of names) this._set.add(name);
+      },
+      remove(...names) {
+        for (const name of names) this._set.delete(name);
+      },
+      contains(name) {
+        return this._set.has(name);
+      },
+      toggle() {},
+    };
+    control.children = [];
+    control.appendChild = (child) => {
+      child.parentNode = control;
+      control.children.push(child);
+      return child;
+    };
+    control.querySelector = (selector) =>
+      selector.includes("settings-applied") && control.children.length
+        ? control.children[control.children.length - 1]
+        : null;
+    control.closest = (selector) =>
+      selector === ".option" ? control : null;
+    ctx.document.activeElement = control;
+
+    await ctx.saveOptions();
+    ok(
+      control.children.some(
+        (child) => String(child.className) === "settings-applied",
+      ),
+      "green applied badge appended to the changed row",
+    );
+  });
+
+  it("marks server settings saved state green on success and red on failure", async () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    const err = ctx.document.getElementById("serverSettingsError");
+    const errClasses = new Set();
+    err.classList = {
+      add(name) {
+        errClasses.add(name);
+      },
+      remove(name) {
+        errClasses.delete(name);
+      },
+      contains(name) {
+        return errClasses.has(name);
+      },
+      toggle() {},
+    };
+    ctx.document.getElementById("optServerBind").value = "127.0.0.1:8787";
+    ctx.document.getElementById("optBackendMode").value = "builtin";
+
+    ctx.fetch = async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ bind: "127.0.0.1:8787", enabled_backends: {} }),
+    });
+    await ctx.applyServerSettings();
+    ok(errClasses.has("saved"), "success turns the status line green");
+    match(err.textContent, /Saved\./);
+
+    ctx.fetch = async () => {
+      throw Error("network down");
+    };
+    await ctx.applyServerSettings();
+    ok(!errClasses.has("saved"), "failure drops the saved state");
+    equal(err.textContent, "network down");
+  });
+
+  it("keeps server settings validation errors red without saved state", async () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    const err = ctx.document.getElementById("serverSettingsError");
+    const errClasses = new Set();
+    err.classList = {
+      add(name) {
+        errClasses.add(name);
+      },
+      remove(name) {
+        errClasses.delete(name);
+      },
+      contains(name) {
+        return errClasses.has(name);
+      },
+      toggle() {},
+    };
+    ctx.document.getElementById("optServerBind").value = "0.0.0.0:8787";
+    ctx.document.getElementById("optServerUser").value = "";
+    ctx.document.getElementById("optServerPassword").value = "";
+    ctx.document.getElementById("optServerPassword").dataset.hasPassword = "false";
+
+    let posted = false;
+    ctx.fetch = async () => {
+      posted = true;
+      return { ok: true, json: async () => ({}) };
+    };
+    await ctx.applyServerSettings();
+    ok(!posted, "invalid input never reaches the server");
+    ok(!errClasses.has("saved"));
+    match(err.textContent, /Username and password are required/);
+  });
+
   it("renders extracted worktree and shortcut modals", () => {
     const ctx = context();
     vm.runInContext(source, ctx);

--- a/src/assets/desktop/app_css/modals.css
+++ b/src/assets/desktop/app_css/modals.css
@@ -422,3 +422,41 @@
   font-size: 11px;
   margin-top: 2px;
 }
+
+/* Applied / error confirmation badges injected next to settings controls. */
+.settings-applied,
+.settings-error-flash {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  margin-left: auto;
+  padding: 3px 8px;
+  border-radius: 999px;
+  pointer-events: none;
+  white-space: nowrap;
+}
+.settings-applied {
+  color: var(--git-added-color);
+  border: 1px solid var(--git-added-color);
+}
+.settings-applied::before {
+  content: "✓";
+  font-weight: 800;
+}
+.settings-error-flash {
+  color: #f38ba8;
+  border: 1px solid #f38ba8;
+}
+/* Server settings save confirmation reuses the shared error slot, turned green. */
+.worktree-error.saved {
+  color: var(--git-added-color);
+  font-weight: 600;
+}
+.worktree-error.saved::before {
+  content: "✓ ";
+  font-weight: 800;
+}

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -105,6 +105,10 @@ el("shortcutsModal").addEventListener("click", (e) => {
 el("optTheme").onchange = () => {
   themeMode = normalizeThemeMode(el("optTheme").value);
   applyTheme();
+  // Theme mode persists via applyTheme() -> localStorage, not saveOptions,
+  // so it needs its own confirmation badge.
+  if (typeof flashSettingsApplied === "function")
+    flashSettingsApplied(el("optTheme"));
 };
 el("themeColorsApply").onclick = applyThemeColorsFromSettings;
 el("themeColorsReset").onclick = () => applyThemeColorProfile("default");

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -851,6 +851,7 @@ function recordShortcut(scope, action, button) {
     saveOptions();
     applyOptions();
     renderShortcutEditor();
+    flashShortcutRow(scope, action);
   };
   window.addEventListener("keydown", capture, { once: true, capture: true });
 }
@@ -860,6 +861,18 @@ function resetShortcut(scope, action) {
   saveOptions();
   applyOptions();
   renderShortcutEditor();
+  flashShortcutRow(scope, action);
+}
+// The shortcut editor rebuilds its own DOM on every save, so the generic
+// saveOptions() badge lands on the clicked button and is immediately wiped.
+// Flash the rebuilt row instead, keyed by its data attributes.
+function flashShortcutRow(scope, action) {
+  if (!settingsFeedback) return;
+  const button = document.querySelector(
+    `[data-shortcut-record="${scope}:${action}"]`,
+  );
+  const row = button && button.closest ? button.closest(".shortcut-row") : null;
+  if (row) settingsFeedback.flashAppliedRow(row);
 }
 function themeCustomizerHtml() {
   const rows = (mode) =>
@@ -1476,10 +1489,31 @@ function normalizeOptions(value) {
 let options = normalizeOptions(loadOptions());
 localStorage.removeItem("herdr-web-shiftenter-migrated");
 let workingDismissals = loadWorkingDismissals();
+// Green "Applied" confirmation badge for settings rows. Every local option
+// save goes through saveOptions(), so flashing there covers every binding
+// (checkboxes, selects, number inputs, module settings) without touching
+// each handler. Rows that persist through a dedicated Apply button (theme
+// colors) or that re-render their editor (shortcut editor) flash from their
+// own handlers instead.
+const settingsFeedback = window.HerdrSettingsFeedback
+  ? window.HerdrSettingsFeedback.create({ document, setTimeout, clearTimeout })
+  : null;
+function flashSettingsApplied(control, label) {
+  if (!settingsFeedback) return;
+  settingsFeedback.flashApplied(control, label);
+}
 function saveOptions() {
   options = normalizeOptions(options);
   if (window.HerdrOptions) window.HerdrOptions.write(options);
   else localStorage.setItem("herdr-web-options", JSON.stringify(options));
+  // The control that triggered this save is the focused element for change
+  // events; fall back to the row owning the last settings interaction so
+  // saves from buttons (theme profiles) still get their badge.
+  const control =
+    document.activeElement && document.activeElement.closest
+      ? document.activeElement
+      : null;
+  if (control) flashSettingsApplied(control);
 }
 function loadWorkingDismissals() {
   try {
@@ -2955,7 +2989,11 @@ async function api(url, opt) {
 }
 async function loadServerSettings() {
   const err = el("serverSettingsError");
-  if (err) err.textContent = "";
+  if (err) {
+    err.textContent = "";
+    err.classList.remove("saved");
+  }
+  const loadButton = el("serverSettingsLoad");
   try {
     const settings = await api("/api/server-settings");
     el("optServerBind").value = settings.bind || "127.0.0.1:8787";
@@ -2988,6 +3026,7 @@ async function loadServerSettings() {
     el("optNoSleepAutoCooldown").value = String(
       settings.no_sleep_auto_cooldown_seconds ?? 60,
     );
+    flashSettingsApplied(loadButton, "Loaded");
   } catch (ex) {
     if (err) err.textContent = ex.message || String(ex);
   }
@@ -3006,7 +3045,10 @@ async function applyServerSettings() {
     builtinShell = el("optBuiltinShell").value.trim(),
     defaultFolder = el("optDefaultFolder").value.trim(),
     noSleepAutoCooldown = Number(el("optNoSleepAutoCooldown").value || 60);
-  if (err) err.textContent = "";
+  if (err) {
+    err.textContent = "";
+    err.classList.remove("saved");
+  }
   const validationError = serverSettingsValidationError(
     bind,
     username,
@@ -3045,9 +3087,11 @@ async function applyServerSettings() {
     }
     syncSessionBackendFromServer();
     el("optDefaultFolder").value = state.defaultFolder || "";
-    if (err)
+    if (err) {
       err.textContent =
         "Saved. If Bind changed, listener is restarting. If Backend mode changed, restart WebUI, then reload this page.";
+      err.classList.add("saved");
+    }
     el("optServerPassword").value = "";
   } catch (ex) {
     if (err) err.textContent = ex.message || String(ex);

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -1728,3 +1728,23 @@ body.light .mobile-nav-status.working {
 .herdr-lsp-diagnostic.warning {
   color: var(--warning, #f9e2af);
 }
+
+/* Settings applied badge: emitted inline by the mobile settings renderer
+   after a value change survives the re-render. */
+.settings-applied {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  justify-self: start;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: var(--git-added-color);
+  border: 1px solid var(--git-added-color);
+}
+.settings-applied::before {
+  content: "✓";
+  font-weight: 800;
+}

--- a/src/assets/mobile/settings.js
+++ b/src/assets/mobile/settings.js
@@ -7,6 +7,36 @@
   }) {
     const normalizeOrder = globalThis.HerdrAppHelpers.normalizeOrder;
     let settingsFilter = "";
+    // Row id -> { label } for badges to emit on the next render. Setters run
+    // before HerdrMobile.refresh() re-renders the whole settings screen, so a
+    // badge appended to the live DOM would be wiped; instead render() bakes
+    // the badge into the row keyed by data-settings-id, and a timer clears it
+    // with one extra re-render.
+    const pendingAppliedFlash = new Map();
+    let appliedFlashTimer = null;
+    let pendingSearchOrderFlash = null;
+    const APPLIED_FLASH_MS = 2500;
+
+    function queueAppliedFlash(settingsId, label) {
+      if (!settingsId) return;
+      pendingAppliedFlash.set(String(settingsId), { label: label || "Applied" });
+      if (appliedFlashTimer) clearTimeout(appliedFlashTimer);
+      appliedFlashTimer = setTimeout(clearAppliedFlash, APPLIED_FLASH_MS);
+    }
+
+    function clearAppliedFlash() {
+      pendingAppliedFlash.clear();
+      appliedFlashTimer = null;
+      pendingSearchOrderFlash = null;
+      if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
+    }
+
+    function appliedFlashHtml(settingsId) {
+      if (!pendingAppliedFlash.size) return "";
+      const pending = pendingAppliedFlash.get(String(settingsId));
+      if (!pending) return "";
+      return `<span class="settings-applied" aria-live="polite" data-state="settings-applied-ok">✓ ${escapeHtml(pending.label)}</span>`;
+    }
 
     function render() {
       const layout = localStorage.getItem("herdr-web-layout") || "auto";
@@ -69,40 +99,40 @@
     }
 
     function appearanceSection(theme) {
-      return `<div class="mobile-settings-group"><h3>Appearance</h3><label><span>Theme</span><select onchange="HerdrMobile.setThemeMode(this.value)"><option value="auto" ${theme === "auto" ? "selected" : ""}>Auto</option><option value="dark" ${theme === "dark" ? "selected" : ""}>Dark</option><option value="light" ${theme === "light" ? "selected" : ""}>Light</option></select></label></div>`;
+      return `<div class="mobile-settings-group"><h3>Appearance</h3><label data-settings-id="theme">${appliedFlashHtml("theme")}<span>Theme</span><select onchange="HerdrMobile.setThemeMode(this.value)"><option value="auto" ${theme === "auto" ? "selected" : ""}>Auto</option><option value="dark" ${theme === "dark" ? "selected" : ""}>Dark</option><option value="light" ${theme === "light" ? "selected" : ""}>Light</option></select></label></div>`;
     }
 
     function layoutSection(layout) {
-      return `<div class="mobile-settings-group"><h3>Layout</h3><label><span>Layout mode</span><select onchange="HerdrMobile.setLayoutPreference(this.value)"><option value="auto" ${layout === "auto" ? "selected" : ""}>Auto</option><option value="mobile" ${layout === "mobile" ? "selected" : ""}>Mobile</option><option value="desktop" ${layout === "desktop" ? "selected" : ""}>Desktop</option></select><small>Auto uses viewport width, not user agent.</small></label></div>`;
+      return `<div class="mobile-settings-group"><h3>Layout</h3><label data-settings-id="layout">${appliedFlashHtml("layout")}<span>Layout mode</span><select onchange="HerdrMobile.setLayoutPreference(this.value)"><option value="auto" ${layout === "auto" ? "selected" : ""}>Auto</option><option value="mobile" ${layout === "mobile" ? "selected" : ""}>Mobile</option><option value="desktop" ${layout === "desktop" ? "selected" : ""}>Desktop</option></select><small>Auto uses viewport width, not user agent.</small></label></div>`;
     }
 
     function filesSection(depth, lineNumbers, headerSearch, searchOrder, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile, matchCase, regex) {
-      return `<div class="mobile-settings-group"><h3>Files and search</h3><label><span>Browser depth</span><input type="number" min="0" max="8" step="1" value="${depth}" onchange="HerdrMobile.setFileBrowserDepth(this.value)"></label><small>0 shows current folder only. 3 expands three folder levels.</small><label><input type="checkbox" ${lineNumbers ? "checked" : ""} onchange="HerdrMobile.setFileBrowserLineNumbers(this.checked)"><span>Line numbers</span><small>Show line numbers when previewing text files.</small></label><label><input type="checkbox" ${headerSearch ? "checked" : ""} onchange="HerdrMobile.setHeaderSearchEnabled(this.checked)"><span>Header search button</span><small>Show the search action and allow the palette to open.</small></label><div><span>Search section order</span>${renderSearchSectionOrder(searchOrder)}</div><small>Use arrows to move sections. Use Shown/Hidden to include or remove a section.</small><label><span>File/folder page size</span><input type="number" min="10" max="500" step="10" value="${pathSearchPageSize}" onchange="HerdrMobile.setFileBrowserSearchPageSize(this.value)"></label><label><span>Content minimum characters</span><input type="number" min="1" max="20" step="1" value="${minChars}" onchange="HerdrMobile.setFileContentSearchMinChars(this.value)"></label><label><span>Content page size</span><input type="number" min="10" max="500" step="10" value="${contentPageSize}" onchange="HerdrMobile.setFileContentSearchPageSize(this.value)"></label><label><span>Content context lines</span><input type="number" min="0" max="20" step="1" value="${contextLines}" onchange="HerdrMobile.setFileContentSearchContextLines(this.value)"></label><label><span>Content auto-collapse files</span><input type="number" min="0" max="200" step="1" value="${autoCollapse}" onchange="HerdrMobile.setFileContentSearchAutoCollapseFiles(this.value)"></label><label><input type="checkbox" ${defaultExpanded ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchDefaultExpanded(this.checked)"><span>Content results expanded by default</span><small>Expand each file group when content results load.</small></label><label><span>Content matches per file</span><input type="number" min="1" max="50" step="1" value="${matchesPerFile}" onchange="HerdrMobile.setFileContentSearchMatchesPerFile(this.value)"></label><label><input type="checkbox" ${matchCase ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchMatchCase(this.checked)"><span>Content search match case</span></label><label><input type="checkbox" ${regex ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchRegex(this.checked)"><span>Content search regex</span></label></div>`;
+      return `<div class="mobile-settings-group"><h3>Files and search</h3><label data-settings-id="fileBrowserDepth">${appliedFlashHtml("fileBrowserDepth")}<span>Browser depth</span><input type="number" min="0" max="8" step="1" value="${depth}" onchange="HerdrMobile.setFileBrowserDepth(this.value)"></label><small>0 shows current folder only. 3 expands three folder levels.</small><label data-settings-id="fileBrowserLineNumbers">${appliedFlashHtml("fileBrowserLineNumbers")}<input type="checkbox" ${lineNumbers ? "checked" : ""} onchange="HerdrMobile.setFileBrowserLineNumbers(this.checked)"><span>Line numbers</span><small>Show line numbers when previewing text files.</small></label><label data-settings-id="headerSearchEnabled">${appliedFlashHtml("headerSearchEnabled")}<input type="checkbox" ${headerSearch ? "checked" : ""} onchange="HerdrMobile.setHeaderSearchEnabled(this.checked)"><span>Header search button</span><small>Show the search action and allow the palette to open.</small></label><div><span>Search section order</span>${renderSearchSectionOrder(searchOrder, pendingSearchOrderFlash)}</div><small>Use arrows to move sections. Use Shown/Hidden to include or remove a section.</small><label data-settings-id="fileBrowserSearchPageSize">${appliedFlashHtml("fileBrowserSearchPageSize")}<span>File/folder page size</span><input type="number" min="10" max="500" step="10" value="${pathSearchPageSize}" onchange="HerdrMobile.setFileBrowserSearchPageSize(this.value)"></label><label data-settings-id="fileContentSearchMinChars">${appliedFlashHtml("fileContentSearchMinChars")}<span>Content minimum characters</span><input type="number" min="1" max="20" step="1" value="${minChars}" onchange="HerdrMobile.setFileContentSearchMinChars(this.value)"></label><label data-settings-id="fileContentSearchPageSize">${appliedFlashHtml("fileContentSearchPageSize")}<span>Content page size</span><input type="number" min="10" max="500" step="10" value="${contentPageSize}" onchange="HerdrMobile.setFileContentSearchPageSize(this.value)"></label><label data-settings-id="fileContentSearchContextLines">${appliedFlashHtml("fileContentSearchContextLines")}<span>Content context lines</span><input type="number" min="0" max="20" step="1" value="${contextLines}" onchange="HerdrMobile.setFileContentSearchContextLines(this.value)"></label><label data-settings-id="fileContentSearchAutoCollapseFiles">${appliedFlashHtml("fileContentSearchAutoCollapseFiles")}<span>Content auto-collapse files</span><input type="number" min="0" max="200" step="1" value="${autoCollapse}" onchange="HerdrMobile.setFileContentSearchAutoCollapseFiles(this.value)"></label><label data-settings-id="fileContentSearchDefaultExpanded">${appliedFlashHtml("fileContentSearchDefaultExpanded")}<input type="checkbox" ${defaultExpanded ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchDefaultExpanded(this.checked)"><span>Content results expanded by default</span><small>Expand each file group when content results load.</small></label><label data-settings-id="fileContentSearchMatchesPerFile">${appliedFlashHtml("fileContentSearchMatchesPerFile")}<span>Content matches per file</span><input type="number" min="1" max="50" step="1" value="${matchesPerFile}" onchange="HerdrMobile.setFileContentSearchMatchesPerFile(this.value)"></label><label data-settings-id="fileContentSearchMatchCase">${appliedFlashHtml("fileContentSearchMatchCase")}<input type="checkbox" ${matchCase ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchMatchCase(this.checked)"><span>Content search match case</span></label><label data-settings-id="fileContentSearchRegex">${appliedFlashHtml("fileContentSearchRegex")}<input type="checkbox" ${regex ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchRegex(this.checked)"><span>Content search regex</span></label></div>`;
     }
 
     function editorSection(enhanced, wordWrap, tabSize, lsp) {
-      return `<div class="mobile-settings-group"><h3>Editor</h3><label><input type="checkbox" ${enhanced ? "checked" : ""} onchange="HerdrMobile.setEditorEnabled(this.checked)"><span>Code editor enhancements</span><small>Enable CodeMirror editing enhancements. Files remain editable when this is disabled.</small></label><label><input type="checkbox" ${wordWrap ? "checked" : ""} onchange="HerdrMobile.setEditorWordWrap(this.checked)"><span>Editor word wrap</span></label><label><span>Editor tab size</span><input type="number" min="1" max="8" step="1" value="${tabSize}" onchange="HerdrMobile.setEditorTabSize(this.value)"></label><label><input type="checkbox" ${lsp ? "checked" : ""} onchange="HerdrMobile.setLspEnabled(this.checked)"><span>LSP diagnostics</span><small>Show language server diagnostics under the editor. Off by default.</small></label></div>`;
+      return `<div class="mobile-settings-group"><h3>Editor</h3><label data-settings-id="editorEnabled">${appliedFlashHtml("editorEnabled")}<input type="checkbox" ${enhanced ? "checked" : ""} onchange="HerdrMobile.setEditorEnabled(this.checked)"><span>Code editor enhancements</span><small>Enable CodeMirror editing enhancements. Files remain editable when this is disabled.</small></label><label data-settings-id="editorWordWrap">${appliedFlashHtml("editorWordWrap")}<input type="checkbox" ${wordWrap ? "checked" : ""} onchange="HerdrMobile.setEditorWordWrap(this.checked)"><span>Editor word wrap</span></label><label data-settings-id="editorTabSize">${appliedFlashHtml("editorTabSize")}<span>Editor tab size</span><input type="number" min="1" max="8" step="1" value="${tabSize}" onchange="HerdrMobile.setEditorTabSize(this.value)"></label><label data-settings-id="lspEnabled">${appliedFlashHtml("lspEnabled")}<input type="checkbox" ${lsp ? "checked" : ""} onchange="HerdrMobile.setLspEnabled(this.checked)"><span>LSP diagnostics</span><small>Show language server diagnostics under the editor. Off by default.</small></label></div>`;
     }
 
-    function renderSearchSectionOrder(value) {
+    function renderSearchSectionOrder(value, flashKey) {
       const labels = { workspaces: "Workspaces", files: "Files", content: "Content" };
       const order = normalizeSearchSectionOrder(value);
       return `<div class="mobile-actions mobile-search-order">${order.map((key, index) => {
         const enabled = searchSectionEnabled(key);
-        return `<span class="mobile-btn mobile-search-order-row"><strong>${escapeHtml(labels[key] || key)}</strong><button class="mobile-btn" ${index === 0 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',-1)">↑</button><button class="mobile-btn ${enabled ? "active" : ""}" onclick="HerdrMobile.toggleSearchSection('${key}')">${enabled ? "Shown" : "Hidden"}</button><button class="mobile-btn" ${index === order.length - 1 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',1)">↓</button></span>`;
+        return `<span class="mobile-btn mobile-search-order-row">${flashKey === key ? `<span class="settings-applied" aria-live="polite" data-state="settings-applied-ok">✓ Applied</span>` : ""}<strong>${escapeHtml(labels[key] || key)}</strong><button class="mobile-btn" ${index === 0 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',-1)">↑</button><button class="mobile-btn ${enabled ? "active" : ""}" onclick="HerdrMobile.toggleSearchSection('${key}')">${enabled ? "Shown" : "Hidden"}</button><button class="mobile-btn" ${index === order.length - 1 ? "disabled" : ""} onclick="HerdrMobile.moveSearchSection('${key}',1)">↓</button></span>`;
       }).join("")}</div>`;
     }
 
     function workspacesSection(worktreeDirectory, explorationDirectory) {
-      return `<div class="mobile-settings-group"><h3>Workspaces</h3><label><span>Worktree default directory</span><input placeholder="../worktrees" value="${escapeHtml(worktreeDirectory)}" onchange="HerdrMobile.setWorktreeDefaultDirectory(this.value)"></label><small>Base for generated worktree checkout paths.</small><label><span>Exploration default directory</span><input placeholder="~/Documents/code" value="${escapeHtml(explorationDirectory)}" onchange="HerdrMobile.setExplorationDefaultDirectory(this.value)"></label><small>Prefills worktree discovery paths.</small></div>`;
+      return `<div class="mobile-settings-group"><h3>Workspaces</h3><label data-settings-id="worktreeDefaultDirectory">${appliedFlashHtml("worktreeDefaultDirectory")}<span>Worktree default directory</span><input placeholder="../worktrees" value="${escapeHtml(worktreeDirectory)}" onchange="HerdrMobile.setWorktreeDefaultDirectory(this.value)"></label><small>Base for generated worktree checkout paths.</small><label data-settings-id="explorationDefaultDirectory">${appliedFlashHtml("explorationDefaultDirectory")}<span>Exploration default directory</span><input placeholder="~/Documents/code" value="${escapeHtml(explorationDirectory)}" onchange="HerdrMobile.setExplorationDefaultDirectory(this.value)"></label><small>Prefills worktree discovery paths.</small></div>`;
     }
 
     function alertsSection(notifications, volume) {
-      return `<div class="mobile-settings-group"><h3>Alerts</h3><label><input type="checkbox" ${notifications ? "checked" : ""} onchange="HerdrMobile.setBrowserNotifications(this.checked)"><span>Browser notifications</span><small>Show system notifications when an agent is blocked or done.</small></label><label><span>Notification volume (${volume}%)</span><input type="range" min="0" max="100" step="1" value="${volume}" onchange="HerdrMobile.setNotificationVolume(this.value)"></label><small>Controls the local attention tone volume.</small></div>`;
+      return `<div class="mobile-settings-group"><h3>Alerts</h3><label data-settings-id="browserNotifications">${appliedFlashHtml("browserNotifications")}<input type="checkbox" ${notifications ? "checked" : ""} onchange="HerdrMobile.setBrowserNotifications(this.checked)"><span>Browser notifications</span><small>Show system notifications when an agent is blocked or done.</small></label><label data-settings-id="notificationVolume">${appliedFlashHtml("notificationVolume")}<span>Notification volume (${volume}%)</span><input type="range" min="0" max="100" step="1" value="${volume}" onchange="HerdrMobile.setNotificationVolume(this.value)"></label><small>Controls the local attention tone volume.</small></div>`;
     }
 
     function terminalSection(font, core, links, mouseReporting) {
-      return `<div class="mobile-settings-group"><h3>Terminal</h3><label><span>Terminal renderer</span><select onchange="HerdrMobile.setTerminalCore(this.value)"><option value="wterm" ${core === "wterm" ? "selected" : ""}>wterm VT core</option><option value="ghostty" ${core === "ghostty" ? "selected" : ""}>Ghostty VT core</option></select></label><label><span>Terminal font</span><input placeholder="JetBrainsMono Nerd Font, monospace" value="${escapeHtml(font)}" onchange="HerdrMobile.setTerminalFontFamily(this.value)"></label><label><input type="checkbox" ${links ? "checked" : ""} onchange="HerdrMobile.setTerminalLinks(this.checked)"><span>Terminal links</span><small>Detect http/https URLs and open them when tapped.</small></label><label><input type="checkbox" ${mouseReporting ? "checked" : ""} onchange="HerdrMobile.setTerminalMouseReporting(this.checked)"><span>Terminal mouse reporting</span><small>Forward mouse input to terminal apps. Disabled by default; scrolling still works.</small></label><small>Add a Nerd Font family name so icon glyphs render. Leave blank for the default stack.</small></div>`;
+      return `<div class="mobile-settings-group"><h3>Terminal</h3><label data-settings-id="terminalCore">${appliedFlashHtml("terminalCore")}<span>Terminal renderer</span><select onchange="HerdrMobile.setTerminalCore(this.value)"><option value="wterm" ${core === "wterm" ? "selected" : ""}>wterm VT core</option><option value="ghostty" ${core === "ghostty" ? "selected" : ""}>Ghostty VT core</option></select></label><label data-settings-id="terminalFontFamily">${appliedFlashHtml("terminalFontFamily")}<span>Terminal font</span><input placeholder="JetBrainsMono Nerd Font, monospace" value="${escapeHtml(font)}" onchange="HerdrMobile.setTerminalFontFamily(this.value)"></label><label data-settings-id="terminalLinks">${appliedFlashHtml("terminalLinks")}<input type="checkbox" ${links ? "checked" : ""} onchange="HerdrMobile.setTerminalLinks(this.checked)"><span>Terminal links</span><small>Detect http/https URLs and open them when tapped.</small></label><label data-settings-id="terminalMouseReporting">${appliedFlashHtml("terminalMouseReporting")}<input type="checkbox" ${mouseReporting ? "checked" : ""} onchange="HerdrMobile.setTerminalMouseReporting(this.checked)"><span>Terminal mouse reporting</span><small>Forward mouse input to terminal apps. Disabled by default; scrolling still works.</small></label><small>Add a Nerd Font family name so icon glyphs render. Leave blank for the default stack.</small></div>`;
     }
 
     function dataSection() {
@@ -129,6 +159,8 @@
     function setThemeMode(value) {
       localStorage.setItem("herdr-web-theme", value);
       applyTheme();
+      queueAppliedFlash("theme");
+      if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
     function setSettingsFilter(value) {
@@ -149,6 +181,8 @@
 
     function setLayoutPreference(value) {
       localStorage.setItem("herdr-web-layout", value);
+      queueAppliedFlash("layout");
+      if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
     function setEditorEnabled(value) { setBooleanOption("editorEnabled", value); }
@@ -158,6 +192,7 @@
       const parsed = readOptions();
       parsed.editorTabSize = Math.max(1, Math.min(8, Number(value) || 2));
       writeOptions(parsed);
+      queueAppliedFlash("editorTabSize");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -279,6 +314,7 @@
       const parsed = readOptions();
       parsed.worktreeDefaultDirectory = String(value || "").trim();
       writeOptions(parsed);
+      queueAppliedFlash("worktreeDefaultDirectory");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -286,6 +322,7 @@
       const parsed = readOptions();
       parsed.explorationDefaultDirectory = String(value || "").trim();
       writeOptions(parsed);
+      queueAppliedFlash("explorationDefaultDirectory");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -293,6 +330,7 @@
       const parsed = readOptions();
       parsed.notificationVolume = Math.max(0, Math.min(100, Number(value) || 0)) / 100;
       writeOptions(parsed);
+      queueAppliedFlash("notificationVolume");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -300,6 +338,7 @@
       const parsed = readOptions();
       parsed.fileBrowserDepth = Math.max(0, Math.min(8, Number(value) || 0));
       writeOptions(parsed);
+      queueAppliedFlash("fileBrowserDepth");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -307,6 +346,7 @@
       const parsed = readOptions();
       parsed.fileBrowserLineNumbers = !!value;
       writeOptions(parsed);
+      queueAppliedFlash("fileBrowserLineNumbers");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -314,6 +354,7 @@
       const parsed = readOptions();
       parsed.headerSearchEnabled = !!value;
       writeOptions(parsed);
+      queueAppliedFlash("headerSearchEnabled");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -321,6 +362,7 @@
       const parsed = readOptions();
       parsed[key] = !!value;
       writeOptions(parsed);
+      queueAppliedFlash(key);
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -328,6 +370,7 @@
       const parsed = readOptions();
       parsed.searchSectionOrder = normalizeSearchSectionOrder(value).join(",");
       writeOptions(parsed);
+      queueAppliedFlash("searchSectionOrder");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -337,6 +380,8 @@
       if (!optionKey) return;
       parsed[optionKey] = parsed[optionKey] === false;
       writeOptions(parsed);
+      pendingSearchOrderFlash = String(key);
+      queueAppliedFlash("searchSectionOrder");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -349,6 +394,8 @@
       [order[index], order[nextIndex]] = [order[nextIndex], order[index]];
       parsed.searchSectionOrder = order.join(",");
       writeOptions(parsed);
+      pendingSearchOrderFlash = String(key);
+      queueAppliedFlash("searchSectionOrder");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -356,6 +403,7 @@
       const parsed = readOptions();
       parsed.fileBrowserSearchPageSize = Math.max(10, Math.min(500, Number(value) || 100));
       writeOptions(parsed);
+      queueAppliedFlash("fileBrowserSearchPageSize");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -363,6 +411,7 @@
       const parsed = readOptions();
       parsed.fileContentSearchMinChars = Math.max(1, Math.min(20, Number(value) || 3));
       writeOptions(parsed);
+      queueAppliedFlash("fileContentSearchMinChars");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -370,6 +419,7 @@
       const parsed = readOptions();
       parsed.fileContentSearchPageSize = Math.max(10, Math.min(500, Number(value) || 50));
       writeOptions(parsed);
+      queueAppliedFlash("fileContentSearchPageSize");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -378,6 +428,7 @@
       const parsedValue = Number(value);
       parsed.fileContentSearchContextLines = Math.max(0, Math.min(20, Number.isFinite(parsedValue) ? parsedValue : 2));
       writeOptions(parsed);
+      queueAppliedFlash("fileContentSearchContextLines");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -386,6 +437,7 @@
       const parsedValue = Number(value);
       parsed.fileContentSearchAutoCollapseFiles = Math.max(0, Math.min(200, Number.isFinite(parsedValue) ? parsedValue : 0));
       writeOptions(parsed);
+      queueAppliedFlash("fileContentSearchAutoCollapseFiles");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -393,6 +445,7 @@
       const parsed = readOptions();
       parsed.fileContentSearchDefaultExpanded = !!value;
       writeOptions(parsed);
+      queueAppliedFlash("fileContentSearchDefaultExpanded");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -400,6 +453,7 @@
       const parsed = readOptions();
       parsed.fileContentSearchMatchesPerFile = Math.max(1, Math.min(50, Number(value) || 5));
       writeOptions(parsed);
+      queueAppliedFlash("fileContentSearchMatchesPerFile");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -407,6 +461,7 @@
       const parsed = readOptions();
       parsed.fileContentSearchMatchCase = !!value;
       writeOptions(parsed);
+      queueAppliedFlash("fileContentSearchMatchCase");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -414,6 +469,7 @@
       const parsed = readOptions();
       parsed.fileContentSearchRegex = !!value;
       writeOptions(parsed);
+      queueAppliedFlash("fileContentSearchRegex");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -422,15 +478,18 @@
         const parsed = readOptions();
         parsed.terminalFontFamily = String(value || "").trim();
         writeOptions(parsed);
+        queueAppliedFlash("terminalFontFamily");
       } catch (_) {}
       if (globalThis.HerdrMobile && globalThis.HerdrMobile.applyTerminalFontFamily)
         globalThis.HerdrMobile.applyTerminalFontFamily();
+      if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
     function setTerminalCore(value) {
       const parsed = readOptions();
       parsed.terminalCore = value === "ghostty" ? "ghostty" : "wterm";
       writeOptions(parsed);
+      queueAppliedFlash("terminalCore");
       if (globalThis.HerdrMobile && globalThis.HerdrMobile.reloadTerminal)
         globalThis.HerdrMobile.reloadTerminal();
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
@@ -440,6 +499,7 @@
       const parsed = readOptions();
       parsed.terminalLinks = !!value;
       writeOptions(parsed);
+      queueAppliedFlash("terminalLinks");
       if (globalThis.HerdrMobile && globalThis.HerdrMobile.applyTerminalLinks)
         globalThis.HerdrMobile.applyTerminalLinks();
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
@@ -449,6 +509,7 @@
       const parsed = readOptions();
       parsed.terminalMouseReporting = !!value;
       writeOptions(parsed);
+      queueAppliedFlash("terminalMouseReporting");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 
@@ -464,6 +525,7 @@
       }
       parsed.browserNotifications = enabled;
       writeOptions(parsed);
+      queueAppliedFlash("browserNotifications", enabled ? "Applied" : "Denied");
       if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
     }
 

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -720,6 +720,73 @@ describe("mobile bundle load", () => {
     );
   });
 
+  it("shows an applied badge that survives the settings re-render and later clears", async () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    ctx.HerdrMobile.showScreen("settings");
+    let html = ctx.document.getElementById("mobileScreen").innerHTML;
+    ok(!html.includes("settings-applied"), "no badge before any change");
+    ok(html.includes('data-settings-id="fileBrowserLineNumbers"'));
+
+    ctx.HerdrMobile.setFileBrowserLineNumbers(false);
+    // refresh() chains several awaits (workspaces, tabs/panes/agents in
+    // Promise.all) before the final render; settle until the badge lands.
+    for (let i = 0; i < 40 && !ctx.document.getElementById("mobileScreen").innerHTML.includes("settings-applied"); i++)
+      await ctx.settle(4);
+    html = ctx.document.getElementById("mobileScreen").innerHTML;
+    ok(
+      html.includes("settings-applied"),
+      "applied badge emitted on the changed row after re-render",
+    );
+    const badgeAt = html.indexOf("settings-applied");
+    const rowAt = html.indexOf('data-settings-id="fileBrowserLineNumbers"');
+    ok(
+      badgeAt > rowAt && badgeAt - rowAt < 400,
+      "badge sits inside the line-numbers row",
+    );
+    ok(
+      JSON.parse(ctx.localStorage.getItem("herdr-web-options"))
+        .fileBrowserLineNumbers === false,
+      "value persisted",
+    );
+
+    // The badge timer clears itself with one more refresh.
+    await ctx.flushTimers();
+    for (let i = 0; i < 40 && ctx.document.getElementById("mobileScreen").innerHTML.includes("settings-applied"); i++)
+      await ctx.settle(4);
+    html = ctx.document.getElementById("mobileScreen").innerHTML;
+    ok(!html.includes("settings-applied"), "badge cleared after the timeout");
+  });
+
+  it("flashes the moved search order row instead of every row", async () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+
+    ctx.HerdrMobile.showScreen("settings");
+    ctx.HerdrMobile.moveSearchSection("content", -1);
+    for (let i = 0; i < 40 && !ctx.document.getElementById("mobileScreen").innerHTML.includes("settings-applied"); i++)
+      await ctx.settle(4);
+    const html = ctx.document.getElementById("mobileScreen").innerHTML;
+    const badges = html.split('class="settings-applied"').length - 1;
+    equal(badges, 1, "exactly one badge for the moved section");
+    const badgeAt = html.indexOf("settings-applied");
+    const contentAt = html.indexOf(">Content<");
+    ok(
+      badgeAt >= 0 &&
+        contentAt >= 0 &&
+        html
+          .slice(badgeAt, contentAt)
+          .includes("mobile-search-order-row") === false &&
+        contentAt - badgeAt < 300,
+      "badge sits on the content row",
+    );
+    const savedOrder = JSON.parse(
+      ctx.localStorage.getItem("herdr-web-options"),
+    ).searchSectionOrder;
+    equal(savedOrder, "workspaces,content,files", "order persisted");
+  });
+
   it("mobile search scope parity uses the shared helper, section order, chips, and load more (B5)", async () => {
     const ctx = context();
     // Custom order and disabled folders must behave identically to desktop.

--- a/src/assets/settings_feedback.test.mjs
+++ b/src/assets/settings_feedback.test.mjs
@@ -1,0 +1,205 @@
+import { describe, it } from "node:test";
+import { equal, ok } from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+const source = readFileSync(
+  new URL("./shared/settings_feedback.js", import.meta.url),
+  "utf8",
+);
+
+function loadFeedback() {
+  const ctx = { console, Map, Object, String, setTimeout, clearTimeout };
+  ctx.window = ctx;
+  ctx.globalThis = ctx;
+  vm.createContext(ctx);
+  vm.runInContext(source, ctx);
+  return ctx.window.HerdrSettingsFeedback;
+}
+
+// Minimal DOM stub: nodes carry className/dataset/attributes plus the child
+// ops the module uses (appendChild, querySelector, remove, closest).
+function createNodeStub({ id = "", className = "" } = {}) {
+  const node = {
+    id,
+    className,
+    children: [],
+    parentNode: null,
+    dataset: {},
+    _attributes: {},
+    setAttribute(name, value) {
+      this._attributes[name] = String(value);
+    },
+    getAttribute(name) {
+      return this._attributes[name];
+    },
+    appendChild(child) {
+      if (child.parentNode && child.parentNode !== this)
+        child.parentNode.children = child.parentNode.children.filter(
+          (existing) => existing !== child,
+        );
+      child.parentNode = this;
+      this.children.push(child);
+      return child;
+    },
+    remove() {
+      if (!this.parentNode) return;
+      this.parentNode.children = this.parentNode.children.filter(
+        (child) => child !== this,
+      );
+      this.parentNode = null;
+    },
+    querySelector(selector) {
+      const wanted = selector
+        .split(",")
+        .map((part) => part.trim())
+        .map((part) => (part.startsWith(".") ? part.slice(1) : part));
+      for (const child of this.children) {
+        if (wanted.includes(String(child.className))) return child;
+        const nested = child.querySelector && child.querySelector(selector);
+        if (nested) return nested;
+      }
+      return null;
+    },
+    closest(selector) {
+      const wanted = selector.startsWith(".") ? selector.slice(1) : selector;
+      let current = this;
+      while (current) {
+        if (String(current.className) === wanted) return current;
+        if (current.tagName === wanted.toUpperCase()) return current;
+        current = current.parentNode;
+      }
+      return null;
+    },
+  };
+  return node;
+}
+
+function createContext() {
+  const timers = [];
+  let seq = 0;
+  const fakeSetTimeout = (callback, delay) => {
+    const id = ++seq;
+    timers.push({ id, callback, delay, cleared: false });
+    return id;
+  };
+  const fakeClearTimeout = (id) => {
+    const timer = timers.find((item) => item.id === id);
+    if (timer) timer.cleared = true;
+  };
+  const document = { createElement: () => createNodeStub() };
+  const api = loadFeedback().create({
+    document,
+    setTimeout: fakeSetTimeout,
+    clearTimeout: fakeClearTimeout,
+  });
+  return { api, timers };
+}
+
+describe("HerdrSettingsFeedback", () => {
+  it("exposes the applied duration for callers and tests", () => {
+    const { api } = createContext();
+    ok(api.APPLIED_MS >= 1000, "badge should stay long enough to be seen");
+  });
+
+  it("flashes an applied badge on the closest .option row", () => {
+    const { api } = createContext();
+    const row = createNodeStub({ className: "option", id: "optRow" });
+    const control = createNodeStub();
+    row.appendChild(control);
+
+    const badge = api.flashApplied(control);
+    ok(badge, "returns the badge node");
+    equal(badge.parentNode, row, "badge is appended to the row");
+    equal(badge.className, "settings-applied");
+    equal(badge.textContent, "✓ Applied");
+    equal(badge.getAttribute("aria-live"), "polite");
+    equal(badge.dataset.state, "settings-applied-ok");
+  });
+
+  it("reuses the same badge on repeated flashes and coalesces timers per row", () => {
+    const { api, timers } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub();
+    row.appendChild(control);
+
+    api.flashApplied(control);
+    equal(row.children.length, 2, "one control + one badge");
+
+    api.flashApplied(control, "Saved");
+    equal(row.children.length, 2, "badge reused, not duplicated");
+    equal(row.children[1].textContent, "✓ Saved");
+    const cleared = timers.filter((timer) => timer.cleared);
+    equal(cleared.length, 1, "first timer is replaced by the second");
+  });
+
+  it("removes the badge after the applied timeout", () => {
+    const { api, timers } = createContext();
+    const row = createNodeStub({ className: "option" });
+    api.flashAppliedRow(row);
+
+    const due = timers.filter((timer) => !timer.cleared);
+    equal(due.length, 1);
+    due[0].callback();
+    ok(!row.children.some((child) => String(child.className).startsWith("settings-")), "badge removed after timeout");
+  });
+
+  it("flashes error badges with a distinct class and state", () => {
+    const { api, timers } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub();
+    row.appendChild(control);
+
+    api.flashError(control, "Could not save");
+    const badge = row.children[1];
+    equal(badge.className, "settings-error-flash");
+    equal(badge.textContent, "Could not save");
+    equal(badge.dataset.state, "settings-applied-error");
+
+    // Switching the same row to applied replaces the error badge state.
+    api.flashApplied(control);
+    equal(badge.className, "settings-applied");
+    equal(badge.dataset.state, "settings-applied-ok");
+    equal(row.children.length, 2, "still a single badge per row");
+
+    timers.filter((timer) => !timer.cleared)[0].callback();
+    equal(row.children.length, 1, "only the control remains after removal");
+  });
+
+  it("falls back to the control itself when no row ancestor matches", () => {
+    const { api } = createContext();
+    const orphan = createNodeStub();
+    const badge = api.flashApplied(orphan, "Done");
+    equal(badge.parentNode, orphan, "badge lands on the control itself");
+  });
+
+  it("prefers the theme customizer container for apply/reset buttons", () => {
+    const { api } = createContext();
+    const customizer = createNodeStub({ className: "theme-customizer" });
+    const button = createNodeStub();
+    customizer.appendChild(button);
+
+    const badge = api.flashApplied(button);
+    equal(badge.parentNode, customizer);
+  });
+
+  it("clear removes badge and pending timer", () => {
+    const { api, timers } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub();
+    row.appendChild(control);
+    api.flashApplied(control);
+    ok(timers.some((timer) => !timer.cleared), "timer pending");
+
+    api.clear(control);
+    ok(!row.children.some((child) => String(child.className).startsWith("settings-")), "badge removed");
+    ok(timers.every((timer) => timer.cleared), "timer cleared");
+  });
+
+  it("does nothing without a control", () => {
+    const { api } = createContext();
+    equal(api.flashApplied(null), null);
+    equal(api.flashError(null, "x"), null);
+    equal(api.clear(null), undefined);
+  });
+});

--- a/src/assets/shared/settings_feedback.js
+++ b/src/assets/shared/settings_feedback.js
@@ -1,0 +1,111 @@
+// Settings "applied" confirmation feedback.
+//
+// Local settings (terminal, theme, agents, editor, module options) persist to
+// browser storage on every change, and server settings save through the
+// Apply button. Before this module there was no visual confirmation anywhere:
+// users could not tell whether a change actually took effect. This helper
+// gives every settings row a short-lived green "Applied" badge (or a red
+// error message) with a screen-reader live region, and clears itself after a
+// timeout. It is layout-agnostic: desktop passes the `.option` row ancestor,
+// mobile passes the label/control container.
+(function (root) {
+  const APPLIED_MS = 2500;
+  const APPLIED_CLASS = "settings-applied";
+  const ERROR_CLASS = "settings-error-flash";
+  const BADGE_ID_PREFIX = "settings-applied-badge-";
+
+  function createSettingsFeedback({ document, setTimeout, clearTimeout }) {
+    const doc = document;
+    const timers = new Map();
+
+    function clearTimer(key) {
+      const timer = timers.get(key);
+      if (timer) {
+        clearTimeout(timer);
+        timers.delete(key);
+      }
+    }
+
+    function scheduleClear(key, badge) {
+      clearTimer(key);
+      const timer = setTimeout(() => {
+        timers.delete(key);
+        if (badge && badge.parentNode) badge.remove();
+      }, APPLIED_MS);
+      timers.set(key, timer);
+    }
+
+    function findRow(control) {
+      if (!control) return null;
+      if (typeof control.closest === "function") {
+        return (
+          control.closest(".option") ||
+          control.closest(".theme-customizer") ||
+          control.closest(".mobile-settings-group") ||
+          control.closest("label") ||
+          control
+        );
+      }
+      return control;
+    }
+
+    function ensureBadge(row, kind) {
+      const key = String(row.id || row.dataset.settingsRow || "");
+      const wantedClass = kind === "error" ? ERROR_CLASS : APPLIED_CLASS;
+      // A row shows at most one badge; reuse it across ok/error kinds so a
+      // save failure followed by a successful save swaps in place.
+      let badge = row.querySelector(`.${APPLIED_CLASS}, .${ERROR_CLASS}`);
+      const wanted = kind === "error" ? "settings-applied-error" : "settings-applied-ok";
+      if (!badge) {
+        badge = doc.createElement("span");
+        badge.className = wantedClass;
+        badge.setAttribute("aria-live", "polite");
+        badge.dataset.state = wanted;
+        if (key) badge.id = BADGE_ID_PREFIX + key;
+        row.appendChild(badge);
+      } else {
+        badge.className = wantedClass;
+        badge.dataset.state = wanted;
+      }
+      return badge;
+    }
+
+    function show(row, kind, message) {
+      if (!row) return null;
+      const badge = ensureBadge(row, kind);
+      badge.textContent = message;
+      // Re-append so the badge lands after any content the row re-rendered.
+      if (badge.parentNode !== row) row.appendChild(badge);
+      scheduleClear(row, badge);
+      return badge;
+    }
+
+    return {
+      flashApplied(control, label = "Applied") {
+        return show(findRow(control), "ok", `✓ ${label}`);
+      },
+      flashAppliedRow(row, label = "Applied") {
+        return show(row, "ok", `✓ ${label}`);
+      },
+      flashError(control, message) {
+        return show(findRow(control), "error", message);
+      },
+      flashErrorRow(row, message) {
+        return show(row, "error", message);
+      },
+      clear(control) {
+        const row = findRow(control);
+        if (!row) return;
+        clearTimer(row);
+        const badge = row.querySelector(`.${APPLIED_CLASS}, .${ERROR_CLASS}`);
+        if (badge) badge.remove();
+      },
+      APPLIED_MS,
+    };
+  }
+
+  const api = { create: createSettingsFeedback, APPLIED_MS };
+  root.HerdrSettingsFeedback = api;
+  if (typeof module !== "undefined" && module.exports)
+    module.exports = api;
+})(typeof globalThis !== "undefined" ? globalThis : window);

--- a/src/builtin_backend.rs
+++ b/src/builtin_backend.rs
@@ -21,7 +21,13 @@ use crate::protocol::{
 use crate::terminal_text::{self, TerminalTextOptions};
 
 const BUILTIN_VERSION: &str = "builtin-0.1.0";
-const PROTOCOL_VERSION: u32 = 20;
+// Must match the WebUI terminal attach client (`PROTOCOL_VERSION` in main.rs,
+// 22 for herdr 0.9.0): the builtin backend emulates a herdr terminal server
+// and requires an exact version match at handshake time. A mismatch made
+// every builtin terminal attach fail with a `herdr_error` frame, so the
+// browser offered the (also broken) built-in fallback and its question
+// modal blocked the whole UI.
+const PROTOCOL_VERSION: u32 = 22;
 const MAX_FRAME_SIZE: usize = 32 * 1024 * 1024;
 const MAX_SCROLLBACK_BYTES: usize = 8 * 1024 * 1024;
 const DETECTION_TAIL_BYTES: usize = 64 * 1024;
@@ -6645,6 +6651,94 @@ mod tests {
         assert_eq!(snapshot["tabs"].as_array().unwrap().len(), 0);
         assert_eq!(snapshot["panes"].as_array().unwrap().len(), 0);
         assert!(snapshot["focused_workspace_id"].is_null());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn client_socket_accepts_webui_attach_protocol_version() {
+        // Regression guard: the WebUI terminal attach client sends
+        // `TerminalHello{version: PROTOCOL_VERSION}` (22 for herdr 0.9.0) and
+        // the builtin backend requires an exact match. When the constants
+        // drifted (client 22, builtin 20) every builtin terminal attach
+        // failed with a herdr_error frame and the browser's fallback question
+        // modal blocked the UI. Exercise the real client socket handshake.
+        let base = format!(
+            "/tmp/herdr-webui-client-hello-test-{}-{}",
+            std::process::id(),
+            now_ms()
+        );
+        let api_socket = PathBuf::from(format!("{base}-api.sock"));
+        let client_socket = PathBuf::from(format!("{base}-client.sock"));
+        let _handle = BuiltinBackendHandle::start(BuiltinBackendConfig {
+            api_socket: api_socket.clone(),
+            client_socket,
+            cwd: std::env::temp_dir(),
+            shell: Some(default_shell()),
+            jcode_detection_variant: JcodeDetectionVariant::Vanilla,
+        })
+        .unwrap();
+        // Seed a workspace + tab; the root pane owns the terminal id. The api
+        // socket serves one request per connection, so open two.
+        let request = |line: &str| -> Value {
+            let mut api = connect_local_stream(&api_socket).unwrap();
+            api.write_all(line.as_bytes()).unwrap();
+            api.write_all(b"\n").unwrap();
+            api.flush().unwrap();
+            let mut reader = BufReader::new(api);
+            let mut out = String::new();
+            reader.read_line(&mut out).unwrap();
+            serde_json::from_str(&out).unwrap()
+        };
+        let workspace =
+            request(r#"{"id":"seed","method":"workspace.create","params":{"label":"handshake"}}"#);
+        let workspace_id = workspace["result"]["workspace"]["workspace_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let tab = request(&format!(
+            r#"{{"id":"tab","method":"tab.create","params":{{"workspace_id":"{workspace_id}"}}}}"#
+        ));
+        let terminal_id = tab["result"]["root_pane"]["terminal_id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // The exact handshake the WebUI attach path performs.
+        let mut client =
+            connect_local_stream(&PathBuf::from(format!("{base}-client.sock"))).unwrap();
+        write_message(
+            &mut client,
+            &ClientMessage::TerminalHello {
+                version: 22,
+                cols: 80,
+                rows: 24,
+                cell_width_px: 0,
+                cell_height_px: 0,
+                pixel_mouse: false,
+            },
+        )
+        .unwrap();
+        match read_message::<_, ServerMessage>(&mut client, MAX_FRAME_SIZE).unwrap() {
+            ServerMessage::Welcome { error: None, .. } => {}
+            ServerMessage::Welcome {
+                error: Some(err), ..
+            } => {
+                panic!("builtin backend rejected the WebUI attach version: {err}")
+            }
+            other => panic!("expected Welcome, got {other:?}"),
+        }
+        write_message(
+            &mut client,
+            &ClientMessage::AttachTerminal {
+                terminal_id,
+                takeover: true,
+            },
+        )
+        .unwrap();
+        match read_message::<_, ServerMessage>(&mut client, MAX_FRAME_SIZE).unwrap() {
+            ServerMessage::Terminal(_) => {}
+            other => panic!("expected Terminal frame after attach, got {other:?}"),
+        }
     }
 
     #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,10 +48,10 @@ use assets::{
     shared_content_search_css, shared_core_js, shared_editor_js, shared_file_content_search_js,
     shared_file_icons_css, shared_file_icons_js, shared_file_tree_css, shared_file_tree_js,
     shared_line_context_js, shared_lsp_js, shared_markdown_preview_css, shared_markdown_preview_js,
-    shared_options_js, shared_temp_terminal_js, shared_terminal_adapter_js, shared_terminal_fit_js,
-    shared_terminal_scroll_js, shared_workspace_search_js, vendor_codemirror_js,
-    vendor_dompurify_js, vendor_ghostty_wasm, vendor_marked_js, vendor_mermaid_js,
-    vendor_wterm_css, vendor_wterm_js,
+    shared_options_js, shared_settings_feedback_js, shared_temp_terminal_js,
+    shared_terminal_adapter_js, shared_terminal_fit_js, shared_terminal_scroll_js,
+    shared_workspace_search_js, vendor_codemirror_js, vendor_dompurify_js, vendor_ghostty_wasm,
+    vendor_marked_js, vendor_mermaid_js, vendor_wterm_css, vendor_wterm_js,
 };
 use compat::SimpleVersion;
 use compat::{backend_compatibility, BackendCompatibility};
@@ -1486,6 +1486,10 @@ fn app_router(state: WebState) -> Router {
         .route(
             "/assets/shared/workspace-search.js",
             get(shared_workspace_search_js),
+        )
+        .route(
+            "/assets/shared/settings-feedback.js",
+            get(shared_settings_feedback_js),
         )
         .route("/assets/vendor/codemirror.js", get(vendor_codemirror_js))
         .route("/assets/vendor/marked.js", get(vendor_marked_js))
@@ -7159,6 +7163,15 @@ mod tests {
             )
             .await
             .unwrap();
+        let settings_feedback_js = app
+            .clone()
+            .oneshot(
+                request(Method::GET, "/assets/shared/settings-feedback.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         let file_icons_js = app
             .clone()
             .oneshot(
@@ -7346,6 +7359,7 @@ mod tests {
         assert_eq!(app_js.status(), StatusCode::OK);
         assert_eq!(app_boot_js.status(), StatusCode::OK);
         assert_eq!(app_core_js.status(), StatusCode::OK);
+        assert_eq!(settings_feedback_js.status(), StatusCode::OK);
         assert_eq!(file_icons_js.status(), StatusCode::OK);
         assert_eq!(file_icons_css.status(), StatusCode::OK);
         assert_eq!(shared_colors_css.status(), StatusCode::OK);


### PR DESCRIPTION
## Summary

- Desktop, mobile, and server settings now show a green **✓ Applied** badge on the changed row right after a change is applied, and it clears itself after a short delay. Server settings Apply keeps the green **Saved** status line, and errors/validation drop it back to red.
- New shared `settings_feedback.js` (flashing, per-row timer coalescing, single badge reused across ok/error kinds) is embedded and served via a new asset route.
- Desktop: `saveOptions()` is the single choke point and flashes the focused row; the theme select, shortcut-record, and rebuilt rows flash through dedicated helpers. Mobile: every setter queues a flash before re-render; search-section order flashes only the moved/toggled section.
- Fixed a real terminal bug found while making the e2e honest: the builtin backend still required terminal protocol 20 while the attach client sends 22 (herdr 0.9.0). Every builtin terminal attach failed with a `herdr_error`, and the fallback question modal blocked the UI. Bumped the backend to 22 with a client-socket handshake regression test.

## Tests

- 9 new unit tests for `settings_feedback.js` (badge reuse, ok/error states, coalescing, clearing).
- `app_load.test.mjs` +3: saveOptions flash via activeElement, server saved-green / failure-red, validation stays red. `mobile_load.test.mjs` +2: badge survives re-render, search-order row targeting. JS suite: 462 pass.
- Rust: new `client_socket_accepts_webui_attach_protocol_version` regression test; extended `static_asset_routes_serve_embedded_content`. Full suite green (514 tests), `cargo fmt --check` clean, clippy baseline unchanged.
- E2E session UX: the settings checkbox check now uses real CDP mouse events (scrollIntoView + mousePressed/Released), asserting badge text, state, green color, persistence, and auto-clear. Server Apply green and validation-red checks. 26/26 checks pass.

## Notes

The e2e used to click the checkbox via synthetic `.click()`, which never reproduced the real user path (no focus/activeElement). Driving it with the CDP Input domain surfaced the protocol mismatch above, since the leftover fallback question modal swallowed the click.

🤖 Generated with [Jcode](https://github.com/1jehuang/jcode)