### PR TITLE
Fix session manager switching, add mobile sessions parity, prove backend routing

### DIFF
--- a/scripts/e2e/acceptance.mjs
+++ b/scripts/e2e/acceptance.mjs
@@ -110,6 +110,23 @@ const closedPrior = await cdp.evalExpr(`(async () => {
 })()`, true);
 if (closedPrior > 0) console.log(`closed ${closedPrior} stale workspace(s) via real sidebar buttons`);
 
+// Capture outgoing request headers while the workspace is created: the
+// Actions UI must stamp the selected session backend (x-herdr-backend) on
+// every create call so the server routes it to that backend.
+const createRequests = [];
+cdp.onEvent((msg) => {
+  if (msg.method === 'Network.requestWillBeSent' && msg.params) {
+    const url = msg.params.request && msg.params.request.url;
+    if (url && /\/api\/workspaces(\?|$)/.test(url) && msg.params.request.method === 'POST') {
+      createRequests.push({
+        url,
+        backend: (msg.params.request.headers || {})['x-herdr-backend'] || null,
+        session: (msg.params.request.headers || {})['x-herdr-session'] || null,
+      });
+    }
+  }
+});
+
 // 1) Open workspace: if the dashboard is shown use its button; else a workspace already exists.
 const openResult = await cdp.evalExpr(`(async () => {
   const dash = !!document.querySelector('.project-dashboard-card');
@@ -144,6 +161,16 @@ if (openResult === 'grid') {
     return JSON.stringify({ modal: modal ? getComputedStyle(modal).display : 'absent', err: err ? err.textContent : '' });
   })()`, true);
   check('workspace created from folder', wsResult && wsResult.includes('"modal":"none"'), String(wsResult).slice(0, 160));
+  // The create request must carry the browser's selected session backend.
+  {
+    const stored = await cdp.evalExpr(`localStorage.getItem('herdr-session-backend')`);
+    const createReq = createRequests[createRequests.length - 1];
+    check(
+      'workspace create request targeted the selected session backend',
+      !!createReq && createReq.backend === (stored || 'builtin'),
+      `x-herdr-backend=${createReq && createReq.backend} selected=${stored || 'builtin'} url=${createReq && createReq.url}`,
+    );
+  }
 } else if (openResult === 'workspace-already-open') {
   check('workspace already open (prior run)', true);
 } else {

--- a/scripts/e2e/cdp-driver.mjs
+++ b/scripts/e2e/cdp-driver.mjs
@@ -26,11 +26,18 @@ export async function connectToPage() {
   });
   let id = 0;
   const pending = new Map();
+  // Optional listener for CDP event notifications (Network.requestWillBeSent
+  // etc.). Tests use it to capture outgoing request headers.
+  let eventListener = null;
   ws.onmessage = (m) => {
     const msg = JSON.parse(m.data);
     if (msg.id && pending.has(msg.id)) {
       pending.get(msg.id)(msg);
       pending.delete(msg.id);
+    } else if (msg.method && eventListener) {
+      try {
+        eventListener(msg);
+      } catch (_) {}
     }
     // The app's desktop UI uses native confirm()/prompt() for destructive
     // actions (dirty tab close, discard, delete). In headless Chrome those
@@ -61,5 +68,12 @@ export async function connectToPage() {
       throw new Error('page eval failed: ' + JSON.stringify(r.exceptionDetails).slice(0, 800));
     return r.result?.value;
   };
-  return { send, evalExpr, close: () => ws.close() };
+  return {
+    send,
+    evalExpr,
+    onEvent(listener) {
+      eventListener = listener;
+    },
+    close: () => ws.close(),
+  };
 }

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -2345,6 +2345,104 @@ describe("app bundle load", () => {
     equal(manager.style.display, "none");
   });
 
+  it("closes the session manager after creating a new built-in session", async () => {
+    const ctx = context();
+    ctx.prompt = () => "revolut";
+    ctx.fetch = async (url) => {
+      if (url === "/api/sessions")
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            sessions: [{ name: "default", backend: "builtin", running: true }],
+            herdr_available: true,
+            herdr_compatible: true,
+            herdr_version: "0.9.0",
+            default_backend: "builtin",
+            enabled_backends: { builtin: true, "external-herdr": true },
+          }),
+        };
+      if (url === "/api/session/launch")
+        return { ok: true, status: 200, json: async () => ({ ok: true, pid: 4242 }) };
+      return { ok: true, status: 200, json: async () => ({ result: { workspaces: [] } }) };
+    };
+    vm.runInContext(source, ctx);
+    ctx.setupSessionChrome();
+    const manager = ctx.document.getElementById("sessionManager");
+
+    await ctx.showSessionManager();
+    equal(manager.style.display, "block");
+
+    // In a real browser goSession pushes /session/revolut before its
+    // parseRoute() re-reads the URL; the harness pushState is a no-op, so
+    // mirror the post-switch URL before the flow runs.
+    ctx.location.pathname = "/session/revolut";
+    await ctx.newSessionTarget("builtin");
+    // The new session is live and the browser switched to it: the manager
+    // must close so the user lands in the session, not the modal.
+    equal(manager.style.display, "none");
+    equal(vm.runInContext("state.session", ctx), "revolut");
+    equal(vm.runInContext("state.sessionBackend", ctx), "builtin");
+  });
+
+  it("closes the session manager when switching targets via a session row", async () => {
+    const ctx = context();
+    vm.runInContext(source, ctx);
+    ctx.setupSessionChrome();
+    const manager = ctx.document.getElementById("sessionManager");
+
+    await ctx.showSessionManager();
+    equal(manager.style.display, "block");
+
+    ctx.location.pathname = "/session/work";
+    ctx.goSession("work", "builtin");
+    equal(manager.style.display, "none");
+    equal(vm.runInContext("state.session", ctx), "work");
+    equal(vm.runInContext("state.sessionBackend", ctx), "builtin");
+  });
+
+  it("closes the session manager after the herdr_error built-in fallback launches", async () => {
+    const ctx = context();
+    let launchCalls = 0;
+    // Mirror the post-switch URL the browser would have after pushState.
+    ctx.history = {
+      pushState(_state, _title, path) {
+        ctx.location.pathname = path;
+      },
+      replaceState() {},
+    };
+    ctx.fetch = async (url) => {
+      if (url === "/api/session/launch") {
+        launchCalls += 1;
+        return { ok: true, status: 200, json: async () => ({ ok: true, pid: 11 }) };
+      }
+      if (url === "/api/session/close")
+        return { ok: true, status: 200, json: async () => ({ ok: true }) };
+      return { ok: true, status: 200, json: async () => ({ result: { workspaces: [] } }) };
+    };
+    vm.runInContext(source, ctx);
+    ctx.setupSessionChrome();
+    const manager = ctx.document.getElementById("sessionManager");
+
+    vm.runInContext('state.sessionBackend = "external-herdr"', ctx);
+    await ctx.showSessionManager();
+    equal(manager.style.display, "block");
+
+    // Accept the built-in fallback offer through the question modal (the
+    // established pattern: kick the frame, settle, answer, await).
+    const handled = ctx.handleHerdrErrorFrame(
+      JSON.stringify({ type: "herdr_error", message: "protocol mismatch" }),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    ctx.closeQuestion(true);
+    equal(await handled, true);
+    equal(launchCalls, 1);
+    equal(vm.runInContext("state.sessionBackend", ctx), "builtin");
+    // The user accepted the built-in fallback: the manager closes instead
+    // of staying open over the recovered session.
+    equal(manager.style.display, "none");
+  });
+
   it("uses backend-aware colors for session rows and the footer button", () => {
     const chromeCss = readFileSync(new URL("./desktop/app_css/chrome.css", import.meta.url), "utf8");
     const workspacesCss = desktopWorkspacesCss;

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -2671,6 +2671,10 @@ async function newSessionTarget(backend) {
   const launched = await launchBackend(name, backend);
   if (launched === false) return;
   goSession(name, backend);
+  // The new session is live and the browser switched to it: close the
+  // manager so the user lands in the fresh session instead of a modal that
+  // still lists the previous target.
+  hideSessionManager();
 }
 async function loadSessions() {
   try {
@@ -2867,7 +2871,10 @@ async function handleHerdrErrorFrame(raw) {
       : false;
     if (wantsBuiltin) {
       goSession(state.session || "default", "builtin");
-      await launchBackend(state.session || "default", "builtin");
+      const launched = await launchBackend(state.session || "default", "builtin");
+      // The user accepted the built-in fallback: land them in the session
+      // instead of leaving the degraded-state manager open.
+      if (launched !== false) hideSessionManager();
     } else {
       // When built-in is disabled (or the user declined), reopen the manager
       // so the user picks an enabled target instead of silently rerouting.
@@ -3284,11 +3291,16 @@ function go(ws, tab, pane) {
   setTerminalLoading(true);
   refresh();
 }
-function goSession(name, backend = currentSessionBackend()) {
+function goSession(name, backend = currentSessionBackend(), { closeManager = true } = {}) {
   // Do not switch the browser to external herdr when no compatible install
   // was detected or the backend is disabled in settings; keep built-in.
   if (backend === "external-herdr" && (!state.herdrCompatible || !backendEnabled("external-herdr")))
     backend = "builtin";
+  // Row clicks and new-session flows finish by switching the browser to the
+  // target; close the manager so the switch is visible. Flows that report a
+  // result message (close session, herdr_error fallback) pass closeManager
+  // false and keep the manager open with their message.
+  if (closeManager) hideSessionManager();
   state.session = name || "default";
   state.sessionBackend = backend || "builtin";
   localStorage.setItem("herdr-session-backend", state.sessionBackend);

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -148,9 +148,13 @@ body.light {
 }
 .mobile-context .mobile-backend-badge {
   align-self: flex-start;
+  -webkit-appearance: none;
+  appearance: none;
+  background: none;
   border: 1px solid var(--border2);
   border-radius: 999px;
   color: var(--muted);
+  cursor: pointer;
   display: inline-block;
   font-size: 10px;
   font-weight: 800;
@@ -161,6 +165,14 @@ body.light {
   text-overflow: clip;
   white-space: nowrap;
   width: auto;
+}
+.mobile-session-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.mobile-session-actions .mobile-btn {
+  flex: 1 1 auto;
 }
 .mobile-context .mobile-backend-badge.backend-builtin {
   border-color: var(--backend-builtin);

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -6,9 +6,10 @@
     pathBasename,
     samePath,
     selectionPath: mobileSelectionPath,
+    sessionPrefix,
   } = globalThis.HerdrMobileCore;
   const { createFaviconNotifier } = globalThis.HerdrAppHelpers;
-  const MORE_SCREENS = ["agents", "panels", "worktrees", "files", "git", "settings"];
+  const MORE_SCREENS = ["agents", "panels", "worktrees", "files", "git", "settings", "sessions"];
 
   const state = {
     session: "default",
@@ -24,6 +25,17 @@
     // The server's configured default backend (settings-change broadcast);
     // used to retarget when the pinned backend gets disabled.
     serverDefaultBackend: null,
+    // Session manager screen state: the known session rows from
+    // /api/sessions, the new-session name input, and its busy/error state.
+    sessions: [],
+    sessionsError: "",
+    sessionNameInput: "",
+    sessionBusy: false,
+    sessionBusyLabel: "",
+    sessionCreateExpanded: false,
+    herdrAvailable: null,
+    herdrCompatible: null,
+    herdrVersion: null,
     workspaces: [],
     tabs: [],
     allTabs: [],
@@ -186,11 +198,20 @@
       }
       state.serverBackendConfirmed = true;
     } catch (_) {}
-    // External herdr sessions are only offered when a compatible herdr
-    // install is detected. If it is missing or incompatible, fall back to
-    // built-in instead of targeting a guaranteed-failed attach.
+    await loadSessions();
+  }
+
+  // Fetch the known sessions plus the herdr install/enablement state.
+  // Shared by the init flow and the mobile sessions screen so the screen
+  // always reflects the server's view.
+  async function loadSessions() {
     try {
       const r = await api("/api/sessions");
+      state.sessions = r.sessions || [];
+      state.sessionsError = "";
+      // External herdr sessions are only offered when a compatible herdr
+      // install is detected. If it is missing or incompatible, fall back to
+      // built-in instead of targeting a guaranteed-failed attach.
       state.herdrAvailable = !!r.herdr_available;
       state.herdrCompatible = !!r.herdr_compatible;
       state.herdrVersion = r.herdr_version || null;
@@ -206,7 +227,12 @@
         state.sessionBackend = "builtin";
         localStorage.setItem("herdr-session-backend", "builtin");
       }
-    } catch (_) {}
+    } catch (e) {
+      state.sessions = [
+        { name: state.session || "default", backend: currentSessionBackend(), running: false },
+      ];
+      state.sessionsError = e.message || String(e);
+    }
   }
 
   function apiErrorMessage(body, statusText) {
@@ -479,7 +505,9 @@
     if (!badge) return;
     const backend = currentSessionBackend() || "builtin";
     badge.className = `mobile-backend-badge ${sessionBackendClass(backend)}`;
-    badge.textContent = sessionBackendLabel(backend);
+    badge.textContent = `${sessionBackendLabel(backend)} · ${state.session || "default"}`;
+    badge.title = "Sessions";
+    badge.onclick = () => showScreen("sessions");
   }
 
   function renderShell() {
@@ -487,7 +515,7 @@
       <div id="mobileApp" class="mobile-app">
         <header class="mobile-header">
           <button class="mobile-btn" id="mobileBack" title="Home">←</button>
-          <div class="mobile-context"><strong id="mobileTitle">Herdr</strong><span id="mobileMeta">Loading</span><span id="mobileBackendBadge" class="mobile-backend-badge backend-builtin">built-in</span></div>
+          <div class="mobile-context"><strong id="mobileTitle">Herdr</strong><span id="mobileMeta">Loading</span><button type="button" id="mobileBackendBadge" class="mobile-backend-badge backend-builtin" title="Sessions" aria-label="Sessions">built-in</button></div>
           <button class="mobile-btn" id="mobileSearch" title="Search">⌕</button>
           <button class="mobile-btn" id="mobileSettings" title="Settings">⚙</button>
           <button class="mobile-btn temp-terminal-toggle" id="mobileTempTerminal" title="Temporary terminal" aria-label="Temporary terminal"><span class="temp-terminal-icon" aria-hidden="true"><span class="temp-terminal-icon-glyph"></span><span class="temp-terminal-icon-label">T</span></span></button>
@@ -525,6 +553,7 @@
     const wasTerminal = state.screen === "terminal";
     state.screen = screen;
     if (wasTerminal && screen !== "terminal") mobileTerminal.destroy(false);
+    if (screen === "sessions" && !state.sessionBusy) refreshSessions();
     render();
     if (screen === "terminal") mobileTerminal.connect();
   }
@@ -566,6 +595,8 @@
     else if (state.screen === "git") renderGitScreen(screen);
     else if (state.screen === "settings")
       screen.innerHTML = mobileSettings.render();
+    else if (state.screen === "sessions")
+      screen.innerHTML = renderSessions();
     else if (state.screen === "terminal") renderTerminalScreen(screen);
     else if (state.screen === "more") screen.innerHTML = renderMore();
     else screen.innerHTML = renderHome();
@@ -637,8 +668,178 @@
       { screen: "files", title: "Files", meta: workspace ? "Browse current workspace" : "Select workspace first", icon: "fi" },
       { screen: "git", title: "Git", meta: workspace ? "Status, diff, branches, history" : "Select workspace first", icon: "git" },
       { screen: "settings", title: "Settings", meta: "Appearance, search, alerts, terminal", icon: "⚙" },
+      { screen: "sessions", title: "Sessions", meta: `${state.session || "default"} · ${sessionBackendLabel(currentSessionBackend())}`, icon: "se" },
     ];
     return `<section class="mobile-section mobile-more"><h2>More tools</h2><p class="mobile-help">Less-used tools stay here so Home, Search, and Terminal remain fast.</p><div class="mobile-more-grid">${tools.map((tool) => `<button class="mobile-more-card" onclick="HerdrMobile.showScreen('${tool.screen}')"><span class="mobile-more-icon">${escapeHtml(tool.icon)}</span><strong>${escapeHtml(tool.title)}</strong><small>${escapeHtml(tool.meta)}</small></button>`).join("")}</div></section>`;
+  }
+
+  // Sessions screen: mobile parity with the desktop session manager.
+  // Lists known sessions, creates built-in/Herdr sessions, switches the
+  // browser target, and closes the active session.
+  function renderSessions() {
+    const busy = !!state.sessionBusy;
+    const loading = busy ? `<div class="mobile-loading">${escapeHtml(state.sessionBusyLabel || "Working...")}</div>` : "";
+    const error = state.sessionsError ? `<div class="mobile-error">${escapeHtml(state.sessionsError)}</div>` : "";
+    const current = `${state.session || "default"} · ${sessionBackendLabel(currentSessionBackend())}`;
+    const rows = (state.sessions || []).map((row) => {
+      const backend = row.backend || (backendEnabled("external-herdr") ? "external-herdr" : "builtin");
+      const active =
+        row.name === state.session && backend === currentSessionBackend();
+      const label = row.name || "default";
+      const pill = `<span class="mobile-chip ${sessionBackendClass(backend)}">${escapeHtml(row.backend_label || sessionBackendLabel(backend))}</span>`;
+      const status = row.running
+        ? '<span class="mobile-chip">running</span>'
+        : '<span class="mobile-chip">offline</span>';
+      const controls = active
+        ? `${pill}<button class="mobile-btn" ${busy ? "disabled" : ""} onclick="HerdrMobile.refreshSessions()">Retry</button><button class="mobile-btn danger" ${busy ? "disabled" : ""} onclick="HerdrMobile.closeSession()">Close</button>`
+        : `${pill}${status}`;
+      return `<button class="mobile-row${active ? " active" : ""}" onclick="HerdrMobile.selectSession(${jsArg(label)},${jsArg(backend)})"><strong>${escapeHtml(label)}${active ? " · current" : ""}</strong><span>${controls}</span></button>`;
+    }).join("");
+    const herdrUsable = state.herdrCompatible && backendEnabled("external-herdr");
+    return `<section class="mobile-section mobile-form"><h2>Sessions</h2><p class="mobile-help">Current target: ${escapeHtml(current)}. Tap a session to switch, or create a new one.</p><div class="mobile-settings-group"><h3>Known sessions</h3>${rows ? rows : '<div class="mobile-loading">No sessions found yet</div>'}${loading}${error}</div><details class="mobile-settings-group mobile-disclosure" ${state.sessionCreateExpanded ? "open" : ""} onchange="HerdrMobile.setSessionCreateExpanded(this.open)"><summary>Create new session</summary><label><span>Session name</span><input value="${escapeHtml(state.sessionNameInput)}" oninput="HerdrMobile.updateSessionField('sessionNameInput', this.value)" placeholder="revolut"></label><div class="mobile-session-actions"><button class="mobile-btn primary" ${busy ? "disabled" : ""} onclick="HerdrMobile.newSession('builtin')">New built-in</button>${herdrUsable ? `<button class="mobile-btn" ${busy ? "disabled" : ""} onclick="HerdrMobile.newSession('external-herdr')">New Herdr</button>` : ""}</div></details></section>`;
+  }
+
+  async function refreshSessions() {
+    state.sessionBusy = true;
+    state.sessionBusyLabel = "Loading sessions...";
+    render();
+    try {
+      await loadSessions();
+    } finally {
+      state.sessionBusy = false;
+      state.sessionBusyLabel = "";
+      render();
+    }
+  }
+
+  function updateSessionField(field, value) {
+    state[field] = value;
+  }
+
+  function setSessionCreateExpanded(open) {
+    state.sessionCreateExpanded = !!open;
+  }
+
+  // Launch a new session on the chosen backend and switch the browser to
+  // it (mobile parity with the desktop newSessionTarget flow).
+  async function newSession(backend) {
+    const name = (state.sessionNameInput || "").trim();
+    if (!name) {
+      state.sessionsError = "Session name is required.";
+      render();
+      return;
+    }
+    if (backend === "external-herdr" && !backendEnabled("external-herdr")) {
+      state.sessionsError = "External Herdr sessions are disabled in server settings.";
+      render();
+      return;
+    }
+    if (backend === "external-herdr" && !state.herdrCompatible) {
+      state.sessionsError = state.herdrAvailable
+        ? `Detected herdr ${state.herdrVersion || ""} is not compatible with this WebUI build. Upgrade herdr or use a built-in session.`
+        : "No compatible herdr install detected. Install herdr to use external Herdr sessions.";
+      render();
+      return;
+    }
+    state.sessionBusy = true;
+    state.sessionBusyLabel = "Launching session...";
+    render();
+    try {
+      const r = await api("/api/session/launch", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ session: name, backend }),
+      });
+      if (!r.ok) throw Error(r.error || "Launch failed");
+      await switchSession(name, backend);
+      state.sessionNameInput = "";
+      state.sessionCreateExpanded = false;
+    } catch (e) {
+      state.sessionsError = e.message || String(e);
+    } finally {
+      state.sessionBusy = false;
+      state.sessionBusyLabel = "";
+      render();
+      setTimeout(refreshSessions, 400);
+    }
+  }
+
+  // Switch the browser target to a session (mobile parity with the desktop
+  // goSession flow: route, terminal, events socket, and list refresh).
+  function switchSession(name, backend) {
+    if (backend === "external-herdr" && (!state.herdrCompatible || !backendEnabled("external-herdr")))
+      backend = "builtin";
+    state.session = name || "default";
+    state.sessionBackend = backend || "builtin";
+    localStorage.setItem("herdr-session-backend", state.sessionBackend);
+    state.ws = null;
+    state.tab = null;
+    state.pane = null;
+    state.terminalId = null;
+    state.workspaces = [];
+    state.tabs = [];
+    state.allTabs = [];
+    state.panes = [];
+    mobileTerminal.destroy(true);
+    if (eventWs) {
+      eventWs.onclose = null;
+      try {
+        eventWs.close();
+      } catch (e) {}
+      eventWs = null;
+    }
+    history.pushState(null, "", sessionPrefix(state.session));
+    syncBackendBadge();
+    refresh();
+    connectEvents();
+  }
+
+  async function selectSession(name, backend) {
+    if (name === state.session && backend === currentSessionBackend()) {
+      // Tapping the current row just refreshes the list.
+      refreshSessions();
+      return;
+    }
+    switchSession(name, backend);
+  }
+
+  // Close the active session (mobile parity with closeCurrentSession).
+  async function closeSession() {
+    if (!confirm(`Close current ${sessionBackendLabel(currentSessionBackend())} session?`)) return;
+    state.sessionBusy = true;
+    state.sessionBusyLabel = "Closing session...";
+    render();
+    try {
+      await api("/api/session/close", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ session: state.session || "default", backend: currentSessionBackend() }),
+      });
+      // Retarget the server's default backend so the refresh below lands
+      // on a working session (the server auto-starts built-in on demand).
+      state.sessionBackend = state.serverDefaultBackend || "builtin";
+      localStorage.setItem("herdr-session-backend", state.sessionBackend);
+      state.ws = null;
+      state.tab = null;
+      state.pane = null;
+      mobileTerminal.destroy(true);
+      if (eventWs) {
+        eventWs.onclose = null;
+        try {
+          eventWs.close();
+        } catch (e) {}
+        eventWs = null;
+      }
+      refresh();
+      connectEvents();
+    } catch (e) {
+      state.sessionsError = e.message || String(e);
+    } finally {
+      state.sessionBusy = false;
+      state.sessionBusyLabel = "";
+      render();
+      setTimeout(refreshSessions, 400);
+    }
   }
 
   function renderWorkspaces() {
@@ -1516,6 +1717,10 @@
       if (mobileTempTerminal) mobileTempTerminal.open(currentWorkspaceCwd());
       return;
     }
+    if (action === "sessions") {
+      showScreen("sessions");
+      return;
+    }
     if (["terminal", "files", "git", "settings"].includes(action)) showScreen(action);
   }
 
@@ -1819,6 +2024,12 @@
     refresh,
     runAction: runMobileAction,
     showScreen,
+    refreshSessions,
+    updateSessionField,
+    setSessionCreateExpanded,
+    newSession,
+    selectSession,
+    closeSession,
   };
 
   globalThis.HerdrMobileFiles = {

--- a/src/assets/mobile/core.js
+++ b/src/assets/mobile/core.js
@@ -83,5 +83,6 @@
     pathBasename,
     samePath,
     selectionPath,
+    sessionPrefix,
   };
 })();

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -268,6 +268,29 @@ function context(pathname = "/", options = {}) {
             ? fallback
             : value;
       };
+      if (url === "/api/sessions")
+        return {
+          ok: true,
+          status: 200,
+          json: async () =>
+            optionValue("sessionsResponse", {
+              sessions: [
+                { name: "default", backend: "builtin", backend_label: "built-in", running: true },
+                { name: "revolut", backend: "builtin", backend_label: "built-in", running: false },
+              ],
+              herdr_available: true,
+              herdr_compatible: true,
+              herdr_version: "0.9.0",
+              default_backend: "builtin",
+              enabled_backends: { builtin: true, "external-herdr": true },
+            }),
+        };
+      if (url === "/api/session/launch" || url === "/api/session/close")
+        return {
+          ok: true,
+          status: 200,
+          json: async () => optionValue("sessionMutation", { ok: true, pid: 4242 }),
+        };
       const result = url.includes("workspaces")
         ? {
             workspaces: optionValue("workspaces", [
@@ -534,16 +557,82 @@ describe("mobile bundle load", () => {
     // to built-in on refresh is covered elsewhere; here we exercise the badge
     // itself without the sessions-gating (the mock /api/sessions reports no
     // herdr install, so refresh alone would always land on built-in).
+    // The badge also names the active session and opens the sessions screen.
+    match(source, /<button type="button" id="mobileBackendBadge"/);
+    match(source, /badge\.onclick = \(\) => showScreen\("sessions"\)/);
     for (const [storedBackend, label, cls] of [["builtin", "built-in", "backend-builtin"], ["external-herdr", "Herdr", "backend-herdr"]]) {
       const ctx = context("/session/default/workspace/w1");
       ctx.localStorage.setItem("herdr-session-backend", storedBackend);
       vm.runInContext(source, ctx);
       ctx.HerdrMobile.showScreen("home");
       const badge = ctx.document.getElementById("mobileBackendBadge");
-      equal(badge.textContent, label);
+      equal(badge.textContent, `${label} · default`);
       ok(badge.className.includes(cls));
+      ok(typeof badge.onclick === "function");
     }
   });
+
+  it("renders a sessions screen listing known sessions and the active target", async () => {
+    const ctx = context("/session/default");
+    vm.runInContext(source, ctx);
+    ctx.HerdrMobile.showScreen("sessions");
+    await ctx.settle();
+    await ctx.flushTimers();
+    const screen = ctx.document.getElementById("mobileScreen");
+    ok(screen.innerHTML.includes("Sessions"));
+    ok(screen.innerHTML.includes("Current target: default · built-in"));
+    ok(screen.innerHTML.includes("revolut"));
+    ok(screen.innerHTML.includes("New built-in"));
+    // herdr is compatible in the mock, so the Herdr offer is visible.
+    ok(screen.innerHTML.includes("New Herdr"));
+  });
+
+  it("creates a new built-in session from the sessions screen and switches to it", async () => {
+    const ctx = context("/session/default");
+    vm.runInContext(source, ctx);
+    ctx.HerdrMobile.updateSessionField("sessionNameInput", "revolut");
+    await ctx.HerdrMobile.newSession("builtin");
+    const launch = ctx.requests.find((r) => r.url === "/api/session/launch");
+    ok(launch, "session launch request missing");
+    equal(launch.opt.body, JSON.stringify({ session: "revolut", backend: "builtin" }));
+    // The browser target switched: header stamping and route follow.
+    const workspacesRequest = ctx.requests.find((r) => r.url === "/api/workspaces");
+    ok(workspacesRequest, "refresh after switch missing");
+    equal(workspacesRequest.opt.headers["x-herdr-backend"], "builtin");
+    ok(ctx.history.calls.some((c) => c.path === "/session/revolut"));
+  });
+
+  it("switches the browser target when tapping another session row", async () => {
+    const ctx = context("/session/default");
+    vm.runInContext(source, ctx);
+    ctx.HerdrMobile.selectSession("revolut", "builtin");
+    ok(ctx.history.calls.some((c) => c.path === "/session/revolut"));
+    equal(ctx.localStorage.getItem("herdr-session-backend"), "builtin");
+  });
+
+  it("closes the current session from the sessions screen and retargets the default", async () => {
+    const ctx = context("/session/revolut");
+    vm.runInContext(source, ctx);
+    await ctx.HerdrMobile.closeSession();
+    const close = ctx.requests.find((r) => r.url === "/api/session/close");
+    ok(close, "session close request missing");
+    equal(close.opt.body, JSON.stringify({ session: "revolut", backend: "builtin" }));
+    equal(ctx.localStorage.getItem("herdr-session-backend"), "builtin");
+  });
+
+  it("rejects a new session without a name and surfaces the error inline", async () => {
+    const ctx = context("/session/default");
+    vm.runInContext(source, ctx);
+    ctx.HerdrMobile.showScreen("sessions");
+    await ctx.settle();
+    await ctx.flushTimers();
+    ctx.HerdrMobile.updateSessionField("sessionNameInput", "  ");
+    await ctx.HerdrMobile.newSession("builtin");
+    const screen = ctx.document.getElementById("mobileScreen");
+    ok(screen.innerHTML.includes("Session name is required."));
+    ok(!ctx.requests.some((r) => r.url === "/api/session/launch"));
+  });
+
 
 
   it("coalesces mobile event socket refreshes and pauses reconnect while hidden", async () => {

--- a/src/assets/shared/actions.js
+++ b/src/assets/shared/actions.js
@@ -39,7 +39,7 @@
       title: "Manage sessions",
       subtitle: "Switch or launch built-in and Herdr backend sessions",
       text: "session backend manage launch switch",
-      surfaces: ["desktop"],
+      surfaces: ["desktop", "mobile"],
     },
     {
       id: "actions-menu",

--- a/src/main.rs
+++ b/src/main.rs
@@ -8229,6 +8229,159 @@ mod tests {
         let _ = fs::remove_file(socket);
     }
 
+    // The Actions UI stamps the selected session backend on every create
+    // call (x-herdr-backend). Creating a workspace while the browser
+    // targets the built-in backend must proxy workspace.create to the
+    // built-in session socket (auto-started), never to the external
+    // default API socket. The fake external socket below fails the test
+    // if it receives the create request.
+    #[cfg(unix)]
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn create_workspace_with_builtin_header_routes_to_builtin_backend() {
+        let _guard = lock_env();
+        let config_home = std::env::temp_dir().join(format!(
+            "herdr-webui-create-builtin-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("XDG_CONFIG_HOME", &config_home);
+
+        // A fake external-herdr API socket that must stay untouched: if the
+        // create request were misrouted there, the spawned handler would
+        // accept it, reply with an id, and the drop guard below would panic
+        // on join because the request never arrived (or the response would
+        // carry the external marker label).
+        let (external_socket, external_handle) = fake_api_socket_for_method(
+            "workspace.create",
+            json!({ "id": "web:workspace:create", "result": { "id": "external-ws" } }),
+        );
+        let session_name = "create-builtin";
+        let mut state = test_state();
+        state.api_socket = Some(external_socket.clone());
+        // Hold a state clone so the shared builtin session registry (and
+        // with it the started backend handle) outlives the oneshot request.
+        let app = test_app_with_state(state.clone());
+
+        let cwd = std::env::temp_dir();
+        let response = app
+            .oneshot(
+                authed_request(Method::POST, "/api/workspaces")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header("x-herdr-backend", "builtin")
+                    .header("x-herdr-session", session_name)
+                    .body(Body::from(
+                        json!({ "cwd": cwd.to_string_lossy(), "label": "routing-test" })
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        // The built-in backend answers workspace.create with a workspace
+        // result (id starts with ws_ / has workspace fields), and definitely
+        // not the external fake marker.
+        let result = body["result"].clone();
+        assert!(
+            result.get("id").and_then(Value::as_str) != Some("external-ws"),
+            "create leaked to the external backend socket: {result}"
+        );
+        // The built-in backend answers workspace.create with a workspace
+        // result: a workspace object (or workspace_id field) is present.
+        let created_id = result
+            .get("workspace")
+            .and_then(|workspace| workspace.get("workspace_id"))
+            .or_else(|| result.get("workspace_id"))
+            .or_else(|| result.get("id"));
+        assert!(
+            created_id.is_some(),
+            "built-in backend did not return a workspace result: {result}"
+        );
+        // The built-in session must be running for the answered session.
+        let (builtin_api, _) = builtin_socket_paths(Some(session_name));
+        assert!(connect_local_stream(&builtin_api).is_ok());
+
+        let _ = fs::remove_dir_all(&config_home);
+        let _ = fs::remove_file(&external_socket);
+        drop(external_handle);
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
+    // Mirrors the above for worktree creation: the Actions UI worktree
+    // create flow also routes through the selected session backend.
+    #[cfg(unix)]
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn create_worktree_with_builtin_header_routes_to_builtin_backend() {
+        let _guard = lock_env();
+        let config_home = std::env::temp_dir().join(format!(
+            "herdr-wt-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("XDG_CONFIG_HOME", &config_home);
+
+        // The worktree create handler performs git checks locally, then
+        // proxies the create to the backend. A request without branch/path
+        // is rejected early by the built-in backend, but the key assertion
+        // is which socket the proxy talks to: seed the external fake socket
+        // with a marker reply; if the request lands there, the response
+        // leaks the marker.
+        let (external_socket, external_handle) = fake_api_socket_for_method(
+            "worktree.create",
+            json!({ "id": "web:worktree:create", "result": { "id": "external-wt" } }),
+        );
+        let session_name = "wt1";
+        let mut state = test_state();
+        state.api_socket = Some(external_socket.clone());
+        // Hold a state clone so the started built-in backend outlives the
+        // oneshot request (the router is consumed and dropped after it).
+        let app = test_app_with_state(state.clone());
+
+        let cwd = std::env::temp_dir().join("herdr-webui-wt-src");
+        let _ = fs::create_dir_all(&cwd);
+        let response = app
+            .oneshot(
+                authed_request(Method::POST, "/api/worktrees")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header("x-herdr-backend", "builtin")
+                    .header("x-herdr-session", session_name)
+                    .body(Body::from(
+                        json!({ "cwd": cwd.to_string_lossy(), "path": "", "branch": "" })
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = response_json(response).await;
+        // Either the built-in backend rejected the empty worktree (fine)
+        // or it answered; in both cases the external fake marker must be
+        // absent from the response.
+        let body_text = body.to_string();
+        assert!(
+            !body_text.contains("external-wt"),
+            "worktree create leaked to the external backend socket: {body_text}"
+        );
+        let (builtin_api, _) = builtin_socket_paths(Some(session_name));
+        assert!(
+            connect_local_stream(&builtin_api).is_ok(),
+            "built-in session socket missing after worktree create; body: {body_text}; socket: {}",
+            builtin_api.display()
+        );
+
+        let _ = fs::remove_dir_all(&config_home);
+        let _ = fs::remove_file(&external_socket);
+        drop(external_handle);
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn rename_workspace_handler_proxies_rename() {


### PR DESCRIPTION
## What

Three related fixes from the session-management audit:

1. **Session manager does not switch/close (desktop)** - "New built-in" launched the session and switched the footer/route, but the session manager modal stayed open over the fresh session, which read as "not switching". `goSession` now hides the manager when the switch is the goal (row clicks, new-session flows); close-session and herdr_error-declined flows keep it open for their message. The accepted herdr_error built-in fallback also closes it after launch.

2. **Mobile parity** - Mobile had no session manager at all. New Sessions screen: tappable header backend badge, More card, actions-registry entry (both surfaces), session list with backend pills/running state, tap-to-switch rows, New built-in / New Herdr create flow with desktop-identical gating, close+retarget flow. `switchSession` mirrors desktop `goSession` (route, pin, reset, events cycle, refresh). Init `/api/sessions` fetch extracted to `loadSessions()` shared by both flows.

3. **Actions UI backend routing proof** - Confirmed all creation surfaces stamp `x-herdr-session` + `x-herdr-backend` and the server routes creates through `api_for_headers_ensured`. Added two Rust handler tests (workspace + worktree create with builtin header must hit the auto-started builtin socket, never the external default marker socket) and an e2e header-capture check (CDP `Network.requestWillBeSent` -> POST `/api/workspaces` carries the pinned backend).

## Repro of the desktop bug

CDP probe against a live server: footer switched to "revolut - built-in", route `/session/revolut`, session running - but `sessionManager` display stayed `block` with stale "Launched built-in session." text.

## Validation

- 516 Rust tests pass (514 + 2 new routing tests)
- 470 JS tests pass (462 + 8 new: 3 desktop manager-close, 5 mobile sessions)
- e2e 58/58 (26 before + session-ux suite + new header-capture check)
- `cargo fmt --check` clean, clippy baseline unchanged (9 pre-existing dead-code warnings)
- Live probe re-run after fix: manager closes, switch lands in the session

## Notes

- v0.4.22 released and installed locally first (protocol 22 builtin fix live on :8787).
- The mobile badge is now a `<button>` (was a span) - tests updated.
- Harness detail: `goSession` re-reads the URL via its own `parseRoute()`, and the test harness `pushState` is a no-op, so tests mirror the post-switch URL before invoking the flow.