### PR TITLE
Removable recent workspaces, full terminal fill, shell refit on resize

### DIFF
--- a/scripts/e2e/terminal-fit-acceptance.mjs
+++ b/scripts/e2e/terminal-fit-acceptance.mjs
@@ -1,0 +1,156 @@
+// Terminal fill + panel-switch refit acceptance checks.
+// Drives the real UI in headless Chrome over CDP:
+//   1. Creates a workspace over the API and waits for its terminal to attach.
+//   2. The terminal surface fills the shell horizontally and vertically
+//      (accounting for the 8px shell padding), with cols/rows matching.
+//   3. Switching to the Git drawer and back refills the terminal.
+//   4. Switching to the Files browser and back refills the terminal.
+//   5. Sidebar toggle (shell width change without window resize) refits.
+// Usage: ACCEPT_REPO=... E2E_BASE_URL=... CDP_PORT=... node scripts/e2e/terminal-fit-acceptance.mjs
+import { connectToPage } from './cdp-driver.mjs';
+
+const REPO = process.env.ACCEPT_REPO;
+const BASE = process.env.E2E_BASE_URL || 'https://127.0.0.1:8899/';
+if (!REPO) {
+  console.error('ACCEPT_REPO (absolute path to the fixture git repo) is required');
+  process.exit(2);
+}
+
+const results = [];
+function check(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ' :: ' + detail : ''}`);
+}
+
+const cdp = await connectToPage();
+await cdp.send('Page.enable');
+await cdp.send('Security.enable');
+await cdp.send('Security.setIgnoreCertificateErrors', { ignore: true });
+await cdp.send('Page.navigate', { url: BASE });
+await new Promise((r) => setTimeout(r, 2500));
+
+async function evalx(expr) {
+  return cdp.evalExpr(expr, true);
+}
+
+function boxExpr(id) {
+  return `(() => {
+    const el = document.getElementById(${JSON.stringify(id)});
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const cs = getComputedStyle(el);
+    return { x: r.x, y: r.y, w: r.width, h: r.height, display: cs.display };
+  })()`;
+}
+
+async function box(id) {
+  return cdp.evalExpr(boxExpr(id));
+}
+
+const PAD = 16; // 8px shell padding each side
+function fillChecks(tag, shell, term, cell, cols, rows) {
+  const horizGap = Math.abs(shell.w - term.w - PAD);
+  const vertGap = shell.h - (term.h + PAD);
+  check(`${tag}: terminal fills shell horizontally`, horizGap <= 1.5, `shell=${shell.w} term=${term.w}`);
+  check(`${tag}: terminal fills shell vertically`, vertGap <= 1.5, `shell=${shell.h} term=${term.h} gap=${vertGap.toFixed(1)}`);
+  const expectedCols = Math.floor((shell.w - PAD) / cell.width);
+  const expectedRows = Math.floor((shell.h - PAD) / cell.height);
+  check(`${tag}: cols match shell width`, Math.abs(cols - expectedCols) <= 1, `cols=${cols} expected≈${expectedCols}`);
+  check(`${tag}: rows match shell height`, Math.abs(rows - expectedRows) <= 1, `rows=${rows} expected≈${expectedRows}`);
+}
+
+// Create a workspace over the API and wait for the terminal to attach.
+const created = await evalx(`(async () => {
+  try {
+    const r = await fetch('/api/workspaces', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'terminal-fit-e2e', cwd: ${JSON.stringify(REPO)} }),
+    });
+    return await r.json();
+  } catch (e) { return { error: String(e) }; }
+})()`);
+const wsId = created && (created.workspace_id || (created.result && created.result.workspace_id));
+check('workspace created', !!wsId, `resp=${JSON.stringify(created).slice(0, 120)}`);
+if (!wsId) process.exit(1);
+
+await evalx(`go(${JSON.stringify(wsId)})`);
+await new Promise((r) => setTimeout(r, 3000));
+
+// Wait until the terminal surface is attached and rendered.
+let state = null;
+for (let i = 0; i < 20 && !state; i++) {
+  state = await evalx(`(async () => {
+    if (!state.terminalId) return null;
+    const rows = document.querySelectorAll('#terminal .term-row');
+    if (!rows.length) return null;
+    return { terminalId: state.terminalId, cols: state.termCols, rows: state.termRows };
+  })()`);
+  if (!state) await new Promise((r) => setTimeout(r, 500));
+}
+check('terminal attached with rendered rows', !!state, `state=${JSON.stringify(state)}`);
+if (!state) process.exit(1);
+
+// 1. Fill checks on the pristine shell.
+{
+  const shell = await box('terminalShell');
+  const term = await box('terminal');
+  const cell = await evalx('HerdrTerminalFit.cellSize(term, document.getElementById("terminal"), { width: 9, height: 20 })');
+  fillChecks('initial', shell, term, cell, state.cols, state.rows);
+}
+
+// 2. Git drawer open and back.
+await evalx(`openWorkspaceGitUi(state.ws, { forceOpen: true })`);
+await new Promise((r) => setTimeout(r, 1500));
+let gitVisible = await evalx('!!(window.HerdrGitUi && window.HerdrGitUi.isVisible && window.HerdrGitUi.isVisible())');
+check('git drawer opens', gitVisible === true);
+await evalx('showTerminalShellMode({})');
+await new Promise((r) => setTimeout(r, 1200));
+{
+  const shell = await box('terminalShell');
+  const term = await box('terminal');
+  const after = await evalx('({ cols: state.termCols, rows: state.termRows })');
+  const cell = await evalx('HerdrTerminalFit.cellSize(term, document.getElementById("terminal"), { width: 9, height: 20 })');
+  fillChecks('after git drawer close', shell, term, cell, after.cols, after.rows);
+}
+
+// 3. Files browser open and back.
+await evalx(`openWorkspaceFileBrowser(state.ws, { forceOpen: true })`);
+await new Promise((r) => setTimeout(r, 1500));
+let filesVisible = await evalx('!!(window.HerdrFileBrowser && window.HerdrFileBrowser.isVisible && window.HerdrFileBrowser.isVisible())');
+check('file browser opens', filesVisible === true);
+await evalx('showTerminalShellMode({})');
+await new Promise((r) => setTimeout(r, 1200));
+{
+  const shell = await box('terminalShell');
+  const term = await box('terminal');
+  const after = await evalx('({ cols: state.termCols, rows: state.termRows })');
+  const cell = await evalx('HerdrTerminalFit.cellSize(term, document.getElementById("terminal"), { width: 9, height: 20 })');
+  fillChecks('after file browser close', shell, term, cell, after.cols, after.rows);
+}
+
+// 4. Sidebar toggle changes shell width without a window resize.
+{
+  const before = await box('terminalShell');
+  await evalx('document.getElementById("sidebarToggle").click()');
+  await new Promise((r) => setTimeout(r, 1200));
+  const during = await box('terminalShell');
+  const termDuring = await box('terminal');
+  const after = await evalx('({ cols: state.termCols, rows: state.termRows })');
+  const cell = await evalx('HerdrTerminalFit.cellSize(term, document.getElementById("terminal"), { width: 9, height: 20 })');
+  check('sidebar toggle changes shell width', Math.abs(during.w - before.w) > 50, `before=${before.w} after=${during.w}`);
+  fillChecks('after sidebar toggle', during, termDuring, cell, after.cols, after.rows);
+  // Toggle back.
+  await evalx('document.getElementById("sidebarToggle").click()');
+  await new Promise((r) => setTimeout(r, 1200));
+  const restored = await box('terminalShell');
+  const termRestored = await box('terminal');
+  const restoredState = await evalx('({ cols: state.termCols, rows: state.termRows })');
+  const cell2 = await evalx('HerdrTerminalFit.cellSize(term, document.getElementById("terminal"), { width: 9, height: 20 })');
+  check('sidebar restored to original width', Math.abs(restored.w - before.w) <= 1, `before=${before.w} restored=${restored.w}`);
+  fillChecks('after sidebar restore', restored, termRestored, cell2, restoredState.cols, restoredState.rows);
+}
+
+const failed = results.filter((r) => !r.ok).length;
+console.log(failed ? `terminal fit acceptance: ${failed} FAILED of ${results.length}` : `terminal fit acceptance: all ${results.length} checks passed`);
+process.exitCode = failed ? 1 : 0;

--- a/src/assets/app_load.test.mjs
+++ b/src/assets/app_load.test.mjs
@@ -309,12 +309,67 @@ describe("app bundle load", () => {
     ok(section.includes("Beta"), "section renders recent rows");
     ok(section.includes('class="search-section-toggle search-section-head-toggle"'), "recent toggle uses the shared toggle styling inside the head row");
     ok(section.includes('aria-expanded="true"'), "recent toggle exposes expanded state");
+    ok(section.includes('class="search-result-remove"'), "recent rows render a remove button");
+    ok(section.includes('HerdrSearchPalette.removeRecent(event, &#39;/repo/beta&#39;)') || section.includes("HerdrSearchPalette.removeRecent(event, '/repo/beta')"), "remove button targets the row path");
+    ok(section.includes('app-icon-trash'), "remove button shows the trash icon");
     const collapsed = vm.runInContext("searchPaletteState.sectionsExpanded.recent = false; renderRecentSection([{ type: 'recent', icon: 'wt', title: 'Beta', subtitle: 'worktree · /repo/beta', path: '/repo/beta' }])", ctx);
     ok(collapsed.includes('aria-expanded="false"'), "collapsed recent toggle reports not expanded");
     ok(!collapsed.includes('onclick="HerdrSearchPalette.openRecent'), "collapsed section hides rows");
 
     const empty = vm.runInContext("renderRecentSection([])", ctx);
     equal(empty, "", "empty recents render no section");
+
+    // removeRecent: POSTs the path, drops the row, invalidates the cache,
+    // rerenders, and never triggers the row's own open action.
+    let removeCalls = 0;
+    const originalRemoveFetch = ctx.fetch;
+    ctx.fetch = async (url, init) => {
+      if (String(url).includes("/api/recent-workspaces/remove")) {
+        removeCalls += 1;
+        ok(init && init.method === "POST", "remove uses POST");
+        equal(init.headers["content-type"], "application/json", "remove posts JSON");
+        const body = JSON.parse(init.body);
+        equal(body.path, "/repo/beta", "remove sends the row path");
+        recentPayload = [];
+        return { status: 200, ok: true, json: async () => ({ ok: true, removed: 1, path: "/repo/beta" }) };
+      }
+      if (String(url).includes("/api/recent-workspaces/clear")) {
+        return { status: 200, json: async () => ({ ok: true, cleared: 0 }) };
+      }
+      if (String(url).includes("/api/recent-workspaces")) {
+        return { status: 200, ok: true, json: async () => ({ recent: recentPayload }) };
+      }
+      return originalRemoveFetch(url, init);
+    };
+    vm.runInContext('searchPaletteState.recent = recentWorkspaceCandidates([{ path: "/repo/beta", label: "Beta", kind: "workspace" }, { path: "/repo/delta", label: "Delta", kind: "workspace" }]);', ctx);
+    let removeStopped = 0;
+    await vm.runInContext("HerdrSearchPalette.removeRecent({ preventDefault() {}, stopPropagation() { globalThis.__removeStopped = (globalThis.__removeStopped || 0) + 1; } }, '/repo/beta')", ctx);
+    equal(removeCalls, 1, "removeRecent posts to the remove endpoint once");
+    equal(ctx.__removeStopped, 1, "removeRecent stops event propagation so the row does not open");
+    equal(vm.runInContext("searchPaletteState.recent.length", ctx), 1, "removeRecent drops only the removed row");
+    equal(vm.runInContext("searchPaletteState.recent[0].path", ctx), "/repo/delta", "removeRecent keeps other rows");
+    const removedCache = await registry.loadRecent();
+    equal(removedCache.length, 0, "removeRecent invalidates the loadRecent cache");
+    // API failure leaves state untouched and surfaces the error.
+    let failCalls = 0;
+    ctx.fetch = async (url, init) => {
+      if (String(url).includes("/api/recent-workspaces/remove")) {
+        failCalls += 1;
+        return { status: 500, json: async () => ({ error: "boom" }) };
+      }
+      return { status: 200, ok: true, json: async () => ({ recent: recentPayload }) };
+    };
+    let alerted = "";
+    ctx.alert = (message) => { alerted = String(message); };
+    vm.runInContext('searchPaletteState.recent = recentWorkspaceCandidates([{ path: "/repo/beta", label: "Beta", kind: "workspace" }]);', ctx);
+    await vm.runInContext("HerdrSearchPalette.removeRecent(null, '/repo/beta')", ctx);
+    equal(failCalls, 1, "failed remove calls the API");
+    equal(alerted, "boom", "failed remove surfaces the server error");
+    equal(vm.runInContext("searchPaletteState.recent.length", ctx), 1, "failed remove keeps the row");
+    // Empty path is a no-op.
+    removeCalls = 0;
+    await vm.runInContext("HerdrSearchPalette.removeRecent(null, '')", ctx);
+    equal(removeCalls, 0, "removeRecent ignores an empty path");
   });
 
   it("returns desktop UX actions from a single command-palette candidate path", () => {
@@ -581,6 +636,35 @@ describe("app bundle load", () => {
     match(desktopTerminalSource, /function sendBackendTail\(\) \{[\s\S]*?for \(let i = 0; i < 120; i \+= 1\)[\s\S]*?sendBackendScroll\(200\)/);
     match(desktopTerminalSource, /function scrollTerminalToBottom\(focus = true\) \{[\s\S]*?sendBackendTail\(\);[\s\S]*?setTerminalFollowPaused\(false\);[\s\S]*?term\.scrollToBottom\(\);/);
     match(desktopTerminalSource, /ws\.onopen = \(\) => \{[\s\S]*?scrollTerminalToBottom\(false\);/);
+  });
+
+  it("fills terminal shell vertically regardless of content height", () => {
+    // Non-overflow mode must stretch the surface to the full shell inner
+    // height instead of clamping to the content height, so short terminal
+    // output never leaves empty space at the bottom of the shell.
+    match(
+      desktopTerminalSource,
+      /const visibleHeight = shellHeight > 0 \? shellHeight : height;/,
+    );
+    ok(
+      !desktopTerminalSource.includes("Math.min(height, shellHeight)"),
+      "fitTerminalSurface must not clamp surface height to content height",
+    );
+    // The shell itself must not reserve scrollbar gutters (it never scrolls).
+    const terminalCss = readFileSync(new URL("./desktop/app_css/terminal.css", import.meta.url), "utf8");
+    ok(!terminalCss.includes("scrollbar-gutter"), "terminal shell must not reserve a dead scrollbar gutter");
+  });
+
+  it("refits terminal on shell resize via ResizeObserver", () => {
+    // The shell changes size without a window resize (sidebar toggle, Git
+    // drawer, Files browser, project dashboard); a ResizeObserver keeps the
+    // terminal grid renegotiated against the real shell box.
+    match(desktopTerminalSource, /new ResizeObserver\(refitAfterShellResize\)\.observe\(shell\);/);
+    match(desktopTerminalSource, /function observeTerminalShell\(\) \{[\s\S]*?typeof ResizeObserver !== "function"/);
+    match(
+      desktopTerminalSource,
+      /if \(applyBrowserTerminalSize\(\)\) connectTerminal\(\);\n\s+else fitTerminalSurface\(\);/,
+    );
   });
 
   it("keeps Git UI keyboard input away from the terminal", () => {

--- a/src/assets/desktop/app_css/terminal.css
+++ b/src/assets/desktop/app_css/terminal.css
@@ -8,7 +8,6 @@
   padding: 8px;
   overflow: hidden;
   background: var(--bg);
-  scrollbar-gutter: stable both-edges;
 }
 .terminal {
   display: block;

--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -775,9 +775,6 @@ function fitTerminalSurface() {
   const width = Math.ceil(cellWidth * cols);
   const height = Math.ceil(rowHeight * rows);
   const shellHeight = terminalShellInnerHeight(shell);
-  const visibleHeight = !options.overflow && shellHeight > 0
-    ? Math.min(height, shellHeight)
-    : height;
   if (options.overflow) {
     terminal.style.width = width + "px";
     terminal.style.height = height + "px";
@@ -786,6 +783,11 @@ function fitTerminalSurface() {
     terminal.style.minHeight = height + "px";
     terminal.style.overflow = "";
   } else {
+    // Fill the shell vertically so short terminal content never leaves empty
+    // space at the bottom. Grid renegotiation (state.termCols/termRows, see
+    // applyBrowserTerminalSize and the shell ResizeObserver) keeps the actual
+    // rows in sync with the space, so the surface and the grid always match.
+    const visibleHeight = shellHeight > 0 ? shellHeight : height;
     terminal.style.width = "100%";
     terminal.style.height = visibleHeight > 0 ? visibleHeight + "px" : "";
     terminal.style.maxHeight = shellHeight > 0 ? shellHeight + "px" : "";
@@ -895,6 +897,41 @@ window.addEventListener("resize", () => {
     }
   });
 });
+// Refit the terminal whenever the shell itself changes size, even when the
+// window does not (sidebar toggle, Git drawer / Files browser open-close,
+// project dashboard appearing, panel switcher, zoom). The observer is the
+// single source of truth for shell-driven refits; every pane-layout path
+// keeps working because the window "resize" listener above still exists.
+(function observeTerminalShell() {
+  const shell =
+    (typeof el === "function" && el("terminalShell")) ||
+    (typeof document !== "undefined" &&
+      document.getElementById &&
+      document.getElementById("terminalShell"));
+  if (!shell || typeof ResizeObserver !== "function") return;
+  let shellResizeFrame = null;
+  const refitAfterShellResize = () => {
+    if (shellResizeFrame !== null) {
+      cancelAnimationFrame(shellResizeFrame);
+    }
+    shellResizeFrame = requestAnimationFrame(() => {
+      shellResizeFrame = null;
+      if (!state.terminalId) return;
+      fitTerminalShell();
+      if (
+        options.fitToBrowser ||
+        shouldFitFocusedWebTerminal() ||
+        shouldAutoFitDetachedTerminal()
+      ) {
+        if (applyBrowserTerminalSize()) connectTerminal();
+        else fitTerminalSurface();
+      } else {
+        fitTerminalSurface();
+      }
+    });
+  };
+  new ResizeObserver(refitAfterShellResize).observe(shell);
+})();
 window.addEventListener("focus", () =>
   requestAnimationFrame(fitFocusedTerminal),
 );

--- a/src/assets/desktop/search.css
+++ b/src/assets/desktop/search.css
@@ -35,7 +35,7 @@
 }
 .search-result {
   display: grid;
-  grid-template-columns: 30px minmax(0, 1fr);
+  grid-template-columns: 30px minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
   border: 1px solid transparent;
@@ -58,6 +58,34 @@
   font-weight: 900;
   height: 28px;
   width: 28px;
+}
+.search-result-remove {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  color: var(--muted);
+  cursor: pointer;
+  display: none;
+  flex: none;
+  height: 26px;
+  padding: 5px;
+  width: 26px;
+}
+.search-result:hover .search-result-remove,
+.search-result.active .search-result-remove {
+  display: inline-flex;
+}
+.search-result-remove:hover {
+  background: color-mix(in srgb, var(--danger, #f38ba8), transparent 86%);
+  color: var(--danger, #f38ba8);
+}
+.search-result-remove .app-icon-trash {
+  background: currentColor;
+  display: inline-block;
+  height: 14px;
+  mask: url("/assets/icons/trash.svg") center / contain no-repeat;
+  width: 14px;
 }
 .search-result-title {
   font-weight: 750;

--- a/src/assets/desktop/search.js
+++ b/src/assets/desktop/search.js
@@ -480,7 +480,7 @@ function renderSearchPalette() {
 function renderRecentSection(recent) {
   const expanded = searchPaletteState.sectionsExpanded.recent !== false;
   if (!recent.length) return "";
-  const rows = recent.map((result) => renderSearchRowResult(result)).join("");
+  const rows = recent.map((result) => renderRecentRowResult(result)).join("");
   const clear = `<button class="git-ui-btn" onclick="HerdrSearchPalette.clearRecent(event)" title="Clear recent workspaces">Clear</button>`;
   return `<section class="search-section"><div class="search-section-head"><button class="search-section-toggle search-section-head-toggle" onclick="HerdrSearchPalette.toggleSection('recent')" aria-expanded="${expanded ? "true" : "false"}"><strong><span class="herdr-tree-icon herdr-tree-icon-${expanded ? "chevron-down" : "chevron-right"}" aria-hidden="true"></span>Recent workspaces</strong><span>${recent.length}</span></button>${clear}</div>${expanded ? rows : ""}</section>`;
 }
@@ -516,8 +516,14 @@ function renderSearchRowResult(result) {
   return renderTargetResult(result, index);
 }
 
-function renderTargetResult(result, index) {
-  return `<div class="search-result ${index === searchPaletteState.selectedIndex ? "active" : ""}" onclick="chooseSearchResult(${index})"><span class="search-result-icon">${escapeHtml(result.icon)}</span><div><div class="search-result-title">${escapeHtml(result.title)}</div><div class="search-result-subtitle">${escapeHtml(result.subtitle || result.kind)}</div></div></div>`;
+function renderRecentRowResult(result, index) {
+  if (!result.path) return renderTargetResult(result, index);
+  const remove = `<button class="search-result-remove" type="button" title="Remove this recent workspace" aria-label="Remove ${escapeAttr(result.title)} from recent workspaces" onclick="HerdrSearchPalette.removeRecent(event, '${escapeAttr(result.path)}')"><span class="app-icon app-icon-trash" aria-hidden="true"></span></button>`;
+  return renderTargetResult(result, index, remove);
+}
+
+function renderTargetResult(result, index, trailingHtml = "") {
+  return `<div class="search-result ${index === searchPaletteState.selectedIndex ? "active" : ""}" onclick="chooseSearchResult(${index})"><span class="search-result-icon">${escapeHtml(result.icon)}</span><div class="search-result-body"><div class="search-result-title">${escapeHtml(result.title)}</div><div class="search-result-subtitle">${escapeHtml(result.subtitle || result.kind)}</div></div>${trailingHtml}</div>`;
 }
 
 function renderWorkspacePathSection(opts = searchSettings()) {
@@ -690,6 +696,28 @@ const HerdrSearchPalette = {
       await api("/api/recent-workspaces/clear", { method: "POST" });
     } catch (_) {}
     searchPaletteState.recent = [];
+    if (window.HerdrActionRegistry && window.HerdrActionRegistry.invalidateRecent) window.HerdrActionRegistry.invalidateRecent();
+    renderSearchPalette();
+  },
+  async removeRecent(event, path) {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    if (!path) return;
+    try {
+      await api("/api/recent-workspaces/remove", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path }),
+      });
+    } catch (error) {
+      alert(error.message || String(error));
+      return;
+    }
+    searchPaletteState.recent = (searchPaletteState.recent || []).filter(
+      (item) => (item && item.path) !== path,
+    );
     if (window.HerdrActionRegistry && window.HerdrActionRegistry.invalidateRecent) window.HerdrActionRegistry.invalidateRecent();
     renderSearchPalette();
   },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1424,6 +1424,10 @@ fn app_router(state: WebState) -> Router {
             "/api/recent-workspaces/clear",
             post(clear_recent_workspaces),
         )
+        .route(
+            "/api/recent-workspaces/remove",
+            post(remove_recent_workspace),
+        )
         .route("/api/worktrees", get(worktrees).post(create_worktree))
         .route("/api/worktrees/open", post(open_worktree))
         .route("/api/worktrees/remove-path", post(remove_worktree_path))
@@ -3188,6 +3192,50 @@ async fn clear_recent_workspaces(
     }
 }
 
+async fn remove_recent_workspace(
+    State(state): State<WebState>,
+    headers: HeaderMap,
+    ConnectInfo(remote): ConnectInfo<SocketAddr>,
+    Json(body): Json<RemoveRecentWorkspaceRequest>,
+) -> Response {
+    if let Err(response) = require_auth(&state, &headers, remote) {
+        return response;
+    }
+    let path = body
+        .path
+        .as_deref()
+        .map(expand_user_path_string)
+        .map(|value| value.trim().to_string())
+        .unwrap_or_default();
+    if path.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "path is required" })),
+        )
+            .into_response();
+    }
+    let removed = {
+        let Ok(mut guard) = state.server_settings.lock() else {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({ "error": "server settings unavailable" })),
+            )
+                .into_response();
+        };
+        let count = guard.recent_workspaces.len();
+        guard.recent_workspaces.retain(|item| item.path != path);
+        count - guard.recent_workspaces.len()
+    };
+    match persist_server_settings(&state).await {
+        Ok(()) => Json(json!({ "ok": true, "removed": removed, "path": path })).into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": err.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
 fn open_created_worktree_request(
     cwd: &str,
     path: &str,
@@ -3808,6 +3856,11 @@ struct OpenRecentWorkspaceRequest {
     path: Option<String>,
     label: Option<String>,
     branch: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RemoveRecentWorkspaceRequest {
+    path: Option<String>,
 }
 
 async fn open_recent_workspace(
@@ -6835,6 +6888,113 @@ mod tests {
                 .unwrap();
             assert_eq!(cleared.status(), StatusCode::OK);
             assert_eq!(response_json(cleared).await["cleared"], json!(1));
+        }
+
+        let _ = fs::remove_dir_all(config_home);
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn remove_recent_workspace_removes_single_entry_and_validates() {
+        let _env = lock_env();
+        // The authed remove persists server settings; keep that write inside
+        // a temp config dir so the real operator config is never touched.
+        let config_home = std::env::temp_dir().join(format!(
+            "herdr-webui-recent-remove-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("XDG_CONFIG_HOME", &config_home);
+
+        {
+            let state = test_state();
+            {
+                let mut guard = state.server_settings.lock().unwrap();
+                push_recent_workspace(
+                    &mut guard.recent_workspaces,
+                    "/repo/keep",
+                    Some("Keep".to_string()),
+                    None,
+                    Some("workspace".to_string()),
+                );
+                push_recent_workspace(
+                    &mut guard.recent_workspaces,
+                    "/repo/gone",
+                    Some("Gone".to_string()),
+                    None,
+                    Some("worktree".to_string()),
+                );
+            }
+            let app = test_app_with_state(state);
+
+            let unauthorized = app
+                .clone()
+                .oneshot(
+                    request(Method::POST, "/api/recent-workspaces/remove")
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(json!({ "path": "/repo/gone" }).to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+            let missing_path = app
+                .clone()
+                .oneshot(
+                    authed_request(Method::POST, "/api/recent-workspaces/remove")
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(json!({}).to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(missing_path.status(), StatusCode::BAD_REQUEST);
+
+            let removed = app
+                .clone()
+                .oneshot(
+                    authed_request(Method::POST, "/api/recent-workspaces/remove")
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(json!({ "path": "/repo/gone" }).to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(removed.status(), StatusCode::OK);
+            let json = response_json(removed).await;
+            assert_eq!(json["ok"], json!(true));
+            assert_eq!(json["removed"], json!(1));
+            assert_eq!(json["path"], "/repo/gone");
+
+            let listed = app
+                .clone()
+                .oneshot(
+                    authed_request(Method::GET, "/api/recent-workspaces")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let recent = response_json(listed).await["recent"].clone();
+            assert_eq!(recent.as_array().map(Vec::len), Some(1));
+            assert_eq!(recent[0]["path"], "/repo/keep");
+
+            // Removing an unknown path reports zero removals and keeps state.
+            let noop = app
+                .oneshot(
+                    authed_request(Method::POST, "/api/recent-workspaces/remove")
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(json!({ "path": "/repo/unknown" }).to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(noop.status(), StatusCode::OK);
+            assert_eq!(response_json(noop).await["removed"], json!(0));
         }
 
         let _ = fs::remove_dir_all(config_home);


### PR DESCRIPTION
## Summary

- **Removable recent workspaces**: each entry in the recent-workspaces list now has a hover-revealed trash button at the row's right edge (same pattern as the git-branch-row trash). New `POST /api/recent-workspaces/remove` endpoint drops one entry and invalidates the cache.
- **Terminal fills the shell**: `fitTerminalSurface()` stretches the terminal to the full shell inner height instead of clamping to content height, so short output no longer leaves empty space at the bottom. Removed the dead `scrollbar-gutter: stable both-edges` from `.terminal-shell` (the shell is `overflow: hidden`; the gutter only wasted horizontal space).
- **Refit on panel switch/resize**: a `ResizeObserver` on `#terminalShell` renegotiates the grid (`applyBrowserTerminalSize()` -> `connectTerminal()`) whenever the shell resizes without a window resize: sidebar toggle, Git drawer open/close, file browser, dashboard, zoom.

## Test plan

- Rust: `cargo test` (377 pass), `cargo fmt --check` clean.
- JS: `node --test src/assets/*.test.mjs` (486 pass), including new tests for vertical fill, ResizeObserver refit, and no scrollbar-gutter.
- E2E: `scripts/e2e/terminal-fit-acceptance.mjs` drives the real UI over CDP (fill, git drawer, file browser, sidebar toggle checks).