### PR TITLE
Fix terminal shaking on scroll-follow by aligning surface height to whole rows

### DIFF
--- a/src/assets/desktop/app_js/terminal.js
+++ b/src/assets/desktop/app_js/terminal.js
@@ -788,14 +788,24 @@ function fitTerminalSurface() {
     // applyBrowserTerminalSize and the shell ResizeObserver) keeps the actual
     // rows in sync with the space, so the surface and the grid always match.
     const visibleHeight = shellHeight > 0 ? shellHeight : height;
+    // Align the surface to whole terminal rows. When the shell height is not
+    // an exact multiple of the row height, a full-shell surface leaves a
+    // sub-row gap at the bottom. wterm's follow-scroll snaps scrollTop to
+    // whole rows while the app's scrollToBottom targets the exact bottom, so
+    // the two fight on every frame (visible "shaking"). Keeping at most one
+    // row of reserved gap at the bottom makes both land on the same value.
+    const alignedHeight =
+      rows > 0 && rowHeight > 0
+        ? Math.min(visibleHeight, Math.floor(visibleHeight / rowHeight) * rowHeight)
+        : visibleHeight;
     terminal.style.width = "100%";
-    terminal.style.height = visibleHeight > 0 ? visibleHeight + "px" : "";
-    terminal.style.maxHeight = shellHeight > 0 ? shellHeight + "px" : "";
+    terminal.style.height = alignedHeight > 0 ? alignedHeight + "px" : "";
+    terminal.style.maxHeight = alignedHeight > 0 ? alignedHeight + "px" : "";
     terminal.style.minWidth = "0";
     terminal.style.minHeight = "0";
     // Don't force overflow:hidden - wterm needs overflow:auto on .terminal for internal scrollback
     // terminal.style.overflow = "hidden";  // REMOVED: breaks wterm scrollTop
-    HerdrTerminalFit.fitTerminalToContainer(terminal, { height: visibleHeight });
+    HerdrTerminalFit.fitTerminalToContainer(terminal, { height: alignedHeight });
   }
 }
 function cssPixels(value) {


### PR DESCRIPTION
## Problem

The desktop terminal visibly "shakes" (rapid up/down jitter) while output streams, e.g. when using jcode in the webui terminal. Scrolling up a little makes it stop.

## Root cause

The terminal surface was sized to fill the full shell height, which is rarely an exact multiple of the row height. Two scroll-to-bottom policies then disagreed on every frame:

- wterm's internal render follow snaps `scrollTop` to whole rows: `floor(max/rowHeight)*rowHeight`
- the app's follow (`scrollToBottom` in the adapter) targets the exact bottom

With a sub-row remainder at the bottom, the two targets differ by up to (rowHeight - 1)px and alternate on each render while output arrives, producing the shake. Scrolling up disables wterm's bottom-follow (5px threshold), which is why the jitter stopped when scrolled.

## Fix

In `fitTerminalSurface` (desktop terminal JS), size the surface to `rows * rowHeight` and leave the sub-row remainder as a reserved bottom gap, so both policies always land on the same `scrollTop`. This mirrors the row alignment `temp_terminal.js` already applies for its input-shifting bug. Mobile surfaces size to content and are unaffected.

## Verification

- Live app in headless Chrome (CDP): with the fix, both scroll targets are identical (delta 0px). Pre-fix geometry (worst-case 15px leftover) conflicts by 15px.
- Scroll-policy model harness: misaligned height oscillates 16px per frame, aligned height is stable within 1px.
- All 486 JS tests and 517 Rust tests pass; `cargo fmt --check` clean.