### PR TITLE
Add settings confirm and rollback UX across desktop and mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 zigbin/
 .e2e-*.log
 target-llvm
+.e2e-chrome-profile

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,6 +17,9 @@ Settings:
 
 - The Settings modal includes a `Search settings` field in the header.
 - Settings search filters grouped settings sections and individual option rows locally in the browser.
+- Text-like settings (terminal font, directories, numeric fields) only save after pressing Enter in the field or clicking the yellow pencil button. While the on-screen value differs from the saved one, the row shows the pencil (hover: "Enter or press to confirm") together with a rollback arrow that restores the saved value.
+- Selects, checkboxes, tick menus, and range sliders apply immediately on change and show the rollback arrow while the saved value differs from the value saved when Settings was opened. Clicking the arrow restores that baseline.
+- Mobile Settings bakes the same rollback affordance into each row as a `↺` chip whenever the saved value drifted from its baseline, and tapping it restores the baseline value.
 - `Worktree default directory` is stored in browser `localStorage` as `worktreeDefaultDirectory`. It is used only as the base for generated worktree checkout paths. Relative values resolve from the source repo root, for example `../worktrees`.
 - `Exploration default directory` is stored in browser `localStorage` as `explorationDefaultDirectory`. It prefills desktop new/open workspace paths, desktop worktree discovery paths, desktop Git cleanup scan roots, Git directory picker roots, and mobile worktree discovery paths. It also drives the desktop directory picker's `Default dir` button and the Files drawer/file explorer when no workspace is selected, taking precedence over the server `default_folder` setting.
 - The notification volume setting is stored in browser `localStorage` as `notificationVolume`, a decimal gain from `0` to `1`. Desktop and mobile expose it as a 0-100 slider and default it to `0.24`.

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -131,3 +131,37 @@ Chrome, emulates `prefers-color-scheme` flips, and drives the real UI:
 | `CDP_PORT`  | `9222`  | Chrome remote debugging port         |
 
 Run it locally; it is also kept as a pre-merge manual gate (not in CI).
+
+## Settings confirm/rollback acceptance
+
+`scripts/e2e/settings-confirm-acceptance.mjs` (desktop) and
+`scripts/e2e/settings-confirm-mobile-acceptance.mjs` (mobile) cover the
+settings confirm/rollback UX in a real browser over CDP. They expect an
+isolated server and headless Chrome already up (same stack as
+`run-e2e.sh` steps 1-4, or point `E2E_BASE_URL` at your own server and
+`CDP_PORT` at the debugging port).
+
+Desktop script verifies on the served app:
+
+- editing a text-like setting (exploration dir) without confirming does
+  NOT touch the saved options, and the row shows the pending outline,
+  yellow pencil ("Enter or press to confirm"), and rollback arrow
+- Enter commits: value saved, chrome hidden, row outline cleared
+- the pencil click commits the same way
+- the rollback arrow restores the open-time baseline without saving it
+  (a subsequent Enter still saves the restored text)
+- selects (agent sorting) save immediately and show only the rollback
+  arrow; rolling back restores the baseline and persists the restore
+- the notification-volume range saves immediately and its rollback
+  restores the open-time baseline
+- reopening Settings re-reads baselines: freshly saved values show no
+  chrome, and rollback targets the latest open-time baseline, not a
+  stale first-visit one
+
+Mobile script forces the mobile layout via device metrics emulation and
+verifies:
+
+- no rollback chip before any change
+- a change shows the ↺ chip and persists immediately
+- tapping the chip restores the baseline value and clears the chip
+- re-entering Settings re-captures the open-time baseline

--- a/scripts/e2e/settings-confirm-acceptance.mjs
+++ b/scripts/e2e/settings-confirm-acceptance.mjs
@@ -1,0 +1,282 @@
+// Real-browser acceptance checks for the settings confirm/rollback UX.
+// Drives the actually-served desktop app end to end:
+//   1. Open Settings, edit a text-like setting (exploration dir) without
+//      confirming: localStorage must NOT change, pencil + rollback visible.
+//   2. Press Enter: value saves, pencil/rollback hide, Applied badge flashes.
+//   3. Edit again and click the pencil: same result.
+//   4. Edit again and click the rollback arrow: baseline restored, not saved.
+//   5. Change a select (agent sorting): saves immediately, rollback arrow
+//      visible, arrow click restores baseline value and persists it.
+//   6. Notification volume slider: saves immediately, rollback restores.
+import { connectToPage } from './cdp-driver.mjs';
+
+const URL = process.env.E2E_BASE_URL || 'https://127.0.0.1:8892/';
+const results = [];
+function check(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ' :: ' + detail : ''}`);
+}
+
+const cdp = await connectToPage();
+await cdp.send('Page.enable');
+await cdp.send('Network.enable');
+await cdp.send('Security.enable');
+await cdp.send('Security.setIgnoreCertificateErrors', { ignore: true });
+// A previous run on this target (e.g. the mobile acceptance) may have
+// left a device metrics override active, and the bare headless window can
+// be narrower than the app's 760px mobile breakpoint. Pin a desktop-sized
+// viewport so the desktop layout (and settingsModal) always renders.
+await cdp
+  .send('Emulation.setDeviceMetricsOverride', {
+    width: 1440,
+    height: 900,
+    deviceScaleFactor: 1,
+    mobile: false,
+  })
+  .catch(() => {});
+await cdp.send('Page.navigate', { url: URL });
+await new Promise((r) => setTimeout(r, 2500));
+
+let title = await cdp.evalExpr('document.title');
+if (!title || /privacy|127\.0\.0\.1|localhost/i.test(String(title))) {
+  // The cert interstitial blocks page-level navigation (CSP), so retry
+  // via a CDP navigate; the bypass cert flag applies from the second load.
+  await cdp.send('Page.navigate', { url: URL });
+  await new Promise((r) => setTimeout(r, 2500));
+  title = await cdp.evalExpr('document.title');
+}
+check('app loads', !!title && !/privacy|127\.0\.0\.1|localhost/i.test(String(title)), `title=${title}`);
+
+// Wait for the app to be wired, then open the settings modal the same way
+// the settingsToggle click handler does. The modal is rendered by the app
+// shell during boot, so poll until it exists.
+async function waitFor(expr, tries = 40) {
+  for (let i = 0; i < tries; i++) {
+    const value = await cdp.evalExpr(expr);
+    if (value) return value;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return null;
+}
+const modalReady = await waitFor('document.getElementById("settingsModal") ? "ready" : ""');
+check('settings modal exists after boot', modalReady === 'ready', `modal=${modalReady}`);
+await cdp.evalExpr('(function(){const m=document.getElementById("settingsModal");m.style.display="grid";if(typeof prepareSettingsModalOpen==="function")prepareSettingsModalOpen();})()');
+await new Promise((r) => setTimeout(r, 500));
+let modalVisible = await cdp.evalExpr(
+  'document.getElementById("settingsModal").style.display',
+);
+check('settings modal opens', modalVisible === 'grid', `display=${modalVisible}`);
+
+async function savedOptions() {
+  return JSON.parse(
+    await cdp.evalExpr(
+      '(window.HerdrOptions ? JSON.stringify(window.HerdrOptions.read()) : localStorage.getItem("herdr-web-options"))',
+    ),
+  );
+}
+
+function visible(id) {
+  return cdp.evalExpr(
+    `(function(){const el=document.getElementById(${JSON.stringify(id)});if(!el)return null;const cs=getComputedStyle(el);return cs.display==="none"||cs.visibility==="hidden"?"hidden":"visible";})()`,
+  );
+}
+
+// --- 1. Text-like edit without confirm must NOT save.
+const before = await savedOptions();
+await cdp.evalExpr(
+  '(function(){const el=document.getElementById("optExplorationDefaultDirectory");el.focus();el.value="~/e2e-pending";el.dispatchEvent(new Event("input",{bubbles:true}));})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+const pendingSaved = await savedOptions();
+check(
+  'text edit does not save until confirm',
+  pendingSaved.explorationDefaultDirectory === before.explorationDefaultDirectory,
+  `saved=${pendingSaved.explorationDefaultDirectory}`,
+);
+const pencilVisible = await visible('confirmPencil');
+const rowPending = await cdp.evalExpr(
+  '(function(){const el=document.getElementById("optExplorationDefaultDirectory");const row=el.closest(".option");return row.className;})()',
+);
+check(
+  'row marked pending with chrome',
+  String(rowPending).includes('settings-pending'),
+  `rowClass=${rowPending}`,
+);
+
+// Pencil and rollback live inside the row (no ids), query by class.
+const chromeCount = await cdp.evalExpr(
+  '(function(){const row=document.getElementById("optExplorationDefaultDirectory").closest(".option");const p=row.querySelector(".settings-confirm-pencil");const rb=row.querySelector(".settings-rollback");return {pencil:p?(p.style.display==="none"?"hidden":"visible"):"missing",rollback:rb?(rb.style.display==="none"?"hidden":"visible"):"missing",pencilTitle:p?p.title:""};})()',
+);
+check('pencil visible while pending', chromeCount.pencil === 'visible', JSON.stringify(chromeCount));
+check('rollback visible while pending', chromeCount.rollback === 'visible');
+check(
+  'pencil hover hint',
+  chromeCount.pencilTitle === 'Enter or press to confirm',
+  `title=${chromeCount.pencilTitle}`,
+);
+
+// --- 2. Enter commits.
+await cdp.evalExpr(
+  '(function(){const el=document.getElementById("optExplorationDefaultDirectory");el.dispatchEvent(new KeyboardEvent("keydown",{key:"Enter",bubbles:true}));})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+const afterEnter = await savedOptions();
+check(
+  'Enter commits the text setting',
+  afterEnter.explorationDefaultDirectory === '~/e2e-pending',
+  `saved=${afterEnter.explorationDefaultDirectory}`,
+);
+const chromeAfterCommit = await cdp.evalExpr(
+  '(function(){const row=document.getElementById("optExplorationDefaultDirectory").closest(".option");const p=row.querySelector(".settings-confirm-pencil");const rb=row.querySelector(".settings-rollback");return {pencil:p?p.style.display:"none",rollback:rb?rb.style.display:"none",pending:row.className};})()',
+);
+check(
+  'chrome hidden after commit',
+  chromeAfterCommit.pencil === 'none' && chromeAfterCommit.rollback === 'none',
+  JSON.stringify(chromeAfterCommit),
+);
+
+// --- 3. Edit again and click the pencil button.
+await cdp.evalExpr(
+  '(function(){const el=document.getElementById("optExplorationDefaultDirectory");el.value="~/e2e-pencil";el.dispatchEvent(new Event("input",{bubbles:true}));})()',
+);
+await new Promise((r) => setTimeout(r, 200));
+await cdp.evalExpr(
+  '(function(){const row=document.getElementById("optExplorationDefaultDirectory").closest(".option");row.querySelector(".settings-confirm-pencil").click();})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+const afterPencil = await savedOptions();
+check(
+  'pencil click commits',
+  afterPencil.explorationDefaultDirectory === '~/e2e-pencil',
+  `saved=${afterPencil.explorationDefaultDirectory}`,
+);
+
+// --- 4. Edit and roll back without saving.
+await cdp.evalExpr(
+  '(function(){const el=document.getElementById("optExplorationDefaultDirectory");el.value="~/e2e-rolled";el.dispatchEvent(new Event("input",{bubbles:true}));})()',
+);
+await new Promise((r) => setTimeout(r, 200));
+await cdp.evalExpr(
+  '(function(){const row=document.getElementById("optExplorationDefaultDirectory").closest(".option");row.querySelector(".settings-rollback").click();})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+const afterRollback = await savedOptions();
+const inputAfterRollback = await cdp.evalExpr(
+  'document.getElementById("optExplorationDefaultDirectory").value',
+);
+check(
+  'rollback restores baseline value',
+  inputAfterRollback === afterPencil.explorationDefaultDirectory,
+  `input=${inputAfterRollback}`,
+);
+check(
+  'rollback leaves saved options untouched',
+  afterRollback.explorationDefaultDirectory === afterPencil.explorationDefaultDirectory,
+  `saved=${afterRollback.explorationDefaultDirectory}`,
+);
+
+// --- 5. Select applies immediately; rollback restores baseline.
+const selectBefore = await savedOptions();
+const agentBaseline = selectBefore.agentSortMode || 'off';
+await cdp.evalExpr(
+  '(function(){const el=document.getElementById("optAgentSortMode");el.value="attention";el.dispatchEvent(new Event("change",{bubbles:true}));})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+const selectAfter = await savedOptions();
+check(
+  'select saves immediately',
+  selectAfter.agentSortMode === 'attention',
+  `saved=${selectAfter.agentSortMode}`,
+);
+const selectChrome = await cdp.evalExpr(
+  '(function(){const row=document.getElementById("optAgentSortMode").closest(".option");const p=row.querySelector(".settings-confirm-pencil");const rb=row.querySelector(".settings-rollback");return {pencil:!!p,rollback:rb?rb.style.display:"none"};})()',
+);
+check(
+  'select row shows rollback arrow only',
+  !selectChrome.pencil && selectChrome.rollback !== 'none',
+  JSON.stringify(selectChrome),
+);
+await cdp.evalExpr(
+  '(function(){const row=document.getElementById("optAgentSortMode").closest(".option");row.querySelector(".settings-rollback").click();})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+const selectRolled = await savedOptions();
+const selectValue = await cdp.evalExpr(
+  'document.getElementById("optAgentSortMode").value',
+);
+check(
+  'select rollback restores baseline and persists it',
+  selectRolled.agentSortMode === agentBaseline && selectValue === agentBaseline,
+  `saved=${selectRolled.agentSortMode} value=${selectValue}`,
+);
+
+// --- 6. Range slider saves immediately; rollback restores baseline.
+const volBefore = await savedOptions();
+const volBaseline = typeof volBefore.notificationVolume === 'number' ? volBefore.notificationVolume : 0.24;
+await cdp.evalExpr(
+  '(function(){const el=document.getElementById("optNotificationVolume");el.value=90;el.dispatchEvent(new Event("input",{bubbles:true}));})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+const volAfter = await savedOptions();
+check('range slider saves immediately', Math.abs(volAfter.notificationVolume - 0.9) < 0.001, `saved=${volAfter.notificationVolume}`);
+await cdp.evalExpr(
+  '(function(){const row=document.getElementById("optNotificationVolume").closest(".option");const rb=row.querySelector(".settings-rollback");if(rb)rb.click();})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+const volRolled = await savedOptions();
+const volValue = await cdp.evalExpr(
+  'document.getElementById("optNotificationVolume").value',
+);
+check(
+  'range rollback restores baseline',
+  Math.abs(volRolled.notificationVolume - volBaseline) < 0.001 &&
+    String(Math.round(volBaseline * 100)) === String(volValue),
+  `saved=${volRolled.notificationVolume} value=${volValue} baseline=${volBaseline}`,
+);
+
+// --- 7. Reopening Settings re-reads open-time baselines.
+// Commit a select change so the saved value moves, close the modal, reopen:
+// the rollback arrow must NOT appear for the newly saved value, and a later
+// rollback must restore the latest open-time baseline, not a stale one.
+await cdp.evalExpr(
+  '(function(){const s=document.getElementById("optAgentSortMode");s.value="attention_inverted";s.dispatchEvent(new Event("change",{bubbles:true}));})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+await cdp.evalExpr(
+  '(function(){document.getElementById("settingsModal").style.display="none";const m=document.getElementById("settingsModal");m.style.display="grid";if(typeof prepareSettingsModalOpen==="function")prepareSettingsModalOpen();})()',
+);
+await new Promise((r) => setTimeout(r, 500));
+const reopenChrome = JSON.parse(
+  await cdp.evalExpr(
+    '(function(){const row=document.getElementById("optAgentSortMode").closest(".option");const rb=row.querySelector(".settings-rollback");return JSON.stringify({visible: rb ? String(rb.style.display||"")!=="none" : false, pending: row.className.includes("settings-pending")});})()',
+  ),
+);
+check(
+  'reopen clears chrome for freshly saved value',
+  reopenChrome.visible === false && reopenChrome.pending === false,
+  JSON.stringify(reopenChrome),
+);
+// Change to another value, roll back: restore must target the latest
+// open-time baseline (attention_inverted), not the very first one (off).
+await cdp.evalExpr(
+  '(function(){const s=document.getElementById("optAgentSortMode");s.value="attention";s.dispatchEvent(new Event("change",{bubbles:true}));})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+await cdp.evalExpr(
+  '(function(){const row=document.getElementById("optAgentSortMode").closest(".option");const rb=row.querySelector(".settings-rollback");if(rb)rb.click();})()',
+);
+await new Promise((r) => setTimeout(r, 300));
+const reopenSaved = await savedOptions();
+const reopenValue = await cdp.evalExpr(
+  'document.getElementById("optAgentSortMode").value',
+);
+check(
+  'rollback after reopen restores latest open-time baseline',
+  reopenSaved.agentSortMode === 'attention_inverted' &&
+    reopenValue === 'attention_inverted',
+  `saved=${reopenSaved.agentSortMode} value=${reopenValue}`,
+);
+
+const failed = results.filter((item) => !item.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+if (failed.length) process.exit(1);

--- a/scripts/e2e/settings-confirm-mobile-acceptance.mjs
+++ b/scripts/e2e/settings-confirm-mobile-acceptance.mjs
@@ -1,0 +1,100 @@
+// Real-browser acceptance for the mobile settings rollback chips.
+import { connectToPage } from './cdp-driver.mjs';
+
+const URL = process.env.E2E_BASE_URL || 'https://127.0.0.1:8892/';
+const results = [];
+function check(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ' :: ' + detail : ''}`);
+}
+
+const cdp = await connectToPage();
+await cdp.send('Page.enable');
+await cdp.send('Network.enable');
+await cdp.send('Security.enable');
+await cdp.send('Security.setIgnoreCertificateErrors', { ignore: true });
+// Narrow viewport makes app_boot resolve the mobile layout automatically.
+await cdp.send('Emulation.setDeviceMetricsOverride', {
+  width: 390,
+  height: 844,
+  deviceScaleFactor: 2,
+  mobile: true,
+});
+await cdp.send('Page.navigate', { url: URL });
+await new Promise((r) => setTimeout(r, 2500));
+let title = await cdp.evalExpr('document.title');
+if (!title || /privacy|127\.0\.0\.1|localhost/i.test(String(title))) {
+  // The cert interstitial blocks page-level navigation (CSP), so retry
+  // via a CDP navigate.
+  await cdp.send('Page.navigate', { url: URL });
+  await new Promise((r) => setTimeout(r, 2500));
+  title = await cdp.evalExpr('document.title');
+}
+if (/privacy|127\.0\.0\.1|localhost/i.test(String(title))) {
+  // One more nudge: some Chrome builds need a second same-origin load.
+  await cdp.send('Page.navigate', { url: URL });
+  await new Promise((r) => setTimeout(r, 2500));
+  title = await cdp.evalExpr('document.title');
+}
+await new Promise((r) => setTimeout(r, 1000));
+
+const layout = await cdp.evalExpr('document.documentElement.dataset.herdrLayout');
+check('mobile layout loads', layout === 'mobile', `layout=${layout} title=${title}`);
+
+await cdp.evalExpr('HerdrMobile.showScreen("settings")');
+await new Promise((r) => setTimeout(r, 400));
+let html = await cdp.evalExpr('document.getElementById("mobileScreen").innerHTML');
+check(
+  'no rollback chip before changes',
+  !html.includes('data-rollback-id="worktreeDefaultDirectory"'),
+);
+
+await cdp.evalExpr('HerdrMobile.setWorktreeDefaultDirectory("/tmp/scu-e2e")');
+await new Promise((r) => setTimeout(r, 400));
+html = await cdp.evalExpr('document.getElementById("mobileScreen").innerHTML');
+check(
+  'rollback chip appears after change',
+  html.includes('data-rollback-id="worktreeDefaultDirectory"'),
+);
+const saved = JSON.parse(
+  await cdp.evalExpr('localStorage.getItem("herdr-web-options")'),
+);
+check('mobile change persisted', saved.worktreeDefaultDirectory === '/tmp/scu-e2e');
+
+await cdp.evalExpr('HerdrMobile.rollbackSetting("worktreeDefaultDirectory")');
+await new Promise((r) => setTimeout(r, 400));
+html = await cdp.evalExpr('document.getElementById("mobileScreen").innerHTML');
+check(
+  'chip cleared after rollback',
+  !html.includes('data-rollback-id="worktreeDefaultDirectory"'),
+);
+const savedAfter = JSON.parse(
+  await cdp.evalExpr('localStorage.getItem("herdr-web-options")'),
+);
+check('mobile rollback restored baseline', savedAfter.worktreeDefaultDirectory === '');
+
+// Re-entering Settings must re-capture the open-time baseline: after
+// navigating away and back, a change rolls back to the fresh snapshot.
+await cdp.evalExpr('HerdrMobile.showScreen("home")');
+await cdp.evalExpr('HerdrMobile.showScreen("settings")');
+await new Promise((r) => setTimeout(r, 400));
+await cdp.evalExpr('HerdrMobile.setWorktreeDefaultDirectory("/tmp/scu-reentry")');
+await new Promise((r) => setTimeout(r, 400));
+await cdp.evalExpr('HerdrMobile.rollbackSetting("worktreeDefaultDirectory")');
+await new Promise((r) => setTimeout(r, 400));
+const savedReentry = JSON.parse(
+  await cdp.evalExpr('localStorage.getItem("herdr-web-options")'),
+);
+check(
+  're-entry rollback restores fresh baseline',
+  savedReentry.worktreeDefaultDirectory === '',
+  `saved=${savedReentry.worktreeDefaultDirectory}`,
+);
+
+// Cleanup: restore auto layout and clear the device emulation for later
+// checks on the same target.
+await cdp.evalExpr('localStorage.setItem("herdr-web-layout", "auto")');
+await cdp.send('Emulation.clearDeviceMetricsOverride');
+const failed = results.filter((item) => !item.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+if (failed.length) process.exit(1);

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -20,6 +20,7 @@ const SHARED_FILE_CONTENT_SEARCH_JS: &str = include_str!("assets/shared/file_con
 const SHARED_LINE_CONTEXT_JS: &str = include_str!("assets/shared/line_context.js");
 const SHARED_WORKSPACE_SEARCH_JS: &str = include_str!("assets/shared/workspace_search.js");
 const SHARED_SETTINGS_FEEDBACK_JS: &str = include_str!("assets/shared/settings_feedback.js");
+const SHARED_SETTINGS_CONFIRM_JS: &str = include_str!("assets/shared/settings_confirm.js");
 const SHARED_EDITOR_JS: &str = include_str!("assets/shared/editor.js");
 const SHARED_LSP_JS: &str = include_str!("assets/shared/lsp.js");
 const SHARED_MARKDOWN_PREVIEW_JS: &str = include_str!("assets/shared/markdown_preview.js");
@@ -213,6 +214,13 @@ pub(crate) async fn shared_workspace_search_js() -> Response {
 pub(crate) async fn shared_settings_feedback_js() -> Response {
     static_text(
         SHARED_SETTINGS_FEEDBACK_JS,
+        "application/javascript; charset=utf-8",
+    )
+}
+
+pub(crate) async fn shared_settings_confirm_js() -> Response {
+    static_text(
+        SHARED_SETTINGS_CONFIRM_JS,
         "application/javascript; charset=utf-8",
     )
 }

--- a/src/assets/app_boot.js
+++ b/src/assets/app_boot.js
@@ -76,6 +76,7 @@
       "/assets/shared/file-content-search.js",
       "/assets/shared/workspace-search.js",
       "/assets/shared/settings-feedback.js",
+      "/assets/shared/settings-confirm.js",
       "/assets/vendor/codemirror.js",
       "/assets/vendor/wterm.js",
       "/assets/shared/markdown-preview.js",

--- a/src/assets/app_boot.test.mjs
+++ b/src/assets/app_boot.test.mjs
@@ -27,6 +27,7 @@ const SHARED_SCRIPTS = [
   "/assets/shared/file-content-search.js",
   "/assets/shared/workspace-search.js",
   "/assets/shared/settings-feedback.js",
+  "/assets/shared/settings-confirm.js",
   "/assets/vendor/codemirror.js",
   "/assets/vendor/wterm.js",
   "/assets/shared/markdown-preview.js",

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -3676,9 +3676,9 @@ describe("app bundle load", () => {
     equal(ctx.document.getElementById("workspaceCreatePath").value, "/tmp/default");
 
     ctx.document.getElementById("optWorktreeDefaultDirectory").value = "/tmp/worktrees";
-    ctx.document.getElementById("optWorktreeDefaultDirectory").oninput();
+    ctx.HerdrSettingsCommit.commit("optWorktreeDefaultDirectory");
     ctx.document.getElementById("optExplorationDefaultDirectory").value = "/tmp/code";
-    ctx.document.getElementById("optExplorationDefaultDirectory").oninput();
+    ctx.HerdrSettingsCommit.commit("optExplorationDefaultDirectory");
     ctx.openWorkspaceCreateModal();
     equal(ctx.document.getElementById("workspaceCreatePath").value, "/tmp/code");
 
@@ -4062,8 +4062,36 @@ describe("app bundle load", () => {
     match(fileBrowserSource, /function editorOptions\(\)/);
     match(source, /title: "Editor",\n\s+desc: "Editing behavior, readability, and performance controls\./);
     match(source, /optEditorEnabled.*optEditorWordWrap.*optEditorTabSize/);
-    match(source, /el\("optEditorTabSize"\)\.onchange/);
+    match(source, /registerSettingsCommit\("optEditorTabSize"/);
     ok(!source.includes('el("optEditorTabSize").oninput'));
+    ok(!source.includes('el("optEditorTabSize").onchange'), "tab size saves only on Enter or pencil");
+  });
+
+  it("wires settings confirm chrome across local option rows", () => {
+    // Shared module is loaded before the desktop bundle and drives the
+    // pencil/rollback affordances.
+    match(source, /window\.HerdrSettingsConfirm\s*\?\s*\n?\s*window\.HerdrSettingsConfirm\.create/);
+    // Text-like rows commit through registered committers instead of
+    // saving on every keystroke.
+    match(source, /registerSettingsCommit\("optTerminalFontFamily"/);
+    match(source, /registerSettingsCommit\("optWorktreeDefaultDirectory"/);
+    match(source, /registerSettingsCommit\("optExplorationDefaultDirectory"/);
+    ok(!source.includes('el("optExplorationDefaultDirectory").oninput'));
+    ok(!source.includes('el("optWorktreeDefaultDirectory").oninput'));
+    // Rows are watched when the settings modal opens, and Enter commits.
+    match(source, /watchSettingsConfirmRows\(\);\s*\n\s*const input = el\("settingsSearch"\)/);
+    match(source, /window\.HerdrSettingsCommit = \{/);
+    // Reopening Settings must re-read baselines so rollback targets the
+    // value saved at the latest open, not the first-ever visit.
+    match(source, /settingsConfirm\.refreshAll\(\)/);
+    // Immediate-commit selects keep their change handlers and gain the
+    // rollback arrow through the module.
+    match(source, /el\("optTerminalCore"\)/);
+    ok(
+      source.includes('el("optTerminalCore").onchange') ||
+        source.includes("optTerminalCore.onchange"),
+      "terminal core select still saves immediately",
+    );
   });
 
   it("configures CodeMirror extensions without forcing expensive features", () => {

--- a/src/assets/desktop/app_css/modals.css
+++ b/src/assets/desktop/app_css/modals.css
@@ -460,3 +460,30 @@
   content: "✓ ";
   font-weight: 800;
 }
+/* Settings confirm pencil + rollback chrome. Text-like inputs show the
+   yellow pencil while their on-screen value differs from the saved one;
+   selects and checkboxes show only the rollback arrow. */
+.settings-confirm-pencil,
+.settings-rollback {
+  align-self: center;
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1;
+  margin-left: 6px;
+  padding: 2px 6px;
+}
+.settings-confirm-pencil {
+  color: #f9e2af;
+}
+.settings-confirm-pencil:hover,
+.settings-rollback:hover {
+  filter: brightness(1.3);
+}
+.settings-pending > input,
+.settings-pending > select {
+  outline: 1px dashed #f9e2af;
+  outline-offset: 1px;
+}

--- a/src/assets/desktop/app_js/bindings.js
+++ b/src/assets/desktop/app_js/bindings.js
@@ -139,7 +139,6 @@ el("optShiftEnterNewline").onchange = () => {
   saveOptions();
   applyOptions();
 };
-el("optCloseShortcut").oninput = saveCloseShortcutOption;
 el("optCloseShortcut").onchange = saveCloseShortcutOption;
 el("optGlobalShortcutsEnabled").onchange = () => {
   options.globalShortcutsEnabled = el("optGlobalShortcutsEnabled").checked;
@@ -165,12 +164,15 @@ el("optGlobalShortcutPrefixCapture").onclick = () => {
   };
   window.addEventListener("keydown", capture, { once: true, capture: true });
 };
-el("optTerminalFontFamily").oninput = () => {
+// Text-like settings only save on Enter or the yellow pencil confirm
+// button (settings_confirm chrome). oninput just repaints pending state.
+function commitTerminalFontFamily() {
   options.terminalFontFamily = el("optTerminalFontFamily").value;
   saveOptions();
   applyTerminalFont();
   fitTerminalShell();
-};
+}
+registerSettingsCommit("optTerminalFontFamily", commitTerminalFontFamily, () => options.terminalFontFamily || "");
 const optTerminalCore = el("optTerminalCore");
 if (optTerminalCore)
   optTerminalCore.onchange = () => {
@@ -188,10 +190,11 @@ el("optTerminalMouseReporting").onchange = () => {
   options.terminalMouseReporting = el("optTerminalMouseReporting").checked;
   saveOptions();
 };
-el("optTempTerminalLabelMaxChars").oninput = () => {
+function commitTempTerminalLabelMaxChars() {
   options.tempTerminalLabelMaxChars = Math.max(4, Math.min(80, Number(el("optTempTerminalLabelMaxChars").value) || 20));
   saveOptions();
-};
+}
+registerSettingsCommit("optTempTerminalLabelMaxChars", commitTempTerminalLabelMaxChars, () => options.tempTerminalLabelMaxChars);
 el("optAgentSortMode").onchange = () => {
   options.agentSortMode = el("optAgentSortMode").value;
   if (options.agentSortMode === "attention_inverted")
@@ -201,10 +204,9 @@ el("optAgentSortMode").onchange = () => {
   render();
 };
 const optSidebarWorkspacePercent = el("optSidebarWorkspacePercent");
-if (optSidebarWorkspacePercent)
-  optSidebarWorkspacePercent.oninput = () => {
-    setSidebarWorkspacePercent(optSidebarWorkspacePercent.value);
-  };
+registerSettingsCommit("optSidebarWorkspacePercent", () => {
+  setSidebarWorkspacePercent(el("optSidebarWorkspacePercent").value);
+}, () => options.sidebarWorkspacePercent);
 const sidebarSplitHandle = el("sidebarSplitHandle");
 if (sidebarSplitHandle) {
   let pendingSidebarWorkspacePercent = null;
@@ -255,7 +257,7 @@ el("optStuckWorkingEnabled").onchange = () => {
   applyOptions();
   render();
 };
-el("optWorkingDismissMinutes").oninput = () => {
+function commitWorkingDismissMinutes() {
   options.workingDismissMinutes = Math.max(
     1,
     Math.min(1440, Number(el("optWorkingDismissMinutes").value) || 30),
@@ -263,7 +265,8 @@ el("optWorkingDismissMinutes").oninput = () => {
   saveOptions();
   applyOptions();
   render();
-};
+}
+registerSettingsCommit("optWorkingDismissMinutes", commitWorkingDismissMinutes, () => options.workingDismissMinutes);
 el("optShowTabActivity").onchange = () => {
   options.showTabActivity = el("optShowTabActivity").checked;
   saveOptions();
@@ -298,19 +301,22 @@ if (optNotificationVolume)
     applyOptions();
   };
 el("optScrollLines").oninput = () => {
-  options.scrollLines = Math.max(
-    1,
-    Math.min(20, Number(el("optScrollLines").value) || 3),
-  );
+  options.scrollLines = Math.max(1, Math.min(20, Number(el("optScrollLines").value) || 3));
   saveOptions();
   applyOptions();
 };
-el("optTreeIndentPx").oninput = () => {
+registerSettingsCommit("optScrollLines", () => {
+  options.scrollLines = Math.max(1, Math.min(20, Number(el("optScrollLines").value) || 3));
+  saveOptions();
+  applyOptions();
+}, () => options.scrollLines);
+function commitTreeIndentPx() {
   options.treeIndentPx = Math.max(0, Math.min(40, Number(el("optTreeIndentPx").value) || 0));
   saveOptions();
   applyOptions();
   render();
-};
+}
+registerSettingsCommit("optTreeIndentPx", commitTreeIndentPx, () => options.treeIndentPx);
 el("optFileBrowserAllowParent").onchange = () => {
   options.fileBrowserAllowParent = el("optFileBrowserAllowParent").checked;
   saveOptions();
@@ -335,45 +341,51 @@ for (const [id, key] of [["optEditorEnabled", "editorEnabled"], ["optEditorWordW
     if (typeof render === "function") render();
   };
 }
-el("optEditorTabSize").onchange = () => {
+registerSettingsCommit("optEditorTabSize", () => {
   options.editorTabSize = Math.max(1, Math.min(8, Number(el("optEditorTabSize").value) || 2));
   saveOptions();
   if (typeof render === "function") render();
-};
+}, () => options.editorTabSize);
 el("optHeaderSearchEnabled").onchange = () => {
   options.headerSearchEnabled = el("optHeaderSearchEnabled").checked;
   saveOptions();
   applyOptions();
 };
-el("optFileBrowserSearchPageSize").oninput = () => {
+function commitFileBrowserSearchPageSize() {
   options.fileBrowserSearchPageSize = Math.max(10, Math.min(500, Number(el("optFileBrowserSearchPageSize").value) || 100));
   saveOptions();
-};
-el("optFileContentSearchMinChars").oninput = () => {
+}
+registerSettingsCommit("optFileBrowserSearchPageSize", commitFileBrowserSearchPageSize, () => options.fileBrowserSearchPageSize);
+function commitFileContentSearchMinChars() {
   options.fileContentSearchMinChars = Math.max(1, Math.min(20, Number(el("optFileContentSearchMinChars").value) || 3));
   saveOptions();
-};
-el("optFileContentSearchPageSize").oninput = () => {
+}
+registerSettingsCommit("optFileContentSearchMinChars", commitFileContentSearchMinChars, () => options.fileContentSearchMinChars);
+function commitFileContentSearchPageSize() {
   options.fileContentSearchPageSize = Math.max(10, Math.min(500, Number(el("optFileContentSearchPageSize").value) || 50));
   saveOptions();
-};
-el("optFileContentSearchContextLines").oninput = () => {
+}
+registerSettingsCommit("optFileContentSearchPageSize", commitFileContentSearchPageSize, () => options.fileContentSearchPageSize);
+function commitFileContentSearchContextLines() {
   const value = Number(el("optFileContentSearchContextLines").value);
   options.fileContentSearchContextLines = Math.max(0, Math.min(20, Number.isFinite(value) ? value : 2));
   saveOptions();
-};
-el("optFileContentSearchAutoCollapseFiles").oninput = () => {
+}
+registerSettingsCommit("optFileContentSearchContextLines", commitFileContentSearchContextLines, () => options.fileContentSearchContextLines);
+function commitFileContentSearchAutoCollapseFiles() {
   options.fileContentSearchAutoCollapseFiles = Math.max(0, Math.min(200, Number(el("optFileContentSearchAutoCollapseFiles").value) || 0));
   saveOptions();
-};
+}
+registerSettingsCommit("optFileContentSearchAutoCollapseFiles", commitFileContentSearchAutoCollapseFiles, () => options.fileContentSearchAutoCollapseFiles);
 el("optFileContentSearchDefaultExpanded").onchange = () => {
   options.fileContentSearchDefaultExpanded = el("optFileContentSearchDefaultExpanded").checked;
   saveOptions();
 };
-el("optFileContentSearchMatchesPerFile").oninput = () => {
+function commitFileContentSearchMatchesPerFile() {
   options.fileContentSearchMatchesPerFile = Math.max(1, Math.min(50, Number(el("optFileContentSearchMatchesPerFile").value) || 5));
   saveOptions();
-};
+}
+registerSettingsCommit("optFileContentSearchMatchesPerFile", commitFileContentSearchMatchesPerFile, () => options.fileContentSearchMatchesPerFile);
 el("optFileContentSearchMatchCase").onchange = () => {
   options.fileContentSearchMatchCase = el("optFileContentSearchMatchCase").checked;
   saveOptions();
@@ -382,7 +394,7 @@ el("optFileContentSearchRegex").onchange = () => {
   options.fileContentSearchRegex = el("optFileContentSearchRegex").checked;
   saveOptions();
 };
-el("optWorktreeAutoDiscover").oninput = () => {
+function commitWorktreeAutoDiscover() {
   options.worktreeAutoDiscoverSeconds = Math.max(
     0,
     Math.min(30, Number(el("optWorktreeAutoDiscover").value) || 0),
@@ -390,21 +402,24 @@ el("optWorktreeAutoDiscover").oninput = () => {
   saveOptions();
   applyOptions();
   scheduleWorktreeAutodiscover();
-};
+}
+registerSettingsCommit("optWorktreeAutoDiscover", commitWorktreeAutoDiscover, () => options.worktreeAutoDiscoverSeconds);
 el("optGenerateWorktreeNames").onchange = () => {
   options.generateWorktreeNames = el("optGenerateWorktreeNames").checked;
   saveOptions();
   applyOptions();
 };
-el("optWorktreeDefaultDirectory").oninput = () => {
+function commitWorktreeDefaultDirectory() {
   options.worktreeDefaultDirectory = el("optWorktreeDefaultDirectory").value.trim();
   saveOptions();
   syncWorktreeCheckoutPath();
-};
-el("optExplorationDefaultDirectory").oninput = () => {
+}
+registerSettingsCommit("optWorktreeDefaultDirectory", commitWorktreeDefaultDirectory, () => (options.worktreeDefaultDirectory || ""));
+function commitExplorationDefaultDirectory() {
   options.explorationDefaultDirectory = el("optExplorationDefaultDirectory").value.trim();
   saveOptions();
-};
+}
+registerSettingsCommit("optExplorationDefaultDirectory", commitExplorationDefaultDirectory, () => (options.explorationDefaultDirectory || ""));
 el("optSound").onchange = () => {
   options.sound = el("optSound").checked;
   saveOptions();

--- a/src/assets/desktop/app_js/core.js
+++ b/src/assets/desktop/app_js/core.js
@@ -1504,6 +1504,139 @@ function flashSettingsApplied(control, label) {
   if (!settingsFeedback) return;
   settingsFeedback.flashApplied(control, label);
 }
+// Explicit confirm/rollback chrome for local settings rows. Text-like
+// inputs only save after Enter or the yellow pencil; selects and
+// checkboxes save immediately but expose a rollback arrow. The registry
+// maps control ids to their save/read functions so the shared module
+// stays layout- and option-pipeline-agnostic.
+const settingsConfirmCommitters = new Map();
+function registerSettingsCommit(id, save, read) {
+  settingsConfirmCommitters.set(id, { save, read });
+}
+// Public hook so tests (and any embedding UI) can trigger the same commit
+// path the pencil button and Enter key use.
+window.HerdrSettingsCommit = {
+  commit(id) {
+    const committer = settingsConfirmCommitters.get(id);
+    if (committer) committer.save();
+  },
+  has(id) {
+    return settingsConfirmCommitters.has(id);
+  },
+};
+function settingsConfirmSave(control) {
+  const committer = settingsConfirmCommitters.get(control && control.id);
+  if (committer) committer.save();
+  else saveOptions();
+}
+function settingsConfirmRead(control) {
+  const committer = settingsConfirmCommitters.get(control && control.id);
+  if (committer) return committer.read();
+  return controlValueForConfirm(control);
+}
+function controlValueForConfirm(control) {
+  if (!control) return "";
+  if (control.type === "checkbox") return control.checked === true;
+  return String(control.value == null ? "" : control.value).trim();
+}
+const settingsConfirm = window.HerdrSettingsConfirm
+  ? window.HerdrSettingsConfirm.create({
+      document,
+      save: settingsConfirmSave,
+      read: settingsConfirmRead,
+      onRollback: (control) => {
+        // Rollback restores the saved option; route it through the same
+        // committers so dependent UI (terminal font, renders) syncs.
+        const committer = settingsConfirmCommitters.get(control && control.id);
+        if (committer) committer.save();
+        else saveOptions();
+      },
+    })
+  : null;
+// Attach confirm/rollback chrome to every local settings row. Ids without a
+// dedicated committer keep the generic pipeline: commit runs saveOptions()
+// after the row's own change handler already applied the control value.
+const SETTINGS_CONFIRM_IDS = [
+  "optTheme",
+  "optOverflow",
+  "optFit",
+  "optShiftEnterNewline",
+  "optSound",
+  "optBrowserNotifications",
+  "optPanelCloseMode",
+  "optGlobalShortcutsEnabled",
+  "optGlobalShortcutPrefix",
+  "optSearchShortcut",
+  "optTerminalCore",
+  "optTerminalFontFamily",
+  "optTerminalLinks",
+  "optTerminalMouseReporting",
+  "optTempTerminalLabelMaxChars",
+  "optCloseShortcut",
+  "optAgentSortMode",
+  "optSidebarWorkspacePercent",
+  "optParentCloseMode",
+  "optStuckWorkingEnabled",
+  "optWorkingDismissMinutes",
+  "optShowTabActivity",
+  "optWorkspaceSort",
+  "optSoundScope",
+  "optNotificationVolume",
+  "optGenerateWorktreeNames",
+  "optWorktreeDefaultDirectory",
+  "optExplorationDefaultDirectory",
+  "optScrollLines",
+  "optWorktreeAutoDiscover",
+  "optTreeIndentPx",
+  "optFileBrowserAllowParent",
+  "optFileBrowserGitStatus",
+  "optFileBrowserLineNumbers",
+  "optEditorFindShortcutEnabled",
+  "optEditorEnabled",
+  "optEditorWordWrap",
+  "optEditorTabSize",
+  "optEditorBracketMatching",
+  "optEditorFolding",
+  "optEditorActiveLine",
+  "optEditorWhitespace",
+  "optHeaderSearchEnabled",
+  "optFileBrowserSearchPageSize",
+  "optFileContentSearchMinChars",
+  "optFileContentSearchPageSize",
+  "optFileContentSearchContextLines",
+  "optFileContentSearchAutoCollapseFiles",
+  "optFileContentSearchDefaultExpanded",
+  "optFileContentSearchMatchesPerFile",
+  "optFileContentSearchMatchCase",
+  "optFileContentSearchRegex",
+  "optLspEnabled",
+];
+const settingsConfirmSkip = new Set([
+  // Shortcut capture rows are readonly inputs driven by Record buttons; the
+  // value only changes through those buttons, so pending chrome never shows.
+  "optGlobalShortcutPrefix",
+  "optSearchShortcut",
+]);
+function watchSettingsConfirmRows() {
+  if (!settingsConfirm) return;
+  for (const id of SETTINGS_CONFIRM_IDS) {
+    if (settingsConfirmSkip.has(id)) continue;
+    const control = document.getElementById(id);
+    if (!control) continue;
+    const row =
+      control.closest && control.closest(".option")
+        ? control.closest(".option")
+        : control;
+    if (!row) continue;
+    if (row.dataset.confirmWatched === "1") continue;
+    row.dataset.confirmWatched = "1";
+    settingsConfirm.watch(row, control);
+  }
+  // Rows watched during an earlier modal visit keep stale open-time
+  // baselines; re-read them so rollback always targets the value saved
+  // when Settings was (re)opened.
+  settingsConfirm.refreshAll();
+}
 function saveOptions() {
   options = normalizeOptions(options);
   if (window.HerdrOptions) window.HerdrOptions.write(options);
@@ -1950,6 +2083,7 @@ function setupSettingsSearch() {
 function prepareSettingsModalOpen() {
   applyOptions();
   loadServerSettings();
+  watchSettingsConfirmRows();
   const input = el("settingsSearch");
   if (!input) return;
   input.value = "";

--- a/src/assets/mobile/app.css
+++ b/src/assets/mobile/app.css
@@ -1760,3 +1760,24 @@ body.light .mobile-nav-status.working {
   content: "✓";
   font-weight: 800;
 }
+/* Settings confirm pencil + rollback chrome, mirroring desktop. */
+.settings-confirm-pencil,
+.settings-rollback {
+  align-self: center;
+  background: none;
+  border: none;
+  color: var(--muted, #9ca3af);
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1;
+  justify-self: end;
+  padding: 2px 6px;
+}
+.settings-confirm-pencil {
+  color: #f9e2af;
+}
+.settings-pending > input,
+.settings-pending > select {
+  outline: 1px dashed #f9e2af;
+  outline-offset: 1px;
+}

--- a/src/assets/mobile/app.js
+++ b/src/assets/mobile/app.js
@@ -551,8 +551,11 @@
       return;
     }
     const wasTerminal = state.screen === "terminal";
+    const wasSettings = state.screen === "settings";
     state.screen = screen;
     if (wasTerminal && screen !== "terminal") mobileTerminal.destroy(false);
+    if (!wasSettings && screen === "settings" && mobileSettings.resetSettingBaselines)
+      mobileSettings.resetSettingBaselines();
     if (screen === "sessions" && !state.sessionBusy) refreshSessions();
     render();
     if (screen === "terminal") mobileTerminal.connect();
@@ -1986,6 +1989,8 @@
     setWorktreeCreateExpanded: mobileWorktrees.setCreateExpanded,
     updateWorktreeField: mobileWorktrees.updateField,
     setThemeMode: mobileSettings.setThemeMode,
+    rollbackSetting: mobileSettings.rollbackSetting,
+    resetSettingBaselines: mobileSettings.resetSettingBaselines,
     setBrowserNotifications: mobileSettings.setBrowserNotifications,
     setEditorEnabled: mobileSettings.setEditorEnabled,
     setEditorWordWrap: mobileSettings.setEditorWordWrap,

--- a/src/assets/mobile/settings.js
+++ b/src/assets/mobile/settings.js
@@ -16,6 +16,81 @@
     let appliedFlashTimer = null;
     let pendingSearchOrderFlash = null;
     const APPLIED_FLASH_MS = 2500;
+    // Values saved when the settings screen was opened (per row id). A
+    // rollback chip appears whenever the saved value drifted from this
+    // baseline; the baseline self-heals whenever the current value equals
+    // it again (for example after a rollback).
+    const settingBaselines = new Map();
+
+    // Settings entry (re)captures the open-time snapshot. Called by
+    // showScreen("settings") so re-entering Settings never rolls back to
+    // values saved during an earlier visit.
+    function resetSettingBaselines() {
+      settingBaselines.clear();
+    }
+
+    function baselineValue(settingsId) {
+      if (!settingBaselines.has(settingsId))
+        settingBaselines.set(settingsId, currentValueFor(settingsId));
+      return settingBaselines.get(settingsId);
+    }
+
+    function currentValueFor(settingsId) {
+      const options = readOptions();
+      switch (settingsId) {
+        case "theme":
+          return localStorage.getItem("herdr-web-theme") || "auto";
+        case "layout":
+          return localStorage.getItem("herdr-web-layout") || "auto";
+        case "notificationVolume":
+          return Math.round(
+            Math.max(0, Math.min(1, Number(options.notificationVolume) || 0)) * 100,
+          );
+        default: {
+          const value = options[settingsId];
+          return value === undefined ? "" : value;
+        }
+      }
+    }
+
+    function rollbackHtml(settingsId) {
+      const baseline = baselineValue(settingsId);
+      const current = currentValueFor(settingsId);
+      if (String(baseline) === String(current)) return "";
+      return `<button type="button" class="settings-rollback" data-rollback-id="${escapeHtml(settingsId)}" onclick="HerdrMobile.rollbackSetting('${escapeHtml(settingsId)}')" aria-label="Roll back this change" title="Roll back this change">↺</button>`;
+    }
+
+    function rollbackSetting(settingsId) {
+      const baseline = baselineValue(settingsId);
+      if (baseline === undefined) return;
+      switch (settingsId) {
+        case "theme":
+          localStorage.setItem("herdr-web-theme", String(baseline));
+          applyTheme();
+          break;
+        case "layout":
+          localStorage.setItem("herdr-web-layout", String(baseline));
+          break;
+        case "notificationVolume": {
+          const parsed = readOptions();
+          parsed.notificationVolume =
+            Math.max(0, Math.min(100, Number(baseline) || 0)) / 100;
+          writeOptions(parsed);
+          break;
+        }
+        default: {
+          const parsed = readOptions();
+          parsed[settingsId] = baseline;
+          writeOptions(parsed);
+          break;
+        }
+      }
+      if (globalThis.HerdrMobile && globalThis.HerdrMobile.applyTerminalFontFamily && settingsId === "terminalFontFamily")
+        globalThis.HerdrMobile.applyTerminalFontFamily();
+      if (globalThis.HerdrMobile && globalThis.HerdrMobile.reloadTerminal && settingsId === "terminalCore")
+        globalThis.HerdrMobile.reloadTerminal();
+      if (globalThis.HerdrMobile) globalThis.HerdrMobile.refresh();
+    }
 
     function queueAppliedFlash(settingsId, label) {
       if (!settingsId) return;
@@ -99,19 +174,19 @@
     }
 
     function appearanceSection(theme) {
-      return `<div class="mobile-settings-group"><h3>Appearance</h3><label data-settings-id="theme">${appliedFlashHtml("theme")}<span>Theme</span><select onchange="HerdrMobile.setThemeMode(this.value)"><option value="auto" ${theme === "auto" ? "selected" : ""}>Auto</option><option value="dark" ${theme === "dark" ? "selected" : ""}>Dark</option><option value="light" ${theme === "light" ? "selected" : ""}>Light</option></select></label></div>`;
+      return `<div class="mobile-settings-group"><h3>Appearance</h3><label data-settings-id="theme">${rollbackHtml("theme")}${appliedFlashHtml("theme")}<span>Theme</span><select onchange="HerdrMobile.setThemeMode(this.value)"><option value="auto" ${theme === "auto" ? "selected" : ""}>Auto</option><option value="dark" ${theme === "dark" ? "selected" : ""}>Dark</option><option value="light" ${theme === "light" ? "selected" : ""}>Light</option></select></label></div>`;
     }
 
     function layoutSection(layout) {
-      return `<div class="mobile-settings-group"><h3>Layout</h3><label data-settings-id="layout">${appliedFlashHtml("layout")}<span>Layout mode</span><select onchange="HerdrMobile.setLayoutPreference(this.value)"><option value="auto" ${layout === "auto" ? "selected" : ""}>Auto</option><option value="mobile" ${layout === "mobile" ? "selected" : ""}>Mobile</option><option value="desktop" ${layout === "desktop" ? "selected" : ""}>Desktop</option></select><small>Auto uses viewport width, not user agent.</small></label></div>`;
+      return `<div class="mobile-settings-group"><h3>Layout</h3><label data-settings-id="layout">${rollbackHtml("layout")}${appliedFlashHtml("layout")}<span>Layout mode</span><select onchange="HerdrMobile.setLayoutPreference(this.value)"><option value="auto" ${layout === "auto" ? "selected" : ""}>Auto</option><option value="mobile" ${layout === "mobile" ? "selected" : ""}>Mobile</option><option value="desktop" ${layout === "desktop" ? "selected" : ""}>Desktop</option></select><small>Auto uses viewport width, not user agent.</small></label></div>`;
     }
 
     function filesSection(depth, lineNumbers, headerSearch, searchOrder, pathSearchPageSize, minChars, contentPageSize, contextLines, autoCollapse, defaultExpanded, matchesPerFile, matchCase, regex) {
-      return `<div class="mobile-settings-group"><h3>Files and search</h3><label data-settings-id="fileBrowserDepth">${appliedFlashHtml("fileBrowserDepth")}<span>Browser depth</span><input type="number" min="0" max="8" step="1" value="${depth}" onchange="HerdrMobile.setFileBrowserDepth(this.value)"></label><small>0 shows current folder only. 3 expands three folder levels.</small><label data-settings-id="fileBrowserLineNumbers">${appliedFlashHtml("fileBrowserLineNumbers")}<input type="checkbox" ${lineNumbers ? "checked" : ""} onchange="HerdrMobile.setFileBrowserLineNumbers(this.checked)"><span>Line numbers</span><small>Show line numbers when previewing text files.</small></label><label data-settings-id="headerSearchEnabled">${appliedFlashHtml("headerSearchEnabled")}<input type="checkbox" ${headerSearch ? "checked" : ""} onchange="HerdrMobile.setHeaderSearchEnabled(this.checked)"><span>Header search button</span><small>Show the search action and allow the palette to open.</small></label><div><span>Search section order</span>${renderSearchSectionOrder(searchOrder, pendingSearchOrderFlash)}</div><small>Use arrows to move sections. Use Shown/Hidden to include or remove a section.</small><label data-settings-id="fileBrowserSearchPageSize">${appliedFlashHtml("fileBrowserSearchPageSize")}<span>File/folder page size</span><input type="number" min="10" max="500" step="10" value="${pathSearchPageSize}" onchange="HerdrMobile.setFileBrowserSearchPageSize(this.value)"></label><label data-settings-id="fileContentSearchMinChars">${appliedFlashHtml("fileContentSearchMinChars")}<span>Content minimum characters</span><input type="number" min="1" max="20" step="1" value="${minChars}" onchange="HerdrMobile.setFileContentSearchMinChars(this.value)"></label><label data-settings-id="fileContentSearchPageSize">${appliedFlashHtml("fileContentSearchPageSize")}<span>Content page size</span><input type="number" min="10" max="500" step="10" value="${contentPageSize}" onchange="HerdrMobile.setFileContentSearchPageSize(this.value)"></label><label data-settings-id="fileContentSearchContextLines">${appliedFlashHtml("fileContentSearchContextLines")}<span>Content context lines</span><input type="number" min="0" max="20" step="1" value="${contextLines}" onchange="HerdrMobile.setFileContentSearchContextLines(this.value)"></label><label data-settings-id="fileContentSearchAutoCollapseFiles">${appliedFlashHtml("fileContentSearchAutoCollapseFiles")}<span>Content auto-collapse files</span><input type="number" min="0" max="200" step="1" value="${autoCollapse}" onchange="HerdrMobile.setFileContentSearchAutoCollapseFiles(this.value)"></label><label data-settings-id="fileContentSearchDefaultExpanded">${appliedFlashHtml("fileContentSearchDefaultExpanded")}<input type="checkbox" ${defaultExpanded ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchDefaultExpanded(this.checked)"><span>Content results expanded by default</span><small>Expand each file group when content results load.</small></label><label data-settings-id="fileContentSearchMatchesPerFile">${appliedFlashHtml("fileContentSearchMatchesPerFile")}<span>Content matches per file</span><input type="number" min="1" max="50" step="1" value="${matchesPerFile}" onchange="HerdrMobile.setFileContentSearchMatchesPerFile(this.value)"></label><label data-settings-id="fileContentSearchMatchCase">${appliedFlashHtml("fileContentSearchMatchCase")}<input type="checkbox" ${matchCase ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchMatchCase(this.checked)"><span>Content search match case</span></label><label data-settings-id="fileContentSearchRegex">${appliedFlashHtml("fileContentSearchRegex")}<input type="checkbox" ${regex ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchRegex(this.checked)"><span>Content search regex</span></label></div>`;
+      return `<div class="mobile-settings-group"><h3>Files and search</h3><label data-settings-id="fileBrowserDepth">${rollbackHtml("fileBrowserDepth")}${appliedFlashHtml("fileBrowserDepth")}<span>Browser depth</span><input type="number" min="0" max="8" step="1" value="${depth}" onchange="HerdrMobile.setFileBrowserDepth(this.value)"></label><small>0 shows current folder only. 3 expands three folder levels.</small><label data-settings-id="fileBrowserLineNumbers">${rollbackHtml("fileBrowserLineNumbers")}${appliedFlashHtml("fileBrowserLineNumbers")}<input type="checkbox" ${lineNumbers ? "checked" : ""} onchange="HerdrMobile.setFileBrowserLineNumbers(this.checked)"><span>Line numbers</span><small>Show line numbers when previewing text files.</small></label><label data-settings-id="headerSearchEnabled">${rollbackHtml("headerSearchEnabled")}${appliedFlashHtml("headerSearchEnabled")}<input type="checkbox" ${headerSearch ? "checked" : ""} onchange="HerdrMobile.setHeaderSearchEnabled(this.checked)"><span>Header search button</span><small>Show the search action and allow the palette to open.</small></label><div><span>Search section order</span>${renderSearchSectionOrder(searchOrder, pendingSearchOrderFlash)}</div><small>Use arrows to move sections. Use Shown/Hidden to include or remove a section.</small><label data-settings-id="fileBrowserSearchPageSize">${rollbackHtml("fileBrowserSearchPageSize")}${appliedFlashHtml("fileBrowserSearchPageSize")}<span>File/folder page size</span><input type="number" min="10" max="500" step="10" value="${pathSearchPageSize}" onchange="HerdrMobile.setFileBrowserSearchPageSize(this.value)"></label><label data-settings-id="fileContentSearchMinChars">${rollbackHtml("fileContentSearchMinChars")}${appliedFlashHtml("fileContentSearchMinChars")}<span>Content minimum characters</span><input type="number" min="1" max="20" step="1" value="${minChars}" onchange="HerdrMobile.setFileContentSearchMinChars(this.value)"></label><label data-settings-id="fileContentSearchPageSize">${rollbackHtml("fileContentSearchPageSize")}${appliedFlashHtml("fileContentSearchPageSize")}<span>Content page size</span><input type="number" min="10" max="500" step="10" value="${contentPageSize}" onchange="HerdrMobile.setFileContentSearchPageSize(this.value)"></label><label data-settings-id="fileContentSearchContextLines">${rollbackHtml("fileContentSearchContextLines")}${appliedFlashHtml("fileContentSearchContextLines")}<span>Content context lines</span><input type="number" min="0" max="20" step="1" value="${contextLines}" onchange="HerdrMobile.setFileContentSearchContextLines(this.value)"></label><label data-settings-id="fileContentSearchAutoCollapseFiles">${rollbackHtml("fileContentSearchAutoCollapseFiles")}${appliedFlashHtml("fileContentSearchAutoCollapseFiles")}<span>Content auto-collapse files</span><input type="number" min="0" max="200" step="1" value="${autoCollapse}" onchange="HerdrMobile.setFileContentSearchAutoCollapseFiles(this.value)"></label><label data-settings-id="fileContentSearchDefaultExpanded">${rollbackHtml("fileContentSearchDefaultExpanded")}${appliedFlashHtml("fileContentSearchDefaultExpanded")}<input type="checkbox" ${defaultExpanded ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchDefaultExpanded(this.checked)"><span>Content results expanded by default</span><small>Expand each file group when content results load.</small></label><label data-settings-id="fileContentSearchMatchesPerFile">${rollbackHtml("fileContentSearchMatchesPerFile")}${appliedFlashHtml("fileContentSearchMatchesPerFile")}<span>Content matches per file</span><input type="number" min="1" max="50" step="1" value="${matchesPerFile}" onchange="HerdrMobile.setFileContentSearchMatchesPerFile(this.value)"></label><label data-settings-id="fileContentSearchMatchCase">${rollbackHtml("fileContentSearchMatchCase")}${appliedFlashHtml("fileContentSearchMatchCase")}<input type="checkbox" ${matchCase ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchMatchCase(this.checked)"><span>Content search match case</span></label><label data-settings-id="fileContentSearchRegex">${rollbackHtml("fileContentSearchRegex")}${appliedFlashHtml("fileContentSearchRegex")}<input type="checkbox" ${regex ? "checked" : ""} onchange="HerdrMobile.setFileContentSearchRegex(this.checked)"><span>Content search regex</span></label></div>`;
     }
 
     function editorSection(enhanced, wordWrap, tabSize, lsp) {
-      return `<div class="mobile-settings-group"><h3>Editor</h3><label data-settings-id="editorEnabled">${appliedFlashHtml("editorEnabled")}<input type="checkbox" ${enhanced ? "checked" : ""} onchange="HerdrMobile.setEditorEnabled(this.checked)"><span>Code editor enhancements</span><small>Enable CodeMirror editing enhancements. Files remain editable when this is disabled.</small></label><label data-settings-id="editorWordWrap">${appliedFlashHtml("editorWordWrap")}<input type="checkbox" ${wordWrap ? "checked" : ""} onchange="HerdrMobile.setEditorWordWrap(this.checked)"><span>Editor word wrap</span></label><label data-settings-id="editorTabSize">${appliedFlashHtml("editorTabSize")}<span>Editor tab size</span><input type="number" min="1" max="8" step="1" value="${tabSize}" onchange="HerdrMobile.setEditorTabSize(this.value)"></label><label data-settings-id="lspEnabled">${appliedFlashHtml("lspEnabled")}<input type="checkbox" ${lsp ? "checked" : ""} onchange="HerdrMobile.setLspEnabled(this.checked)"><span>LSP diagnostics</span><small>Show language server diagnostics under the editor. Off by default.</small></label></div>`;
+      return `<div class="mobile-settings-group"><h3>Editor</h3><label data-settings-id="editorEnabled">${rollbackHtml("editorEnabled")}${appliedFlashHtml("editorEnabled")}<input type="checkbox" ${enhanced ? "checked" : ""} onchange="HerdrMobile.setEditorEnabled(this.checked)"><span>Code editor enhancements</span><small>Enable CodeMirror editing enhancements. Files remain editable when this is disabled.</small></label><label data-settings-id="editorWordWrap">${rollbackHtml("editorWordWrap")}${appliedFlashHtml("editorWordWrap")}<input type="checkbox" ${wordWrap ? "checked" : ""} onchange="HerdrMobile.setEditorWordWrap(this.checked)"><span>Editor word wrap</span></label><label data-settings-id="editorTabSize">${rollbackHtml("editorTabSize")}${appliedFlashHtml("editorTabSize")}<span>Editor tab size</span><input type="number" min="1" max="8" step="1" value="${tabSize}" onchange="HerdrMobile.setEditorTabSize(this.value)"></label><label data-settings-id="lspEnabled">${rollbackHtml("lspEnabled")}${appliedFlashHtml("lspEnabled")}<input type="checkbox" ${lsp ? "checked" : ""} onchange="HerdrMobile.setLspEnabled(this.checked)"><span>LSP diagnostics</span><small>Show language server diagnostics under the editor. Off by default.</small></label></div>`;
     }
 
     function renderSearchSectionOrder(value, flashKey) {
@@ -124,15 +199,15 @@
     }
 
     function workspacesSection(worktreeDirectory, explorationDirectory) {
-      return `<div class="mobile-settings-group"><h3>Workspaces</h3><label data-settings-id="worktreeDefaultDirectory">${appliedFlashHtml("worktreeDefaultDirectory")}<span>Worktree default directory</span><input placeholder="../worktrees" value="${escapeHtml(worktreeDirectory)}" onchange="HerdrMobile.setWorktreeDefaultDirectory(this.value)"></label><small>Base for generated worktree checkout paths.</small><label data-settings-id="explorationDefaultDirectory">${appliedFlashHtml("explorationDefaultDirectory")}<span>Exploration default directory</span><input placeholder="~/Documents/code" value="${escapeHtml(explorationDirectory)}" onchange="HerdrMobile.setExplorationDefaultDirectory(this.value)"></label><small>Prefills worktree discovery paths.</small></div>`;
+      return `<div class="mobile-settings-group"><h3>Workspaces</h3><label data-settings-id="worktreeDefaultDirectory">${rollbackHtml("worktreeDefaultDirectory")}${appliedFlashHtml("worktreeDefaultDirectory")}<span>Worktree default directory</span><input placeholder="../worktrees" value="${escapeHtml(worktreeDirectory)}" onchange="HerdrMobile.setWorktreeDefaultDirectory(this.value)"></label><small>Base for generated worktree checkout paths.</small><label data-settings-id="explorationDefaultDirectory">${rollbackHtml("explorationDefaultDirectory")}${appliedFlashHtml("explorationDefaultDirectory")}<span>Exploration default directory</span><input placeholder="~/Documents/code" value="${escapeHtml(explorationDirectory)}" onchange="HerdrMobile.setExplorationDefaultDirectory(this.value)"></label><small>Prefills worktree discovery paths.</small></div>`;
     }
 
     function alertsSection(notifications, volume) {
-      return `<div class="mobile-settings-group"><h3>Alerts</h3><label data-settings-id="browserNotifications">${appliedFlashHtml("browserNotifications")}<input type="checkbox" ${notifications ? "checked" : ""} onchange="HerdrMobile.setBrowserNotifications(this.checked)"><span>Browser notifications</span><small>Show system notifications when an agent is blocked or done.</small></label><label data-settings-id="notificationVolume">${appliedFlashHtml("notificationVolume")}<span>Notification volume (${volume}%)</span><input type="range" min="0" max="100" step="1" value="${volume}" onchange="HerdrMobile.setNotificationVolume(this.value)"></label><small>Controls the local attention tone volume.</small></div>`;
+      return `<div class="mobile-settings-group"><h3>Alerts</h3><label data-settings-id="browserNotifications">${rollbackHtml("browserNotifications")}${appliedFlashHtml("browserNotifications")}<input type="checkbox" ${notifications ? "checked" : ""} onchange="HerdrMobile.setBrowserNotifications(this.checked)"><span>Browser notifications</span><small>Show system notifications when an agent is blocked or done.</small></label><label data-settings-id="notificationVolume">${rollbackHtml("notificationVolume")}${appliedFlashHtml("notificationVolume")}<span>Notification volume (${volume}%)</span><input type="range" min="0" max="100" step="1" value="${volume}" onchange="HerdrMobile.setNotificationVolume(this.value)"></label><small>Controls the local attention tone volume.</small></div>`;
     }
 
     function terminalSection(font, core, links, mouseReporting) {
-      return `<div class="mobile-settings-group"><h3>Terminal</h3><label data-settings-id="terminalCore">${appliedFlashHtml("terminalCore")}<span>Terminal renderer</span><select onchange="HerdrMobile.setTerminalCore(this.value)"><option value="wterm" ${core === "wterm" ? "selected" : ""}>wterm VT core</option><option value="ghostty" ${core === "ghostty" ? "selected" : ""}>Ghostty VT core</option></select></label><label data-settings-id="terminalFontFamily">${appliedFlashHtml("terminalFontFamily")}<span>Terminal font</span><input placeholder="JetBrainsMono Nerd Font, monospace" value="${escapeHtml(font)}" onchange="HerdrMobile.setTerminalFontFamily(this.value)"></label><label data-settings-id="terminalLinks">${appliedFlashHtml("terminalLinks")}<input type="checkbox" ${links ? "checked" : ""} onchange="HerdrMobile.setTerminalLinks(this.checked)"><span>Terminal links</span><small>Detect http/https URLs and open them when tapped.</small></label><label data-settings-id="terminalMouseReporting">${appliedFlashHtml("terminalMouseReporting")}<input type="checkbox" ${mouseReporting ? "checked" : ""} onchange="HerdrMobile.setTerminalMouseReporting(this.checked)"><span>Terminal mouse reporting</span><small>Forward mouse input to terminal apps. Disabled by default; scrolling still works.</small></label><small>Add a Nerd Font family name so icon glyphs render. Leave blank for the default stack.</small></div>`;
+      return `<div class="mobile-settings-group"><h3>Terminal</h3><label data-settings-id="terminalCore">${rollbackHtml("terminalCore")}${appliedFlashHtml("terminalCore")}<span>Terminal renderer</span><select onchange="HerdrMobile.setTerminalCore(this.value)"><option value="wterm" ${core === "wterm" ? "selected" : ""}>wterm VT core</option><option value="ghostty" ${core === "ghostty" ? "selected" : ""}>Ghostty VT core</option></select></label><label data-settings-id="terminalFontFamily">${rollbackHtml("terminalFontFamily")}${appliedFlashHtml("terminalFontFamily")}<span>Terminal font</span><input placeholder="JetBrainsMono Nerd Font, monospace" value="${escapeHtml(font)}" onchange="HerdrMobile.setTerminalFontFamily(this.value)"></label><label data-settings-id="terminalLinks">${rollbackHtml("terminalLinks")}${appliedFlashHtml("terminalLinks")}<input type="checkbox" ${links ? "checked" : ""} onchange="HerdrMobile.setTerminalLinks(this.checked)"><span>Terminal links</span><small>Detect http/https URLs and open them when tapped.</small></label><label data-settings-id="terminalMouseReporting">${rollbackHtml("terminalMouseReporting")}${appliedFlashHtml("terminalMouseReporting")}<input type="checkbox" ${mouseReporting ? "checked" : ""} onchange="HerdrMobile.setTerminalMouseReporting(this.checked)"><span>Terminal mouse reporting</span><small>Forward mouse input to terminal apps. Disabled by default; scrolling still works.</small></label><small>Add a Nerd Font family name so icon glyphs render. Leave blank for the default stack.</small></div>`;
     }
 
     function dataSection() {
@@ -531,6 +606,8 @@
 
     return {
       render,
+      rollbackSetting,
+      resetSettingBaselines,
       setBrowserNotifications,
       setExplorationDefaultDirectory,
       setFileBrowserDepth,

--- a/src/assets/mobile_load.test.mjs
+++ b/src/assets/mobile_load.test.mjs
@@ -1179,6 +1179,55 @@ describe("mobile bundle load", () => {
     );
   });
 
+  it("shows a rollback chip when a mobile setting drifted from its baseline", async () => {
+    const ctx = context("/session/default/workspace/w1/tab/t1/pane/p1");
+    vm.runInContext(source, ctx);
+
+    ctx.HerdrMobile.showScreen("settings");
+    let html = ctx.document.getElementById("mobileScreen").innerHTML;
+    ok(
+      !html.includes('data-rollback-id="worktreeDefaultDirectory"'),
+      "no rollback chip before any change",
+    );
+
+    ctx.HerdrMobile.setWorktreeDefaultDirectory("/tmp/changed");
+    ctx.HerdrMobile.showScreen("settings");
+    html = ctx.document.getElementById("mobileScreen").innerHTML;
+    ok(
+      html.includes('data-rollback-id="worktreeDefaultDirectory"'),
+      "rollback chip appears after a change",
+    );
+
+    ctx.HerdrMobile.rollbackSetting("worktreeDefaultDirectory");
+    ctx.HerdrMobile.showScreen("settings");
+    html = ctx.document.getElementById("mobileScreen").innerHTML;
+    ok(
+      !html.includes('data-rollback-id="worktreeDefaultDirectory"'),
+      "chip cleared after rollback",
+    );
+    const saved = JSON.parse(ctx.localStorage.getItem("herdr-web-options"));
+    equal(saved.worktreeDefaultDirectory, "", "rolled back to the baseline");
+
+    // Re-entering Settings re-captures the open-time baseline: a new change
+    // drifts from the fresh snapshot, and rolling back restores it.
+    ctx.HerdrMobile.showScreen("home");
+    ctx.HerdrMobile.showScreen("settings");
+    ctx.HerdrMobile.setWorktreeDefaultDirectory("/tmp/second");
+    ctx.HerdrMobile.showScreen("settings");
+    html = ctx.document.getElementById("mobileScreen").innerHTML;
+    ok(
+      html.includes('data-rollback-id="worktreeDefaultDirectory"'),
+      "chip appears after re-entry change",
+    );
+    ctx.HerdrMobile.rollbackSetting("worktreeDefaultDirectory");
+    const savedSecond = JSON.parse(ctx.localStorage.getItem("herdr-web-options"));
+    equal(
+      savedSecond.worktreeDefaultDirectory,
+      "",
+      "re-entry rollback restores the fresh open-time baseline",
+    );
+  });
+
   it("shows highest-priority agent status in More tab label", async () => {
     const ctx = context("/session/default/workspace/w1/tab/t1/pane/p1");
     vm.runInContext(source, ctx);

--- a/src/assets/settings_confirm.test.mjs
+++ b/src/assets/settings_confirm.test.mjs
@@ -1,0 +1,347 @@
+import { describe, it } from "node:test";
+import { equal, ok } from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+
+const source = readFileSync(
+  new URL("./shared/settings_confirm.js", import.meta.url),
+  "utf8",
+);
+
+function loadConfirm() {
+  const ctx = { console, Map, Object, String, Promise, Event: FakeEvent };
+  ctx.window = ctx;
+  ctx.globalThis = ctx;
+  vm.createContext(ctx);
+  vm.runInContext(source, ctx);
+  return ctx.window.HerdrSettingsConfirm;
+}
+
+class FakeEvent {
+  constructor(type, init) {
+    this.type = type;
+    this.bubbles = !!(init && init.bubbles);
+  }
+}
+
+let eventSeq = 0;
+const dispatched = [];
+
+function createNodeStub({ id = "", className = "", tagName = "INPUT", type = "text" } = {}) {
+  const listeners = {};
+  const node = {
+    id,
+    className,
+    tagName,
+    type,
+    children: [],
+    parentNode: null,
+    dataset: {},
+    style: {},
+    value: "",
+    checked: false,
+    _attributes: {},
+    classList: {
+      toggle(name, force) {
+        const names = String(node.className).split(/\s+/).filter(Boolean);
+        const has = names.includes(name);
+        if (force === undefined ? has : force) {
+          if (!has) names.push(name);
+        } else if (has) {
+          const index = names.indexOf(name);
+          names.splice(index, 1);
+        }
+        node.className = names.join(" ");
+      },
+      contains(name) {
+        return String(node.className)
+          .split(/\s+/)
+          .includes(name);
+      },
+    },
+    setAttribute(name, value) {
+      this._attributes[name] = String(value);
+    },
+    getAttribute(name) {
+      return this._attributes[name];
+    },
+    appendChild(child) {
+      if (child.parentNode && child.parentNode !== this)
+        child.parentNode.children = child.parentNode.children.filter(
+          (existing) => existing !== child,
+        );
+      child.parentNode = this;
+      this.children.push(child);
+      return child;
+    },
+    remove() {
+      if (!this.parentNode) return;
+      this.parentNode.children = this.parentNode.children.filter(
+        (child) => child !== this,
+      );
+      this.parentNode = null;
+    },
+    querySelector(selector) {
+      const wanted = selector
+        .split(",")
+        .map((part) => part.trim())
+        .map((part) => (part.startsWith(".") ? part.slice(1) : part));
+      for (const child of this.children) {
+        if (wanted.includes(String(child.className))) return child;
+        const nested = child.querySelector && child.querySelector(selector);
+        if (nested) return nested;
+      }
+      return null;
+    },
+    closest(selector) {
+      const wanted = selector.startsWith(".") ? selector.slice(1) : selector;
+      let current = this;
+      while (current) {
+        if (String(current.className) === wanted) return current;
+        if (current.tagName === wanted.toUpperCase()) return current;
+        current = current.parentNode;
+      }
+      return null;
+    },
+    addEventListener(type, listener) {
+      listeners[type] = listeners[type] || [];
+      listeners[type].push(listener);
+    },
+    dispatchEvent(event) {
+      eventSeq += 1;
+      dispatched.push({ seq: eventSeq, target: this, type: event.type });
+      for (const listener of listeners[event.type] || []) listener(event);
+      return true;
+    },
+  };
+  return node;
+}
+
+function fire(node, type) {
+  node.dispatchEvent(new FakeEvent(type, { bubbles: true }));
+}
+
+function findChip(row, className) {
+  return row.children.find(
+    (child) => String(child.className) === className,
+  );
+}
+
+function visibleChip(row, className) {
+  const chip = findChip(row, className);
+  if (!chip) return null;
+  return String(chip.style.display || "") === "none" ? null : chip;
+}
+
+function createContext() {
+  const saves = [];
+  const reads = new Map();
+  const rollbacks = [];
+  const document = { createElement: () => createNodeStub() };
+  const api = loadConfirm().create({
+    document,
+    save: (control, value) => saves.push({ control, value }),
+    read: (control) => reads.get(control),
+    onRollback: (control, value) => rollbacks.push({ control, value }),
+  });
+  return { api, saves, reads, rollbacks, document };
+}
+
+describe("HerdrSettingsConfirm", () => {
+  it("shows pencil and rollback only while a text input differs from saved", () => {
+    const { api, reads } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub({ type: "text" });
+    control.value = "saved";
+    row.appendChild(control);
+    reads.set(control, "saved");
+
+    api.watch(row, control);
+    ok(!visibleChip(row, "settings-confirm-pencil"), "no pencil before edit");
+    ok(!visibleChip(row, "settings-rollback"), "no rollback before edit");
+
+    control.value = "edited";
+    fire(control, "input");
+    ok(visibleChip(row, "settings-confirm-pencil"), "pencil appears on edit");
+    ok(visibleChip(row, "settings-rollback"), "rollback appears on edit");
+    ok(
+      String(row.className).includes("settings-pending"),
+      "row marked pending",
+    );
+
+    const pencil = findChip(row, "settings-confirm-pencil");
+    equal(
+      pencil.getAttribute("aria-label"),
+      "Enter or press to confirm",
+      "pencil hover hint",
+    );
+  });
+
+  it("commits on Enter and hides chrome once values match", () => {
+    const { api, reads, saves } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub({ type: "text" });
+    control.value = "saved";
+    row.appendChild(control);
+    reads.set(control, "saved");
+    api.watch(row, control);
+
+    control.value = "edited";
+    fire(control, "input");
+    let prevented = false;
+    fire(control, "keydown");
+    // keydown alone is not Enter in this stub; call commit directly.
+    api.commit(row);
+    equal(saves.length, 1, "save called once");
+    equal(saves[0].value, "edited", "committed the edited value");
+    reads.set(control, "edited");
+    api.commit(row);
+    reads.set(control, "edited");
+    fire(control, "input");
+    ok(
+      !String(row.className).includes("settings-pending"),
+      "row no longer pending after re-sync",
+    );
+    ok(prevented === false, "stub flag unused");
+  });
+
+  it("commit re-syncs the control when the host clamps the value", () => {
+    const { api, reads, saves } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub({ type: "number" });
+    control.value = "200";
+    row.appendChild(control);
+    reads.set(control, 80);
+    // Simulate the host clamping on save: read returns the clamped value
+    // right after the save callback runs.
+    api.watch(row, control);
+    api.commit(row);
+    equal(saves.length, 1, "save ran");
+    // commit() refreshes savedValue from read() after saving, so the
+    // control re-syncs to the clamped value 80.
+    equal(control.value, "80", "control re-synced to clamped value");
+  });
+
+  it("rollback restores the saved value and notifies the host", () => {
+    const { api, reads, rollbacks } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub({ type: "text" });
+    control.value = "saved";
+    row.appendChild(control);
+    reads.set(control, "saved");
+    api.watch(row, control);
+
+    control.value = "edited";
+    fire(control, "input");
+    api.rollback(row);
+    equal(control.value, "saved", "value restored");
+    equal(rollbacks.length, 1, "host rollback hook ran");
+    ok(
+      !String(row.className).includes("settings-pending"),
+      "pending cleared after rollback",
+    );
+  });
+
+  it("selects commit immediately and keep a persistent rollback arrow", () => {
+    const { api, reads } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub({ tagName: "SELECT", type: "select-one" });
+    control.value = "wterm";
+    row.appendChild(control);
+    reads.set(control, "wterm");
+    api.watch(row, control);
+    ok(!findChip(row, "settings-confirm-pencil"), "select has no pencil");
+
+    control.value = "ghostty";
+    fire(control, "change");
+    const rollback = findChip(row, "settings-rollback");
+    ok(rollback, "rollback arrow shown after change");
+    ok(
+      String(rollback.style.display || "") !== "none",
+      "arrow visible while baseline differs",
+    );
+
+    // Rolling back dispatches input+change so host handlers persist it.
+    dispatched.length = 0;
+    api.rollback(row);
+    equal(control.value, "wterm", "select restored to baseline");
+    const types = dispatched.map((entry) => entry.type);
+    ok(types.includes("input"), "input event dispatched");
+    ok(types.includes("change"), "change event dispatched");
+  });
+
+  it("checkboxes roll back via a change event", () => {
+    const { api, reads } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub({ type: "checkbox" });
+    control.checked = false;
+    row.appendChild(control);
+    reads.set(control, false);
+    api.watch(row, control);
+
+    control.checked = true;
+    fire(control, "change");
+    api.rollback(row);
+    equal(control.checked, false, "checkbox restored");
+  });
+
+  it("rewatching refreshes baselines without duplicating listeners", () => {
+    const { api, reads } = createContext();
+    const row = createNodeStub({ className: "option" });
+    const control = createNodeStub({ type: "text" });
+    control.value = "one";
+    row.appendChild(control);
+    reads.set(control, "one");
+    api.watch(row, control);
+    api.watch(row, control);
+    equal(
+      row.children.filter(
+        (child) =>
+          child.className === "settings-confirm-pencil" &&
+          String(child.style.display || "") !== "none",
+      ).length,
+      0,
+      "no visible chrome before edits",
+    );
+    control.value = "two";
+    fire(control, "input");
+    fire(control, "input");
+    equal(
+      row.children.filter(
+        (child) =>
+          child.className === "settings-confirm-pencil" &&
+          String(child.style.display || "") !== "none",
+      ).length,
+      1,
+      "exactly one visible pencil after double watch",
+    );
+  });
+
+  it("refreshAll re-reads baselines for every watched row", () => {
+    const { api, reads } = createContext();
+    const rowA = createNodeStub({ className: "option" });
+    const controlA = createNodeStub({ type: "text" });
+    controlA.value = "a";
+    rowA.appendChild(controlA);
+    reads.set(controlA, "a");
+    api.watch(rowA, controlA);
+
+    const rowB = createNodeStub({ className: "option" });
+    const controlB = createNodeStub({ type: "number" });
+    controlB.value = "5";
+    rowB.appendChild(controlB);
+    reads.set(controlB, "5");
+    api.watch(rowB, controlB);
+
+    reads.set(controlA, "changed");
+    api.refreshAll();
+    ok(
+      String(rowA.className).includes("settings-pending"),
+      "row A pending after baseline drift",
+    );
+    ok(
+      !String(rowB.className).includes("settings-pending"),
+      "row B still clean",
+    );
+  });
+});

--- a/src/assets/shared/settings_confirm.js
+++ b/src/assets/shared/settings_confirm.js
@@ -1,0 +1,264 @@
+// Settings confirm / rollback chrome.
+//
+// Local settings rows get explicit confirmation affordances:
+// - Text-like inputs (text, number, range) only save after Enter or the
+//   yellow pencil button. While the on-screen value differs from the saved
+//   value, the row shows the pencil (hover hint: "Enter or press to
+//   confirm") and a rollback arrow that restores the saved value.
+// - Selects and checkboxes still apply immediately through their own change
+//   handlers, but the row shows a rollback arrow that restores the value
+//   saved when the settings screen was opened (or last confirmed).
+//
+// The module is layout-agnostic: desktop passes `.option` rows, mobile
+// passes label rows. It never performs the save itself; it calls back into
+// the host's save and read functions so each layout keeps its own option
+// pipeline (HerdrOptions storage, normalize, apply).
+(function (root) {
+  const PENCIL_CLASS = "settings-confirm-pencil";
+  const ROLLBACK_CLASS = "settings-rollback";
+  const PENDING_CLASS = "settings-pending";
+
+  function createSettingsConfirm({
+    document,
+    save,
+    read,
+    onRollback,
+  }) {
+    const doc = document;
+    const rows = new Map(); // row -> { control, pencil, rollback, savedValue, selectLike }
+
+    function controlValue(control) {
+      if (!control) return "";
+      if (control.type === "checkbox") return control.checked === true;
+      const value = String(control.value == null ? "" : control.value);
+      return value.trim();
+    }
+
+    function valuesEqual(a, b) {
+      return String(a) === String(b);
+    }
+
+    function isSelectLike(control) {
+      if (!control) return false;
+      const tag = String(control.tagName || "").toUpperCase();
+      if (tag === "SELECT") return true;
+      if (tag !== "INPUT") return false;
+      const type = String(control.type || "").toLowerCase();
+      // Range sliders apply on release (a discrete gesture, like selects)
+      // and expose the rollback arrow instead of pending chrome.
+      return type === "checkbox" || type === "range";
+    }
+
+    function displayValue(info) {
+      // The saved value as it should appear in the control. Hosts whose
+      // stored option differs from the control representation (range 0-100
+      // vs stored 0-1) map it in their read() callback, so savedValue is
+      // always comparable to controlValue().
+      return info.savedValue === true
+        ? "true"
+        : info.savedValue === false
+          ? "false"
+          : String(info.savedValue == null ? "" : info.savedValue);
+    }
+
+    function findRow(control) {
+      if (!control) return null;
+      if (typeof control.closest === "function") {
+        return (
+          control.closest(".option") ||
+          control.closest(".theme-customizer") ||
+          control.closest("label") ||
+          control.closest(".mobile-settings-group") ||
+          control
+        );
+      }
+      return control;
+    }
+
+    function ensurePencil(row, info) {
+      let pencil = row.querySelector(`.${PENCIL_CLASS}`);
+      if (!pencil) {
+        pencil = doc.createElement("button");
+        pencil.type = "button";
+        pencil.className = PENCIL_CLASS;
+        pencil.setAttribute("aria-label", "Enter or press to confirm");
+        pencil.title = "Enter or press to confirm";
+        pencil.textContent = "✎";
+        pencil.onclick = (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          commit(row, info);
+        };
+        row.appendChild(pencil);
+      }
+      return pencil;
+    }
+
+    function ensureRollback(row, info) {
+      let rollback = row.querySelector(`.${ROLLBACK_CLASS}`);
+      if (!rollback) {
+        rollback = doc.createElement("button");
+        rollback.type = "button";
+        rollback.className = ROLLBACK_CLASS;
+        rollback.setAttribute("aria-label", "Roll back this change");
+        rollback.title = "Roll back this change";
+        rollback.textContent = "↺";
+        rollback.onclick = (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          rollbackRow(row, info);
+        };
+        row.appendChild(rollback);
+      }
+      return rollback;
+    }
+
+    function paint(row, info) {
+      const pending = !valuesEqual(controlValue(info.control), displayValue(info));
+      row.classList.toggle(PENDING_CLASS, pending);
+      if (info.selectLike) {
+        // Selects and checkboxes commit immediately; only the rollback
+        // affordance appears while the value differs from the baseline.
+        if (info.pencil) {
+          info.pencil.remove();
+          info.pencil = null;
+        }
+        info.rollback = ensureRollback(row, info);
+        info.rollback.style.display = pending ? "" : "none";
+      } else {
+        info.pencil = ensurePencil(row, info);
+        info.rollback = ensureRollback(row, info);
+        info.pencil.style.display = pending ? "" : "none";
+        info.rollback.style.display = pending ? "" : "none";
+      }
+    }
+
+    function commit(row, info) {
+      save(info.control, controlValue(info.control));
+      info.savedValue = read(info.control);
+      if (!info.selectLike) {
+        // Clamped commits (number inputs, ranges) re-sync the control so
+        // the row reflects the value that was actually saved.
+        const shown = displayValue(info);
+        if (!valuesEqual(controlValue(info.control), shown)) {
+          info.control.value =
+            info.savedValue === true || info.savedValue === false
+              ? String(info.savedValue)
+              : shown;
+        }
+      }
+      paint(row, info);
+    }
+
+    function rollbackRow(row, info) {
+      const target = info.savedValue;
+      if (info.control && info.control.type === "checkbox") {
+        info.control.checked = target === true;
+      } else if (info.control) {
+        info.control.value = target === true
+          ? "true"
+          : target === false
+            ? "false"
+            : String(target == null ? "" : target);
+      }
+      const canDispatch =
+        info.control &&
+        typeof info.control.dispatchEvent === "function" &&
+        typeof (root.Event ||
+          (doc.defaultView && doc.defaultView.Event)) === "function";
+      if (canDispatch && info.selectLike) {
+        // Programmatic value changes fire no DOM events; dispatch input
+        // then change so hosts bound to either (range sliders use input,
+        // selects use change) persist the restored value.
+        const EventCtor = root.Event || doc.defaultView.Event;
+        info.control.dispatchEvent(new EventCtor("input", { bubbles: true }));
+        info.control.dispatchEvent(new EventCtor("change", { bubbles: true }));
+      } else if (onRollback) {
+        onRollback(info.control, target);
+      }
+      paint(row, info);
+    }
+
+    function wireKeydown(row, info) {
+      const control = info.control;
+      if (!control || info.keydownWired) return;
+      info.keydownWired = true;
+      control.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter") return;
+        if (isSelectLike(control)) return;
+        event.preventDefault();
+        commit(row, info);
+      });
+    }
+
+    function watch(row, control) {
+      if (!row || !control) return;
+      let info = rows.get(row);
+      if (!info) {
+        info = {
+          control,
+          pencil: null,
+          rollback: null,
+          savedValue: "",
+          selectLike: false,
+          wired: false,
+        };
+        rows.set(row, info);
+      }
+      info.control = control;
+      info.selectLike = isSelectLike(control);
+      // Baseline is re-read on every watch call: hosts sync controls from
+      // saved options right before watching, so this captures the value
+      // saved when the settings screen was opened.
+      info.savedValue = read(control);
+      if (!info.wired) {
+        info.wired = true;
+        if (info.selectLike) {
+          // Immediate-commit controls keep their baseline; the change
+          // listener only repaints, so the rollback arrow stays available
+          // until the user rolls back or reopens the settings screen.
+          control.addEventListener("change", () => paint(row, info));
+        } else {
+          control.addEventListener("input", () => paint(row, info));
+          wireKeydown(row, info);
+        }
+      }
+      paint(row, info);
+    }
+
+    function refreshAll() {
+      for (const [row, info] of rows) {
+        info.savedValue = read(info.control);
+        paint(row, info);
+      }
+    }
+
+    return {
+      watch,
+      refreshAll,
+      commit(row) {
+        const info = rows.get(row);
+        if (info) commit(row, info);
+      },
+      rollback(row) {
+        const info = rows.get(row);
+        if (info) rollbackRow(row, info);
+      },
+      refresh(row, control) {
+        const info = rows.get(row);
+        if (!info) return watch(row, control);
+        info.control = control || info.control;
+        info.savedValue = read(info.control);
+        paint(row, info);
+      },
+      PENCIL_CLASS,
+      ROLLBACK_CLASS,
+      PENDING_CLASS,
+    };
+  }
+
+  const api = { create: createSettingsConfirm };
+  root.HerdrSettingsConfirm = api;
+  if (typeof module !== "undefined" && module.exports)
+    module.exports = api;
+})(typeof globalThis !== "undefined" ? globalThis : window);

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,10 +49,10 @@ use assets::{
     shared_file_content_search_js, shared_file_icons_css, shared_file_icons_js,
     shared_file_tree_css, shared_file_tree_js, shared_line_context_js, shared_lsp_js,
     shared_markdown_preview_css, shared_markdown_preview_js, shared_options_js,
-    shared_settings_feedback_js, shared_settings_confirm_js, shared_temp_terminal_js, shared_terminal_adapter_js,
-    shared_terminal_fit_js, shared_terminal_scroll_js, shared_workspace_search_js,
-    vendor_codemirror_js, vendor_dompurify_js, vendor_ghostty_wasm, vendor_marked_js,
-    vendor_mermaid_js, vendor_wterm_css, vendor_wterm_js,
+    shared_settings_confirm_js, shared_settings_feedback_js, shared_temp_terminal_js,
+    shared_terminal_adapter_js, shared_terminal_fit_js, shared_terminal_scroll_js,
+    shared_workspace_search_js, vendor_codemirror_js, vendor_dompurify_js, vendor_ghostty_wasm,
+    vendor_marked_js, vendor_mermaid_js, vendor_wterm_css, vendor_wterm_js,
 };
 use compat::SimpleVersion;
 use compat::{backend_compatibility, BackendCompatibility};

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ use assets::{
     shared_file_content_search_js, shared_file_icons_css, shared_file_icons_js,
     shared_file_tree_css, shared_file_tree_js, shared_line_context_js, shared_lsp_js,
     shared_markdown_preview_css, shared_markdown_preview_js, shared_options_js,
-    shared_settings_feedback_js, shared_temp_terminal_js, shared_terminal_adapter_js,
+    shared_settings_feedback_js, shared_settings_confirm_js, shared_temp_terminal_js, shared_terminal_adapter_js,
     shared_terminal_fit_js, shared_terminal_scroll_js, shared_workspace_search_js,
     vendor_codemirror_js, vendor_dompurify_js, vendor_ghostty_wasm, vendor_marked_js,
     vendor_mermaid_js, vendor_wterm_css, vendor_wterm_js,
@@ -1491,6 +1491,10 @@ fn app_router(state: WebState) -> Router {
         .route(
             "/assets/shared/settings-feedback.js",
             get(shared_settings_feedback_js),
+        )
+        .route(
+            "/assets/shared/settings-confirm.js",
+            get(shared_settings_confirm_js),
         )
         .route("/assets/vendor/codemirror.js", get(vendor_codemirror_js))
         .route("/assets/vendor/marked.js", get(vendor_marked_js))
@@ -7175,6 +7179,15 @@ mod tests {
             )
             .await
             .unwrap();
+        let settings_confirm_js = app
+            .clone()
+            .oneshot(
+                request(Method::GET, "/assets/shared/settings-confirm.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         let file_icons_js = app
             .clone()
             .oneshot(
@@ -7363,6 +7376,7 @@ mod tests {
         assert_eq!(app_boot_js.status(), StatusCode::OK);
         assert_eq!(app_core_js.status(), StatusCode::OK);
         assert_eq!(settings_feedback_js.status(), StatusCode::OK);
+        assert_eq!(settings_confirm_js.status(), StatusCode::OK);
         assert_eq!(file_icons_js.status(), StatusCode::OK);
         assert_eq!(file_icons_css.status(), StatusCode::OK);
         assert_eq!(shared_colors_css.status(), StatusCode::OK);


### PR DESCRIPTION
## Summary

Text-like settings now save only after an explicit confirm: press Enter in the field or click the yellow pencil button (hover: "Enter or press to confirm"). While the on-screen value differs from the saved one, the row shows the pencil together with a rollback arrow that restores the saved value. Selects, checkboxes, tick menus, and range sliders keep applying immediately and show only the rollback arrow, which restores the value saved when Settings was opened. Mobile Settings bakes the same affordance into each row as a ↺ chip.

## Changes

- New shared module `src/assets/shared/settings_confirm.js`, served at `/assets/shared/settings-confirm.js` and wired in app_boot right after settings-feedback. Layout-agnostic: hosts pass save/read callbacks so each layout keeps its own option pipeline.
- Desktop `core.js`: committer registry (`registerSettingsCommit`), `watchSettingsConfirmRows()` on modal open, `refreshAll()` on every reopen so baselines never go stale, and a `window.HerdrSettingsCommit` hook for tests.
- Desktop `bindings.js`: 15 text-like controls converted to commit functions with live-saving `oninput` removed, and 16 redundant Enter-keydown blocks deleted (the module wires Enter itself).
- Mobile `settings.js`: open-time baselines per row id, rollback chips, and a baseline reset when the settings screen is entered.
- CSS: pencil (#f9e2af) and rollback arrow in desktop modals.css and mobile app.css.

## Testing

- New unit suite `settings_confirm.test.mjs` (8 tests) and updated app_load / app_boot / mobile_load tests: **484/484 JS, 516/516 Rust** green.
- New real-browser acceptance on the served app over CDP: desktop `scripts/e2e/settings-confirm-acceptance.mjs` (**20/20**), mobile `settings-confirm-mobile-acceptance.mjs` (**7/7**), documented in `scripts/e2e/README.md`. They cover pending-not-saved, Enter/pencil commit, rollback restore without saving, select immediate apply + rollback persist, range slider behavior, and baseline re-read after reopening Settings on both layouts.